### PR TITLE
Enable server streaming interop tests

### DIFF
--- a/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
@@ -7,15 +7,12 @@ import org.scalatest._
 class GrpcInteropSpec extends WordSpec with GrpcInteropTests {
   override val pendingAkkaTestCases = Seq(
     "ping_pong",
-    "server_streaming",
     "cancel_after_first_response",
     "custom_metadata",
     "status_code_and_message",
     "unimplemented_method",
     "client_compressed_unary",
-    "client_compressed_streaming",
-    "server_compressed_streaming",
-  )
+    "client_compressed_streaming")
 
   javaGrpcTests()
   akkaHttpGrpcTests(implicit mat => implicit ec => TestServiceServiceHandler(new TestServiceImpl()))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
 
   object Versions {
     val akka = "2.5.9"
-    // snapshot from master
-    val akkaHttp = "10.1.0-RC2+15-f80d1fe5"
+    // snapshot from https://github.com/akka/akka-http/pull/1882
+    val akkaHttp = "10.1.0-RC2+19-8e20bb26"
 
     val scalapb = "0.6.7"
     val grpc = "1.10.0"


### PR DESCRIPTION
This was the test case that needed the fix in https://github.com/akka/akka-http/pull/1882

Therefore it also switches to the akka-http snapshots published from the above mentioned PR.