### PR TITLE
Run tests on both server implementations

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 akka {
-  loglevel = DEBUG
+  loglevel = ERROR
 }

--- a/server/src/main/scala/akka/http/grpc/Descriptor.scala
+++ b/server/src/main/scala/akka/http/grpc/Descriptor.scala
@@ -110,8 +110,8 @@ class ServerInvokerBuilder[T] {
 // TODO separate it into "runtime" library;
 object Grpc {
 
-    // TODO should this be a Route to allow mixing GRPC endpoints and other routes?
-    def apply[T](descriptor: Descriptor[T], service: T)(implicit mat: Materializer, ec: ExecutionContext): PartialFunction[HttpRequest, HttpResponse] = {
+  // TODO should this be a Route to allow mixing GRPC endpoints and other routes?
+  def apply[T](descriptor: Descriptor[T], service: T)(implicit mat: Materializer, ec: ExecutionContext): PartialFunction[HttpRequest, HttpResponse] = {
     // TODO this builds up a function based on the Descriptor that was generated from the grpc .proto file.
     // Shouldn't we generate this function directly instead of going via the Descriptor?
     val base = Path / descriptor.name


### PR DESCRIPTION
This refactors pending test support out and uses it for both Akka and original Java grpc server tests.