### PR TITLE
Implement server-side of 'status_code_and_message'

### DIFF
--- a/runtime/src/main/scala/akka/http/grpc/Descriptor.scala
+++ b/runtime/src/main/scala/akka/http/grpc/Descriptor.scala
@@ -29,20 +29,21 @@ class ScalapbProtobufSerializer[T <: GeneratedMessage with Message[T]](companion
 object Grpc {
   val contentType = MediaType.applicationBinary("grpc+proto", MediaType.NotCompressible).toContentType
 
+  // Flag to signal the start of an uncompressed frame
   val notCompressed = ByteString(0)
 
   def grpcFramingEncoder: Flow[ByteString, ByteString, NotUsed] = {
-    Flow[ByteString].map { frame =>
+    Flow[ByteString].map(encodeFrame)
+  }
 
-      // todo handle compression
-
-      val length = frame.size
-      notCompressed ++ ByteString(
-        (length >> 24).toByte,
-        (length >> 16).toByte,
-        (length >> 8).toByte,
-        length.toByte) ++ frame
-    }
+  def encodeFrame(frame: ByteString): ByteString = {
+    // TODO handle compression
+    val length = frame.size
+    notCompressed ++ ByteString(
+      (length >> 24).toByte,
+      (length >> 16).toByte,
+      (length >> 8).toByte,
+      length.toByte) ++ frame
   }
 
   val grpcFramingDecoder: Flow[ByteString, ByteString, NotUsed] =

--- a/runtime/src/main/scala/akka/http/grpc/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/akka/http/grpc/GrpcExceptionHandler.scala
@@ -15,9 +15,9 @@ object GrpcExceptionHandler {
   }
   private val handling: PartialFunction[Throwable, Future[HttpResponse]] = {
     case _: NotImplementedError ⇒
-      Future.successful(GrpcMarshalling.status(Status.UNIMPLEMENTED))
+      Future.successful(GrpcResponse.status(Status.UNIMPLEMENTED))
     case _: UnsupportedOperationException ⇒
-      Future.successful(GrpcMarshalling.status(Status.UNIMPLEMENTED))
+      Future.successful(GrpcResponse.status(Status.UNIMPLEMENTED))
     case other ⇒
       Future.failed(other)
   }

--- a/runtime/src/main/scala/akka/http/grpc/GrpcResponse.scala
+++ b/runtime/src/main/scala/akka/http/grpc/GrpcResponse.scala
@@ -1,0 +1,54 @@
+package akka.http.grpc
+
+import akka.NotUsed
+import akka.http.scaladsl.model.HttpEntity.LastChunk
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse }
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Flow, Source }
+import io.grpc.Status
+
+import scala.concurrent.Future
+
+/**
+ * Some helpers for creating HTTP responses for use with gRPC
+ */
+object GrpcResponse {
+  def apply[T](e: Source[T, NotUsed])(implicit m: ProtobufSerializer[T], mat: Materializer): HttpResponse =
+    GrpcResponse(e, Source.single(trailer(Status.OK)))
+
+  def apply[T](e: Source[T, NotUsed], status: Future[Status])(implicit m: ProtobufSerializer[T], mat: Materializer): HttpResponse = {
+    implicit val ec = mat.executionContext
+    GrpcResponse(
+      e,
+      Source
+        .lazilyAsync(() ⇒ status.map(trailer(_)))
+        .mapMaterializedValue(_ ⇒ NotUsed))
+  }
+
+  def apply[T](e: Source[T, NotUsed], trail: Source[HttpEntity.LastChunk, NotUsed])(implicit m: ProtobufSerializer[T], mat: Materializer): HttpResponse = {
+    val outChunks = e
+      .map(m.serialize)
+      .via(Grpc.grpcFramingEncoder)
+      .map(bytes ⇒ HttpEntity.Chunk(bytes))
+      .concat(trail)
+      .recover {
+        case e: Exception =>
+          // TODO handle better
+          e.printStackTrace()
+          trailer(Status.UNKNOWN.withCause(e).withDescription("Stream failed"))
+      }
+
+    HttpResponse(entity = HttpEntity.Chunked(Grpc.contentType, outChunks))
+  }
+
+  def status(status: Status): HttpResponse =
+    HttpResponse(entity = HttpEntity.Chunked(Grpc.contentType, Source.single(trailer(status))))
+
+  def trailer(status: Status): LastChunk =
+    LastChunk(trailer = statusHeaders(status))
+
+  def statusHeaders(status: Status): List[RawHeader] =
+    List(RawHeader("grpc-status", status.getCode.value.toString)) ++ Option(status.getDescription).map(RawHeader("grpc-message", _))
+
+}


### PR DESCRIPTION
The 'streaming' variant of this test is pretty exotic (determining the
response status while streaming the request), so I guess it's OK that the
implementation is a bit hairy as well.