### PR TITLE
Unify interop-testing with io.grpc and akka-scala server

### DIFF
--- a/interop-tests/src/main/scala/com/lightbend/grpc/interop/AkkaGrpcServerScala.scala
+++ b/interop-tests/src/main/scala/com/lightbend/grpc/interop/AkkaGrpcServerScala.scala
@@ -1,0 +1,77 @@
+package com.lightbend.grpc.interop
+
+import java.io.FileInputStream
+import java.nio.file.{ Files, Paths }
+import java.security.cert.CertificateFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.{ KeyFactory, KeyStore, SecureRandom }
+import java.util.Base64
+import javax.net.ssl.{ KeyManagerFactory, SSLContext }
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import akka.http.scaladsl.{ Http2, HttpsConnectionContext }
+import akka.stream.{ ActorMaterializer, Materializer }
+import io.grpc.internal.testing.TestUtils
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
+
+case class AkkaGrpcServerScala(serverHandlerFactory: Materializer => ExecutionContext => PartialFunction[HttpRequest, Future[HttpResponse]]) extends GrpcServer[(ActorSystem, ServerBinding)] {
+  override def start() = {
+    implicit val sys = ActorSystem()
+    implicit val mat = ActorMaterializer()
+    implicit val ec = sys.dispatcher
+
+    val testService = serverHandlerFactory(mat)(ec)
+
+    val bindingFuture = Http2().bindAndHandleAsync(
+      testService.orElse { case _: HttpRequest ⇒ Future.successful(HttpResponse(StatusCodes.NotFound)) },
+      interface = "127.0.0.1",
+      port = 8080,
+      httpsContext = serverHttpContext())
+
+    val binding = Await.result(bindingFuture, 10.seconds)
+    (sys, binding)
+  }
+
+  override def stop(binding: (ActorSystem, ServerBinding)) = binding match {
+    case (sys, binding) ⇒
+      sys.log.info("Exception thrown, unbinding")
+      Await.result(binding.unbind(), 10.seconds)
+      Await.result(sys.terminate(), 10.seconds)
+
+  }
+
+  private def serverHttpContext() = {
+    val keyEncoded = new String(Files.readAllBytes(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath)), "UTF-8")
+      .replace("-----BEGIN PRIVATE KEY-----\n", "")
+      .replace("-----END PRIVATE KEY-----\n", "")
+      .replace("\n", "")
+
+    val decodedKey = Base64.getDecoder.decode(keyEncoded)
+
+    val spec = new PKCS8EncodedKeySpec(decodedKey)
+
+    val kf = KeyFactory.getInstance("RSA")
+    val privateKey = kf.generatePrivate(spec)
+
+    val fact = CertificateFactory.getInstance("X.509")
+    val is = new FileInputStream(TestUtils.loadCert("server1.pem"))
+    val cer = fact.generateCertificate(is)
+
+    val ks = KeyStore.getInstance("PKCS12")
+    ks.load(null)
+    ks.setKeyEntry("private", privateKey, Array.empty, Array(cer))
+
+    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    keyManagerFactory.init(ks, null)
+
+    val context = SSLContext.getInstance("TLS")
+    context.init(keyManagerFactory.getKeyManagers, null, new SecureRandom)
+
+    new HttpsConnectionContext(context)
+  }
+
+}

--- a/interop-tests/src/main/scala/com/lightbend/grpc/interop/GrpcServer.scala
+++ b/interop-tests/src/main/scala/com/lightbend/grpc/interop/GrpcServer.scala
@@ -1,0 +1,6 @@
+package com.lightbend.grpc.interop
+
+abstract class GrpcServer[T] {
+  def start(): T
+  def stop(binding: T): Unit
+}

--- a/interop-tests/src/main/scala/com/lightbend/grpc/interop/IoGrpcServer.scala
+++ b/interop-tests/src/main/scala/com/lightbend/grpc/interop/IoGrpcServer.scala
@@ -1,0 +1,18 @@
+package com.lightbend.grpc.interop
+
+import io.grpc.testing.integration2.TestServiceServer
+
+object IoGrpcServer extends GrpcServer[TestServiceServer] {
+  override def start() = {
+    val server = new TestServiceServer
+    if (server.useTls)
+      println("\nUsing fake CA for TLS certificate. Test clients should expect host\n" +
+        "*.test.google.fr and our test CA. For the Java test client binary, use:\n" +
+        "--server_host_override=foo.test.google.fr --use_test_ca=true\n")
+
+    server.start()
+    server
+  }
+
+  override def stop(binding: TestServiceServer) = binding.stop()
+}

--- a/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
@@ -1,24 +1,21 @@
 package com.lightbend.grpc.interop
 
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.stream.Materializer
 import io.grpc.testing.integration.test.{ AkkaGrpcClientTester, TestServiceServiceHandler }
 import io.grpc.testing.integration2.{ ClientTester, Settings }
 import org.scalatest._
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
 class GrpcInteropSpec extends WordSpec with GrpcInteropTests {
 
-  javaGrpcTests(GrpcJavaClientTesterProvider)
-  javaGrpcTests(AkkaHttpClientProvider)
+  grpcTests(IoGrpcJavaServer, GrpcJavaClientTesterProvider)
+  grpcTests(IoGrpcJavaServer, AkkaHttpClientProvider)
 
-  akkaGrpcTests(AkkaHttpServerProvider, GrpcJavaClientTesterProvider)
-  akkaGrpcTests(AkkaHttpServerProvider, AkkaHttpClientProvider)
+  grpcTests(AkkaHttpServerProvider, GrpcJavaClientTesterProvider)
+  grpcTests(AkkaHttpServerProvider, AkkaHttpClientProvider)
 
   object AkkaHttpServerProvider extends AkkaHttpServerProvider {
-    val serverHandlerFactory: Materializer => ExecutionContext => PartialFunction[HttpRequest, Future[HttpResponse]] =
-      implicit mat => implicit ec => TestServiceServiceHandler(new TestServiceImpl())
+    val server = AkkaGrpcServerScala(implicit mat => implicit ec => TestServiceServiceHandler(new TestServiceImpl()))
   }
 
   object AkkaHttpClientProvider extends AkkaClientTestProvider {

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
@@ -10,6 +10,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
 import io.grpc.{ManagedChannel, Status, StatusRuntimeException}
 import io.grpc.testing.integration.messages.{Payload, PayloadType, SimpleRequest, SimpleResponse}
+import io.grpc.testing.integration.test.TestServiceServiceHandler
 import io.grpc.testing.integration2.{ChannelBuilder, ClientTester, Settings}
 import org.scalatest.WordSpec
 
@@ -20,13 +21,13 @@ import io.grpc.testing.integration.test.TestServiceServiceHandler
 
 class GrpcInteropSpec extends WordSpec with GrpcInteropTests {
 
-  javaGrpcTests(AkkaHttpClientProvider)
-  akkaGrpcTests(AkkaHttpServerProvider, GrpcJavaClientTesterProvider)
-  akkaGrpcTests(AkkaHttpServerProvider, AkkaHttpClientProvider)
+  grpcTests(IoGrpcJavaServer, AkkaHttpClientProvider)
+
+  grpcTests(AkkaHttpServerProvider, GrpcJavaClientTesterProvider)
+  grpcTests(AkkaHttpServerProvider, AkkaHttpClientProvider)
 
   object AkkaHttpServerProvider extends AkkaHttpServerProvider {
-    val serverHandlerFactory: Materializer => ExecutionContext => PartialFunction[HttpRequest, Future[HttpResponse]] =
-      implicit mat => implicit ec => TestServiceServiceHandler(new TestServiceImpl())
+    val server = AkkaGrpcServerScala(implicit mat => implicit ec => TestServiceServiceHandler(new TestServiceImpl()))
   }
 
   object AkkaHttpClientProvider extends AkkaClientTestProvider {

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.1


### PR DESCRIPTION
To more easily be able to add akka-java server later