### PR TITLE
Maven improvements

### DIFF
--- a/docs/src/main/paradox/client.md
+++ b/docs/src/main/paradox/client.md
@@ -84,6 +84,13 @@ Maven
         <groupId>com.lightbend.akka.grpc</groupId>
         <artifactId>akka-grpc-maven-plugin</artifactId>
         <version>${akka.grpc.project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/docs/src/main/paradox/server.md
+++ b/docs/src/main/paradox/server.md
@@ -85,6 +85,13 @@ Maven
         <groupId>com.lightbend.akka.grpc</groupId>
         <artifactId>akka-grpc-maven-plugin</artifactId>
         <version>${akka.grpc.project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -30,7 +30,7 @@ class GenerateMojo @Inject() (project: MavenProject) extends AbstractMojo {
   override def execute(): Unit = {
     val schemas = findProtoFiles(new File(protoPath))
 
-    val sourceRoot = "target/main/" + language.name().toLowerCase
+    val sourceRoot = "target/generated-sources/akka-grpc-" + language.name().toLowerCase
     val sourceManaged = new File(sourceRoot)
     project.addCompileSourceRoot(sourceRoot)
 


### PR DESCRIPTION
Uses `target/generated-sources/...` for the generated sources which is the maven convention, makes IDEA automagically detect those generated classes.

Also tied the ´generate´ goal into the lifecycle in the samples which makes `mvn compile` etc just work (tm) without having to manually run akka-grpc:generate first