### PR TITLE
Avoids using 'certificate' in favor of a more specific field name

### DIFF
--- a/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
@@ -46,7 +46,7 @@ public class AkkaGrpcJavaClientTester implements ClientTester {
         settings.serverHost(),
         settings.serverPort()
     ).withOverrideAuthority(settings.serverHostOverride())
-     .withCertificate("ca.pem");
+     .withTrustedCaCertificate("ca.pem");
     client = TestServiceClient.create(grpcSettings, mat, ec);
     clientUnimplementedService = UnimplementedServiceClient.create(grpcSettings, mat, ec);
   }

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
@@ -33,7 +33,7 @@ class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializ
       settings.serverPort,
       Option(settings.serverHostOverride),
       None,
-      certificate = Some("ca.pem"))
+      trustedCaCertificate = Some("ca.pem"))
     client = TestServiceClient(grpcSettings)
     clientUnimplementedService = UnimplementedServiceClient(grpcSettings)
   }

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
@@ -32,7 +32,7 @@ class GreeterClient {
     GrpcClientSettings settings = GrpcClientSettings.create(serverHost, serverPort)
       // Note: In this sample we are using a dummy TLS cert so we need to fake the authority
       .withOverrideAuthority("foo.test.google.fr")
-      .withCertificate("rootCA.crt");
+      .withTrustedCaCertificate("rootCA.crt");
 
     ActorSystem system = ActorSystem.create();
     Materializer materializer = ActorMaterializer.create(system);

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
@@ -31,7 +31,7 @@ class LiftedGreeterClient {
     GrpcClientSettings settings = GrpcClientSettings.create(serverHost, serverPort)
         // Note: In this sample we are using a dummy TLS cert so we need to fake the authority
         .withOverrideAuthority("foo.test.google.fr")
-        .withCertificate("rootCA.crt");
+        .withTrustedCaCertificate("rootCA.crt");
 
     ActorSystem system = ActorSystem.create();
     Materializer materializer = ActorMaterializer.create(system);

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
@@ -37,7 +37,7 @@ object GreeterClient {
       8080,
       overrideAuthority = Some("foo.test.google.fr"),
       None,
-      certificate = Some("ca.pem"),
+      trustedCaCertificate = Some("ca.pem"),
     ))
 
 

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
@@ -36,7 +36,7 @@ object LiftedGreeterClient {
       8080,
       overrideAuthority = Some("foo.test.google.fr"),
       options = None,
-      certificate = Some("ca.pem"),
+      trustedCaCertificate = Some("ca.pem"),
     ))
 
     singleRequestReply()

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -10,13 +10,13 @@ final class GrpcClientSettings(
   // TODO remove CallOptions here and build them ourselves inside the client
   val options: Option[CallOptions],
   // TODO more 'akka-http-like' way of configuring TLS
-  val certificate: Option[String]) {
+  val trustedCaCertificate: Option[String]) {
 
   def withOverrideAuthority(authority: String): GrpcClientSettings =
-    new GrpcClientSettings(host, port, Some(authority), options, certificate)
+    new GrpcClientSettings(host, port, Some(authority), options, trustedCaCertificate)
   def withOptions(options: CallOptions): GrpcClientSettings =
-    new GrpcClientSettings(host, port, overrideAuthority, Some(options), certificate)
-  def withCertificate(certificate: String): GrpcClientSettings =
+    new GrpcClientSettings(host, port, overrideAuthority, Some(options), trustedCaCertificate)
+  def withTrustedCaCertificate(certificate: String): GrpcClientSettings =
     new GrpcClientSettings(host, port, overrideAuthority, options, Some(certificate))
 
 }
@@ -31,8 +31,8 @@ object GrpcClientSettings {
   /**
    * Scala API
    */
-  def apply(host: String, port: Int, overrideAuthority: Option[String], options: Option[CallOptions], certificate: Option[String]): GrpcClientSettings =
-    new GrpcClientSettings(host, port, overrideAuthority, options, certificate)
+  def apply(host: String, port: Int, overrideAuthority: Option[String], options: Option[CallOptions], trustedCaCertificate: Option[String]): GrpcClientSettings =
+    new GrpcClientSettings(host, port, overrideAuthority, options, trustedCaCertificate)
 
   /**
    * Java API

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -27,7 +27,7 @@ object NettyClientUtils {
         .forAddress(settings.host, settings.port)
         .flowControlWindow(65 * 1024)
 
-    builder = settings.certificate.map(c => GrpcSslContexts.forClient.trustManager(loadCert(c)).build)
+    builder = settings.trustedCaCertificate.map(c => GrpcSslContexts.forClient.trustManager(loadCert(c)).build)
       .map(ctx => builder.negotiationType(NegotiationType.TLS).sslContext(ctx))
       .getOrElse(builder.negotiationType(NegotiationType.PLAINTEXT))
     builder = settings.overrideAuthority

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
@@ -33,7 +33,7 @@ class AkkaGrpcClientTester(val settings: Settings)(implicit mat: Materializer, e
       settings.serverPort,
       Option(settings.serverHostOverride),
       None,
-      certificate = Some("ca.pem"))
+      trustedCaCertificate = Some("ca.pem"))
     client = TestServiceClient(grpcSettings)
     clientUnimplementedService = UnimplementedServiceClient(grpcSettings)
   }


### PR DESCRIPTION
While testing this out I wasn't sure what `certificate` this field referred to (trusted CA, client cert?). 

I've left the scaladoc as a `TODO` to keep the change as small as possible and to reduce maintenance if we're still iterating this API.