### PR TITLE
Allow for benching without tls

### DIFF
--- a/benchmark-java/README.md
+++ b/benchmark-java/README.md
@@ -11,19 +11,19 @@ grpc-java and akka-grpc.
 Server:
 
 ```
-sbt  "runMain akka.grpc.benchmarks.qps.AsyncServer --address=localhost:50051"
+sbt  "runMain akka.grpc.benchmarks.qps.AsyncServer --tls --address=localhost:50051"
 ```
 
 Client with unary calls:
 
 ```
-sbt "runMain akka.grpc.benchmarks.qps.AsyncClient --address=localhost:50051 --warmup_duration=15 --duration=30 --channels=1 --outstanding_rpcs=16"
+sbt "runMain akka.grpc.benchmarks.qps.AsyncClient --tls --address=localhost:50051 --warmup_duration=15 --duration=30 --channels=1 --outstanding_rpcs=16"
 ```
 
 Client with streaming calls:
 
 ```
-sbt "runMain akka.grpc.benchmarks.qps.AsyncClient --address=localhost:50051 --warmup_duration=15 --duration=30 --channels=1 --outstanding_rpcs=16 --streaming_rpcs"
+sbt "runMain akka.grpc.benchmarks.qps.AsyncClient --tls --address=localhost:50051 --warmup_duration=15 --duration=30 --channels=1 --outstanding_rpcs=16 --streaming_rpcs"
 ```
 
 Use `--help` to show description of all options.

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/Utils.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/Utils.java
@@ -18,6 +18,7 @@
 package akka.grpc.benchmarks;
 
 import akka.grpc.GrpcClientSettings;
+import akka.grpc.benchmarks.proto.Control;
 import akka.grpc.benchmarks.proto.Messages;
 import akka.grpc.benchmarks.proto.Messages.Payload;
 import akka.grpc.benchmarks.proto.Messages.SimpleRequest;
@@ -78,7 +79,6 @@ public final class Utils {
     int port = Integer.parseInt(parts[1]);
     return new InetSocketAddress(host, port);
   }
-
 
 
   /**
@@ -184,11 +184,15 @@ public final class Utils {
     return ConnectionContext.https(context);
   }
 
-  public static GrpcClientSettings createGrpcClientSettings(InetSocketAddress socketAddress) {
-    GrpcClientSettings settings = GrpcClientSettings.create(socketAddress.getHostName(), socketAddress.getPort())
-        // Note: In this sample we are using a dummy TLS cert so we need to fake the authority
-        .withOverrideAuthority(TestUtils.TEST_SERVER_HOST)
-        .withTrustedCaCertificate("ca.pem");
-    return settings;
+  public static GrpcClientSettings createGrpcClientSettings(InetSocketAddress socketAddress, boolean useTls) {
+    GrpcClientSettings settings = GrpcClientSettings.create(socketAddress.getHostName(), socketAddress.getPort());
+    if (useTls) // having security params means --tls
+      // Note: In this sample we are using a dummy TLS cert so we need to fake the authority
+      return settings
+          .withOverrideAuthority(TestUtils.TEST_SERVER_HOST)
+          .withTrustedCaCertificate("ca.pem");
+    else
+      return settings;
+
   }
 }

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadClient.java
@@ -85,7 +85,7 @@ class LoadClient {
       InetSocketAddress socketAddress = (InetSocketAddress) Utils.parseSocketAddress(
           config.getServerTargets(i % config.getServerTargetsCount()));
 
-      GrpcClientSettings settings = Utils.createGrpcClientSettings(socketAddress);
+      GrpcClientSettings settings = Utils.createGrpcClientSettings(socketAddress, config.hasSecurityParams());
 
       BenchmarkServiceClient client = BenchmarkServiceClient.create(settings, mat, system.dispatcher());
 

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadServer.java
@@ -45,6 +45,7 @@ final class LoadServer {
   LoadServer(Control.ServerConfig config) throws Exception {
     log.log(Level.INFO, "Server Config \n" + config.toString());
     port = config.getPort() ==  0 ? Utils.pickUnusedPort() : config.getPort();
+
     switch (config.getServerType()) {
       case ASYNC_SERVER: {
         break;
@@ -85,7 +86,7 @@ final class LoadServer {
     InetSocketAddress address = new InetSocketAddress("127.0.0.1", port);
 
     server = new AsyncServer();
-    server.run(address);
+    server.run(address, true);
 
     lastStatTime = System.nanoTime();
     if (osBean != null) {

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncClient.java
@@ -77,7 +77,10 @@ public class AsyncClient {
 
     InetSocketAddress socketAddress = (InetSocketAddress) config.address;
 
-    GrpcClientSettings settings = Utils.createGrpcClientSettings(socketAddress);
+    if (!config.tls)
+      system.log().info("Using plaintext gRPC HTTP/2 connections");
+
+    GrpcClientSettings settings = Utils.createGrpcClientSettings(socketAddress, config.tls);
 
     List<BenchmarkServiceClient> clients = new ArrayList<BenchmarkServiceClient>(config.channels);
     for (int i = 0; i < config.channels; i++) {

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
@@ -72,6 +72,7 @@ public class AsyncServer {
 
     Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
+
     system = ActorSystem.create("AsyncServer", conf);
 
     Materializer mat = ActorMaterializer.create(system);

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/ClientConfiguration.java
@@ -42,8 +42,7 @@ public class ClientConfiguration implements Configuration {
   private static final ClientConfiguration DEFAULT = new ClientConfiguration();
 
   Transport transport = Transport.AKKA_HTTP;
-  // currenlty we don't support non-tls
-  boolean tls = true;
+  boolean tls = false;
   // currently we only support testca
   boolean testca = true;
   String authorityOverride = TestUtils.TEST_SERVER_HOST;

--- a/benchmark-java/src/main/scala/akka/grpc/benchmarks/Unencrypted.scala
+++ b/benchmark-java/src/main/scala/akka/grpc/benchmarks/Unencrypted.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.grpc.benchmarks
+
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ActorSystem
+import akka.http.javadsl.ConnectHttp
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.HttpResponse
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.{ConnectionContext, Http, UseHttp2}
+import akka.stream.Materializer
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+
+object Unencrypted {
+
+  // needed to bind unencrypted http2 due to short coming in Javadsl with 10.1.3
+  // can be removed when https://github.com/akka/akka-http/issues/2110 is fixed
+  def connect(system: ActorSystem, f: akka.japi.Function[HttpRequest, CompletionStage[HttpResponse]], connect: ConnectHttp, mat: Materializer): CompletionStage[ServerBinding] = {
+    Http(system)
+      .bindAndHandleAsync(
+        r => f.apply(r).toScala.asInstanceOf[Future[akka.http.scaladsl.model.HttpResponse]],
+        connect.host,
+        connect.port,
+        ConnectionContext.noEncryption()(UseHttp2.Always))(mat)
+      .toJava
+  }
+}

--- a/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -77,7 +77,7 @@ public class LoadWorkerTest extends JUnitSuite {
     int port = Utils.pickUnusedPort();
     worker = new LoadWorker(system, port, 0);
     worker.start().toCompletableFuture().get(10, TimeUnit.SECONDS);
-    GrpcClientSettings settings = Utils.createGrpcClientSettings(new InetSocketAddress("127.0.0.1", port));
+    GrpcClientSettings settings = Utils.createGrpcClientSettings(new InetSocketAddress("127.0.0.1", port), true);
     workerServiceStub = WorkerServiceClient.create(settings, mat, system.dispatcher());
   }
 

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -67,13 +67,15 @@ final class GrpcClientSettings private (
   val overrideAuthority: Option[String] = None,
   val trustedCaCertificate: Option[String] = None,
   val deadline: Duration = Duration.Undefined,
-  val userAgent: Option[String] = None) {
+  val userAgent: Option[String] = None,
+  val useTls: Boolean = true) {
 
   def withHost(value: String): GrpcClientSettings = copy(host = value)
   def withPort(value: Int): GrpcClientSettings = copy(port = value)
   def withCallCredentials(value: CallCredentials): GrpcClientSettings = copy(callCredentials = Option(value))
   def withOverrideAuthority(value: String): GrpcClientSettings = copy(overrideAuthority = Option(value))
   def withTrustedCaCertificate(value: String): GrpcClientSettings = copy(trustedCaCertificate = Option(value))
+
   /**
    * Each call will have this deadline.
    */
@@ -90,6 +92,12 @@ final class GrpcClientSettings private (
    */
   def withUserAgent(value: String): GrpcClientSettings = copy(userAgent = Option(value))
 
+  /**
+   * Set to false to use unencrypted HTTP/2. This should not be used in production system.
+   */
+  def withTls(enabled: Boolean): GrpcClientSettings =
+    copy(useTls = enabled)
+
   private def copy(
     host: String = host,
     port: Int = port,
@@ -97,13 +105,15 @@ final class GrpcClientSettings private (
     overrideAuthority: Option[String] = overrideAuthority,
     trustedCaCertificate: Option[String] = trustedCaCertificate,
     deadline: Duration = deadline,
-    userAgent: Option[String] = userAgent): GrpcClientSettings = new GrpcClientSettings(
+    userAgent: Option[String] = userAgent,
+    useTls: Boolean = useTls): GrpcClientSettings = new GrpcClientSettings(
     callCredentials = callCredentials,
     deadline = deadline,
     host = host,
     overrideAuthority = overrideAuthority,
     port = port,
     trustedCaCertificate = trustedCaCertificate,
-    userAgent = userAgent)
+    userAgent = userAgent,
+    useTls = useTls)
 
 }

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -31,12 +31,15 @@ object NettyClientUtils {
         .forAddress(settings.host, settings.port)
         .flowControlWindow(NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW)
 
-    builder = settings.trustedCaCertificate.map(c => GrpcSslContexts.forClient.trustManager(loadCert(c)).build)
-      .map(ctx => builder.negotiationType(NegotiationType.TLS).sslContext(ctx))
-      .getOrElse(builder.negotiationType(NegotiationType.PLAINTEXT))
+    if (!settings.useTls)
+      builder = builder.usePlaintext()
+    else {
+      builder = settings.trustedCaCertificate.map(c => GrpcSslContexts.forClient.trustManager(loadCert(c)).build)
+        .map(ctx => builder.negotiationType(NegotiationType.TLS).sslContext(ctx))
+        .getOrElse(builder.negotiationType(NegotiationType.PLAINTEXT))
 
-    builder = settings.overrideAuthority.map(builder.overrideAuthority(_)).getOrElse(builder)
-
+      builder = settings.overrideAuthority.map(builder.overrideAuthority(_)).getOrElse(builder)
+    }
     builder = settings.userAgent.map(builder.userAgent(_)).getOrElse(builder)
 
     builder.build


### PR DESCRIPTION
Adds actually caring about the `--tls` flag for the server, without the server binds as unencrypted HTTP/2

Also adds a `.useTls` flag to the `GrpcClientSettings`