### PR TITLE
Client settings, #225

### DIFF
--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -51,27 +51,22 @@ public final class @{service.name}Client implements @{service.name} {
 
   private @{service.name}Client(GrpcClientSettings settings, Materializer mat, ExecutionContext ec) {
     this.channel = NettyClientUtils.createChannel(settings);
-    final CallOptions defaultOptions;
-    if (settings.options().isDefined()) {
-      defaultOptions = settings.options().get();
-    } else {
-      defaultOptions = CallOptions.DEFAULT;
-    }
+    final CallOptions options = NettyClientUtils.callOptions(settings);
 
     @for(method <- service.methods) {
       @if(method.methodType == akka.grpc.gen.Unary) {
-        @{method.name}RequestBuilder = new JavaUnaryRequestBuilder<>(@{method.name}Descriptor, channel, defaultOptions);
+        @{method.name}RequestBuilder = new JavaUnaryRequestBuilder<>(@{method.name}Descriptor, channel, options, settings);
       } else {
         @defining(service.grpcName + "." + method.grpcName){ fqName =>
           @if(method.methodType == akka.grpc.gen.ClientStreaming){
             @{method.name}RequestBuilder = new JavaClientStreamingRequestBuilder<>(
-              @{method.name}Descriptor, "@fqName", channel, defaultOptions, mat);
+              @{method.name}Descriptor, "@fqName", channel, options, settings, mat);
           } else if(method.methodType == akka.grpc.gen.ServerStreaming){
             @{method.name}RequestBuilder = new JavaServerStreamingRequestBuilder<>(
-              @{method.name}Descriptor, "@fqName", channel, defaultOptions);
+              @{method.name}Descriptor, "@fqName", channel, options, settings);
           } else if(method.methodType == akka.grpc.gen.BidiStreaming){
             @{method.name}RequestBuilder = new JavaBidirectionalStreamingRequestBuilder<>(
-              @{method.name}Descriptor, "@fqName", channel, defaultOptions);
+              @{method.name}Descriptor, "@fqName", channel, options, settings);
           }
         }
       }

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -25,20 +25,20 @@ final class @{service.name}Client(settings: GrpcClientSettings)(implicit mat: Ma
   import @{service.name}Client._
 
   private val channel = NettyClientUtils.createChannel(settings)
-  private val options = settings.options.getOrElse(CallOptions.DEFAULT)
+  private val options = NettyClientUtils.callOptions(settings)
 
   @for(method <- service.methods) {
     private val @{method.name}RequestBuilder = {
       @if(method.methodType == akka.grpc.gen.Unary) {
-        new ScalaUnaryRequestBuilder(@{method.name}Descriptor, channel, options)
+        new ScalaUnaryRequestBuilder(@{method.name}Descriptor, channel, options, settings)
       } else {
         val fqName = "@{service.grpcName}.@{method.grpcName}"
         @if(method.methodType == akka.grpc.gen.ServerStreaming) {
-          new ScalaServerStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options)
+          new ScalaServerStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options, settings)
         } else if(method.methodType == akka.grpc.gen.ClientStreaming) {
-          new ScalaClientStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options, mat)
+          new ScalaClientStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options, settings, mat)
         } else if (method.methodType == akka.grpc.gen.BidiStreaming) {
-          new ScalaBidirectionalStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options)
+          new ScalaBidirectionalStreamingRequestBuilder(@{method.name}Descriptor, fqName, channel, options, settings)
         }
       }
     }

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
@@ -42,11 +42,10 @@ public class AkkaGrpcJavaClientTester implements ClientTester {
 
   @Override
   public void setUp() {
-    final GrpcClientSettings grpcSettings = GrpcClientSettings.create(
-        settings.serverHost(),
-        settings.serverPort()
-    ).withOverrideAuthority(settings.serverHostOverride())
-     .withTrustedCaCertificate("ca.pem");
+    final GrpcClientSettings grpcSettings =
+        GrpcClientSettings.create(settings.serverHost(), settings.serverPort())
+          .withOverrideAuthority(settings.serverHostOverride())
+          .withTrustedCaCertificate("ca.pem");
     client = TestServiceClient.create(grpcSettings, mat, ec);
     clientUnimplementedService = UnimplementedServiceClient.create(grpcSettings, mat, ec);
   }

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
@@ -28,12 +28,9 @@ class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializ
   private val awaitTimeout = 3.seconds
 
   def setUp(): Unit = {
-    val grpcSettings = new GrpcClientSettings(
-      settings.serverHost,
-      settings.serverPort,
-      Option(settings.serverHostOverride),
-      None,
-      trustedCaCertificate = Some("ca.pem"))
+    val grpcSettings = GrpcClientSettings(settings.serverHost, settings.serverPort)
+      .withOverrideAuthority(settings.serverHostOverride)
+      .withTrustedCaCertificate("ca.pem")
     client = TestServiceClient(grpcSettings)
     clientUnimplementedService = UnimplementedServiceClient(grpcSettings)
   }

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
@@ -32,14 +32,10 @@ object GreeterClient {
     implicit val mat = ActorMaterializer()
     implicit val ec = sys.dispatcher
 
-    val client = new GreeterServiceClient(GrpcClientSettings(
-      "127.0.0.1",
-      8080,
-      overrideAuthority = Some("foo.test.google.fr"),
-      None,
-      trustedCaCertificate = Some("ca.pem"),
-    ))
-
+    val client = new GreeterServiceClient(
+      GrpcClientSettings("127.0.0.1", 8080)
+        .withOverrideAuthority("foo.test.google.fr")
+        .withTrustedCaCertificate("ca.pem"))
 
     singleRequestReply()
     streamingRequest()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
@@ -31,13 +31,10 @@ object LiftedGreeterClient {
     implicit val mat = ActorMaterializer()
     implicit val ec = sys.dispatcher
 
-    val client = new GreeterServiceClient(GrpcClientSettings(
-      "127.0.0.1",
-      8080,
-      overrideAuthority = Some("foo.test.google.fr"),
-      options = None,
-      trustedCaCertificate = Some("ca.pem"),
-    ))
+    val client = new GreeterServiceClient(
+      GrpcClientSettings("127.0.0.1", 8080)
+        .withOverrideAuthority("foo.test.google.fr")
+        .withTrustedCaCertificate("ca.pem"))
 
     singleRequestReply()
     streamingRequest()

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
@@ -28,12 +28,10 @@ class AkkaGrpcClientTester(val settings: Settings)(implicit mat: Materializer, e
   private val awaitTimeout = 7.seconds
 
   def setUp(): Unit = {
-    val grpcSettings = GrpcClientSettings(
-      settings.serverHost,
-      settings.serverPort,
-      Option(settings.serverHostOverride),
-      None,
-      trustedCaCertificate = Some("ca.pem"))
+    val grpcSettings = GrpcClientSettings(settings.serverHost, settings.serverPort)
+      .withOverrideAuthority(settings.serverHostOverride)
+      .withTrustedCaCertificate("ca.pem")
+
     client = TestServiceClient(grpcSettings)
     clientUnimplementedService = UnimplementedServiceClient(grpcSettings)
   }


### PR DESCRIPTION
* remove CallOptions since those expose too much grpc-java implementation specifics
* support CallCredentials, userAgent and deadline
* deadline required some refactoring to pass in the settings to the request builders,
  but that might be useful for other things also later. New CallOptions with the given
  deadline is needed for each call.

Refs #225