### PR TITLE
Update to Akka Http version with trailers support

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -1,9 +1,10 @@
-scalaVersion := "2.12.3"
+scalaVersion := "2.12.4"
+val AkkaHttp = "10.1.0-RC2+12-7675041d"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % "2.5.9",
-  "com.typesafe.akka" %% "akka-http" % "10.0.11",
-  "com.typesafe.akka" %% "akka-http2-support" % "10.0.11",
+  "com.typesafe.akka" %% "akka-http" % AkkaHttp,
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttp,
 
   "io.grpc" % "grpc-netty" % com.trueaccord.scalapb.compiler.Version.grpcJavaVersion,
   "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion

--- a/server/project/build.properties
+++ b/server/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/server/project/plugins.sbt
+++ b/server/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.13")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"


### PR DESCRIPTION
This updates Akka Http to https://github.com/akka/akka-http/pull/1857 which needs to be locally published.

This makes the existing test-case pass with flying colors.