### PR TITLE
Simpler server usage in Play

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
@@ -17,7 +17,7 @@ object PlayJavaServerCodeGenerator extends JavaCodeGenerator {
   private val generateRouter: Service => CodeGeneratorResponse.File = service => {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(Router(service).body)
-    b.setName(s"${service.packageDir}/${service.name}Router.java")
+    b.setName(s"${service.packageDir}/Abstract${service.name}Router.java")
     b.build
   }
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaServerCodeGenerator.scala
@@ -16,7 +16,7 @@ object PlayScalaServerCodeGenerator extends ScalaCodeGenerator {
   private val generateRouter: Service => CodeGeneratorResponse.File = service => {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(Router(service).body)
-    b.setName(s"${service.packageDir}/${service.name}Router.scala")
+    b.setName(s"${service.packageDir}/Abstract${service.name}Router.scala")
     b.build
   }
 }

--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -17,17 +17,13 @@ import akka.stream.Materializer;
 
 import akka.grpc.internal.PlayRouter;
 
-import play.mvc.*;
-import play.api.inject.Injector;
-
-
 /**
  * Abstract base class for implementing @{service.name} in Java and using as a play Router
  */
 public abstract class Abstract@{service.name}Router extends PlayRouter implements @{service.name} {
 
-  public Abstract@{service.name}Router(Injector injector) {
-    super(injector, @{service.name}.name);
+  public Abstract@{service.name}Router(Materializer mat) {
+    super(mat, @{service.name}.name);
   }
 
   /**

--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -6,90 +6,39 @@
 
 package @service.packageName;
 
-import javax.inject.*;
+import java.util.concurrent.CompletionStage;
 
 import akka.japi.Function;
-import play.api.mvc.Handler;
-import play.api.mvc.akkahttp.AkkaHttpHandler$;
-import scala.compat.java8.FutureConverters;
-import scala.compat.java8.JFunction1;
 import scala.concurrent.Future;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import akka.stream.Materializer;
 
+import akka.grpc.internal.PlayRouter;
+
 import play.mvc.*;
-import play.api.mvc.akkahttp.AkkaHttpHandler;
-import play.routing.Router;
+import play.api.inject.Injector;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 
-@@Singleton
-public class @{service.name}Router implements Router {
+/**
+ * Abstract base class for implementing @{service.name} in Java and using as a play Router
+ */
+public abstract class Abstract@{service.name}Router extends PlayRouter implements @{service.name} {
 
-  private final String prefix;
-  private final controllers.@{service.name}Impl impl;
-  private final Materializer mat;
-
-  private final AkkaHttpHandler handler;
-
-  @@Inject
-  public @{service.name}Router(controllers.@{service.name}Impl impl, Materializer mat) {
-      this(@{service.name}.name, impl, mat);
-    }
-
-  public @{service.name}Router(String prefix, controllers.@{service.name}Impl impl, Materializer mat) {
-    this.prefix = prefix;
-    this.impl = impl;
-    this.mat = mat;
-
-    // perhaps provide adapter in runtime lib or introduce javadsl accepting one in Play?
-    this.handler = AkkaHttpHandler$.MODULE$.apply(new JFunction1<HttpRequest, Future<HttpResponse>>() {
-      final Function<akka.http.javadsl.model.HttpRequest, CompletionStage<akka.http.javadsl.model.HttpResponse>> h =
-        @{service.name}HandlerFactory.create(impl, prefix, mat);
-
-      @@Override
-      public Future<HttpResponse> apply(HttpRequest req) {
-        try {
-        CompletionStage<akka.http.scaladsl.model.HttpResponse> res =
-            h.apply(akka.http.javadsl.model.HttpRequest.class.cast(req))
-              .thenApply(r -> akka.http.scaladsl.model.HttpResponse.class.cast(r));
-
-          return FutureConverters.toScala(res);
-        } catch (Exception e) {
-          return FutureConverters.<HttpResponse>failedPromise(e).future();
-        }
-      }
-    });
+  public Abstract@{service.name}Router(Injector injector) {
+    super(injector, @{service.name}.name);
   }
 
-
-  @@Override
-  public List<RouteDocumentation> documentation() {
-    return Collections.emptyList();
+  /**
+   * INTERNAL API
+   */
+  final public scala.Function1<HttpRequest, Future<HttpResponse>> createHandler(String prefix, Materializer mat) {
+     return akka.grpc.internal.PlayRouterHelper.handlerFor(
+        @{service.name}HandlerFactory.create(this, prefix, mat)
+     );
   }
 
-  @@Override
-  public Optional<Handler> route(Http.RequestHeader request) {
-    if (request.path().startsWith(prefix)) return Optional.of(handler);
-    else return Optional.empty();
-  }
-
-  @@Override
-  public Router withPrefix(String newPrefix) {
-    if (newPrefix.equals("/")) return this;
-    else return new @{service.name}Router(newPrefix, impl, mat) {
-      @@Override
-      public Router withPrefix(String newPrefix) {
-        if (newPrefix.equals("/")) return this;
-        else throw new IllegalStateException("Only one level of prefixes is supported for gRPC");
-      }
-    };
-  }
 
 }
 

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -13,12 +13,10 @@ import akka.stream.Materializer
 
 import akka.grpc.internal.PlayRouter
 
-import play.api.inject.Injector
-
 /**
  * Abstract base class for implementing @{service.name} and using as a play Router
  */
-abstract class Abstract@{service.name}Router(injector: Injector) extends PlayRouter(injector, @{service.name}.name) with @{service.name} {
+abstract class Abstract@{service.name}Router(mat: Materializer) extends PlayRouter(mat, @{service.name}.name) with @{service.name} {
 
   final override def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse] =
     @{service.name}Handler(this, serviceName)(mat)

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -6,51 +6,21 @@
 
 package @service.packageName
 
-import javax.inject._
-
 import scala.concurrent.Future
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.stream.Materializer
 
-import play.api.mvc._
-import play.api.mvc.akkahttp.AkkaHttpHandler
-import play.api.routing.Router
-import play.api.routing.Router.Routes
+import akka.grpc.internal.PlayRouter
 
-@@Singleton
-class @{service.name}Router @@Inject()(impl: controllers.@{service.name}Impl)(implicit mat: Materializer)
-  extends Router {
-  protected val prefix = @{service.name}.name
+import play.api.inject.Injector
 
-  protected val handler = new AkkaHttpHandler {
-    val h = @{service.name}Handler(impl, prefix)
-    override def apply(request: HttpRequest): Future[HttpResponse] = h(request)
-  }
+/**
+ * Abstract base class for implementing @{service.name} and using as a play Router
+ */
+abstract class Abstract@{service.name}Router(injector: Injector) extends PlayRouter(injector, @{service.name}.name) with @{service.name} {
 
-  // could look at @{service.name}.name, but isn't this already covered in the route file?
-  override def routes: Routes = {
-    case rh if rh.path.startsWith(prefix) ⇒ handler
-  }
-
-  override def documentation: Seq[(String, String, String)] = Seq.empty
-
-  override def withPrefix(newPrefix: String): Router = {
-    if (newPrefix == "/") this
-    else new @{service.name}Router(impl) {
-      override val prefix = newPrefix
-
-      // Needs to be overridden to point to new prefix due to initialization order
-      override val handler = new AkkaHttpHandler {
-        val h = @{service.name}Handler(impl, newPrefix)
-        override def apply(request: HttpRequest): Future[HttpResponse] = h(request)
-      }
-
-      override def withPrefix(additionalPrefix: String): Router = {
-        if (prefix == "/") this
-        else throw new IllegalStateException("Only one level of prefixes is supported for gRPC")
-      }
-    }
-  }
+  final override def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse] =
+    @{service.name}Handler(this, serviceName)(mat)
 
 }

--- a/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
+++ b/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
@@ -6,17 +6,24 @@ package controllers;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
-import example.myapp.helloworld.grpc.GreeterService;
+import com.google.inject.Inject;
+import example.myapp.helloworld.grpc.AbstractGreeterServiceRouter;
 import example.myapp.helloworld.grpc.HelloReply;
 import example.myapp.helloworld.grpc.HelloRequest;
+import play.api.inject.Injector;
 
 import javax.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-/** Would be written by the user, with support for dependency injection etc */
+/** User implementation, with support for dependency injection etc */
 @Singleton
-public class GreeterServiceImpl implements GreeterService {
+public class GreeterServiceImpl extends AbstractGreeterServiceRouter {
+
+  @Inject
+  public GreeterServiceImpl(Injector injector) {
+    super(injector);
+  }
 
   @Override
   public CompletionStage<HelloReply> sayHello(HelloRequest in) {

--- a/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
+++ b/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
@@ -2,11 +2,10 @@
  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
+// #service-impl
 package controllers;
 
-import akka.NotUsed;
 import akka.stream.Materializer;
-import akka.stream.javadsl.Source;
 import com.google.inject.Inject;
 import example.myapp.helloworld.grpc.AbstractGreeterServiceRouter;
 import example.myapp.helloworld.grpc.HelloReply;
@@ -33,3 +32,4 @@ public class GreeterServiceImpl extends AbstractGreeterServiceRouter {
   }
 
 }
+// #service-impl

--- a/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
+++ b/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
@@ -11,7 +11,6 @@ import com.google.inject.Inject;
 import example.myapp.helloworld.grpc.AbstractGreeterServiceRouter;
 import example.myapp.helloworld.grpc.HelloReply;
 import example.myapp.helloworld.grpc.HelloRequest;
-import play.api.inject.Injector;
 
 import javax.inject.Singleton;
 import java.util.concurrent.CompletableFuture;

--- a/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
+++ b/play-interop-test-java/src/main/java/controllers/GreeterServiceImpl.java
@@ -5,6 +5,7 @@
 package controllers;
 
 import akka.NotUsed;
+import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import com.google.inject.Inject;
 import example.myapp.helloworld.grpc.AbstractGreeterServiceRouter;
@@ -21,8 +22,8 @@ import java.util.concurrent.CompletionStage;
 public class GreeterServiceImpl extends AbstractGreeterServiceRouter {
 
   @Inject
-  public GreeterServiceImpl(Injector injector) {
-    super(injector);
+  public GreeterServiceImpl(Materializer mat) {
+    super(mat);
   }
 
   @Override

--- a/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
+++ b/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
@@ -73,6 +73,11 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
       reply.getMessage shouldBe s"Hello, $name!"
     }
 
+    "allow it's expected prefix" in {
+      val result = router.withPrefix(s"/${GreeterService.name}")
+      result shouldBe theSameInstanceAs(router)
+    }
+
     "not allow specifying another prefix" in {
       intercept[UnsupportedOperationException] {
         router.withPrefix("/some")
@@ -89,7 +94,7 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
       RequestFactory.plain.createRequest(
         RemoteConnection(uri.authority.host.address, secure = false, clientCertificateChain = None),
         "GET",
-        RequestTarget(uri.toString, uri.path.toString.tail, queryString = Map.empty),
+        RequestTarget(uri.toString, uri.path.toString, queryString = Map.empty),
         version = "42",
         Headers(),
         attrs = TypedMap.empty,

--- a/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
+++ b/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
@@ -5,32 +5,28 @@
 package akka.grpc.gen
 
 import akka.NotUsed
-
-import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.grpc.scaladsl.GrpcMarshalling
-import akka.http.scaladsl.model._
-import akka.stream.{ ActorMaterializer, Materializer }
-import play.api.libs.typedmap.TypedMap
-import play.api.mvc.akkahttp.AkkaHttpHandler
-import play.api.mvc.Headers
-import play.mvc.Http.RequestHeader
-import play.mvc.{ Http ⇒ PlayHttp }
-import controllers.GreeterServiceImpl
 import akka.grpc.{ Codec, Grpc, ProtobufSerializer }
 import akka.http.scaladsl.marshalling.{ Marshaller, ToResponseMarshaller }
 import akka.http.scaladsl.model.HttpEntity.Chunk
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{ FromRequestUnmarshaller, Unmarshaller }
 import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.{ ActorMaterializer, Materializer }
 import akka.util.ByteString
-import example.myapp.helloworld.grpc.{ GreeterService, GreeterServiceRouter }
-import example.myapp.helloworld.grpc.HelloRequest
-import example.myapp.helloworld.grpc.HelloReply
+import controllers.GreeterServiceImpl
+import example.myapp.helloworld.grpc.{ GreeterService, HelloReply, HelloRequest }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import play.api.inject.SimpleInjector
+import play.api.libs.typedmap.TypedMap
+import play.api.mvc.{ Handler, Headers, RequestHeader }
+import play.api.mvc.akkahttp.AkkaHttpHandler
 import play.api.mvc.request.{ RemoteConnection, RequestFactory, RequestTarget }
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
   implicit val sys = ActorSystem()
@@ -54,23 +50,24 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
   implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec): ToResponseMarshaller[Source[T, NotUsed]] =
     Marshaller.opaque((response: Source[T, NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec))
 
+  val injector = new SimpleInjector(null, Map(
+    classOf[Materializer] -> mat))
+
+  val router = new GreeterServiceImpl(injector)
+
   "The generated Play (Java) Router" should {
 
     "don't accept requests for other paths" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl(), mat)
-
-      router.route(playRequestFor(Uri("http://localhost/foo"))).isPresent shouldBe false
+      router.routes.lift(playRequestFor(Uri("http://localhost/foo"))).isEmpty shouldBe true
     }
 
-    "by default accept requests using the service name as prefix" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl(), mat)
-
+    "accept requests using the service name as prefix" in {
       val uri = Uri(s"http://localhost/${GreeterService.name}/SayHello")
-      router.route(playRequestFor(uri)).isPresent shouldBe true
+      router.routes.lift(playRequestFor(uri)).isDefined shouldBe true
 
       val name = "John"
 
-      val handler = router.route(playRequestFor(uri)).get().asInstanceOf[AkkaHttpHandler]
+      val handler = router.routes(playRequestFor(uri)).asInstanceOf[AkkaHttpHandler]
       val request = akkaHttpRequestFor(uri, HelloRequest.newBuilder().setName(name).build())(HelloRequestSerializer)
       val response = handler(request).futureValue
       response.status shouldBe StatusCodes.OK
@@ -79,21 +76,10 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
       reply.getMessage shouldBe s"Hello, $name!"
     }
 
-    "allow specifying a different prefix" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl(), mat).withPrefix("otherPrefix")
-
-      val uri = Uri(s"http://localhost/otherPrefix/SayHello")
-      router.route(playRequestFor(uri)).isPresent shouldBe true
-
-      val name = "John"
-
-      val handler = router.route(playRequestFor(uri)).get().asInstanceOf[AkkaHttpHandler]
-      val request = akkaHttpRequestFor(uri, HelloRequest.newBuilder().setName(name).build())(HelloRequestSerializer)
-      val response = handler(request).futureValue
-      response.status shouldBe StatusCodes.OK
-
-      val reply = akkaHttpResponse[HelloReply](response).futureValue
-      reply.getMessage shouldBe s"Hello, $name!"
+    "not allow specifying another prefix" in {
+      intercept[UnsupportedOperationException] {
+        router.withPrefix("/some")
+      }
     }
 
     def akkaHttpRequestFor[T](uri: Uri, msg: T)(implicit serializer: ProtobufSerializer[T]) = {
@@ -110,7 +96,7 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
         version = "42",
         Headers(),
         attrs = TypedMap.empty,
-        body = ()).asJava
+        body = ())
   }
 
   override def afterAll(): Unit = {

--- a/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
+++ b/play-interop-test-java/src/test/scala/akka/grpc/gen/PlayJavaRouterSpec.scala
@@ -50,10 +50,7 @@ class PlayJavaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll w
   implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec): ToResponseMarshaller[Source[T, NotUsed]] =
     Marshaller.opaque((response: Source[T, NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec))
 
-  val injector = new SimpleInjector(null, Map(
-    classOf[Materializer] -> mat))
-
-  val router = new GreeterServiceImpl(injector)
+  val router = new GreeterServiceImpl(mat)
 
   "The generated Play (Java) Router" should {
 

--- a/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
+++ b/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
@@ -5,16 +5,16 @@
 package controllers
 
 import akka.NotUsed
-import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import example.myapp.helloworld.grpc.helloworld.{ GreeterService, HelloReply, HelloRequest }
+import example.myapp.helloworld.grpc.helloworld.{ AbstractGreeterServiceRouter, HelloReply, HelloRequest }
 import javax.inject.{ Inject, Singleton }
+import play.api.inject.Injector
 
 import scala.concurrent.Future
 
-/** Would be written by the user, with support for dependency injection etc */
+/** User implementation, with support for dependency injection etc */
 @Singleton
-class GreeterServiceImpl @Inject() (implicit mat: Materializer) extends GreeterService {
+class GreeterServiceImpl @Inject() (injector: Injector) extends AbstractGreeterServiceRouter(injector) {
 
   override def sayHello(in: HelloRequest): Future[HelloReply] = Future.successful(HelloReply(s"Hello, ${in.name}!"))
 

--- a/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
+++ b/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
@@ -2,14 +2,12 @@
  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
+// #service-impl
 package controllers
 
-import akka.NotUsed
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import example.myapp.helloworld.grpc.helloworld.{ AbstractGreeterServiceRouter, HelloReply, HelloRequest }
 import javax.inject.{ Inject, Singleton }
-import play.api.inject.Injector
 
 import scala.concurrent.Future
 
@@ -20,3 +18,4 @@ class GreeterServiceImpl @Inject() (implicit mat: Materializer) extends Abstract
   override def sayHello(in: HelloRequest): Future[HelloReply] = Future.successful(HelloReply(s"Hello, ${in.name}!"))
 
 }
+// #service-impl

--- a/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
+++ b/play-interop-test-scala/src/main/scala/controllers/GreeterServiceImpl.scala
@@ -5,6 +5,7 @@
 package controllers
 
 import akka.NotUsed
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import example.myapp.helloworld.grpc.helloworld.{ AbstractGreeterServiceRouter, HelloReply, HelloRequest }
 import javax.inject.{ Inject, Singleton }
@@ -14,7 +15,7 @@ import scala.concurrent.Future
 
 /** User implementation, with support for dependency injection etc */
 @Singleton
-class GreeterServiceImpl @Inject() (injector: Injector) extends AbstractGreeterServiceRouter(injector) {
+class GreeterServiceImpl @Inject() (implicit mat: Materializer) extends AbstractGreeterServiceRouter(mat) {
 
   override def sayHello(in: HelloRequest): Future[HelloReply] = Future.successful(HelloReply(s"Hello, ${in.name}!"))
 

--- a/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
+++ b/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
@@ -29,10 +29,7 @@ class PlayScalaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll 
   implicit val ec = sys.dispatcher
   implicit val patience = PatienceConfig(timeout = 3.seconds, interval = 15.milliseconds)
 
-  val injector = new SimpleInjector(null, Map(
-    classOf[Materializer] -> mat))
-
-  val router = new GreeterServiceImpl(injector)
+  val router = new GreeterServiceImpl
 
   "The generated Play Router" should {
 

--- a/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
+++ b/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
@@ -52,9 +52,14 @@ class PlayScalaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll 
       reply.message shouldBe s"Hello, $name!"
     }
 
-    "not allow specifying a different prefix" in {
+    "allow it's expected prefix" in {
+      val result = router.withPrefix(s"/${GreeterService.name}")
+      result shouldBe theSameInstanceAs(router)
+    }
+
+    "not allow specifying another prefix" in {
       intercept[UnsupportedOperationException] {
-        router.withPrefix("otherPrefix")
+        router.withPrefix("/some")
       }
     }
 
@@ -67,7 +72,7 @@ class PlayScalaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll 
     def playRequestFor(uri: Uri) = RequestFactory.plain.createRequest(
       RemoteConnection(uri.authority.host.address, secure = false, clientCertificateChain = None),
       "GET",
-      RequestTarget(uri.toString, uri.path.toString.tail, queryString = Map.empty),
+      RequestTarget(uri.toString, uri.path.toString, queryString = Map.empty),
       version = "42",
       Headers(),
       attrs = TypedMap.empty,

--- a/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
+++ b/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayScalaRouterSpec.scala
@@ -7,7 +7,7 @@ package akka.grpc.gen
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
+import akka.stream.{ ActorMaterializer, Materializer }
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.akkahttp.AkkaHttpHandler
 import play.api.mvc.Headers
@@ -21,24 +21,26 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import play.api.inject.SimpleInjector
 
-class PlayRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class PlayScalaRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
   implicit val sys = ActorSystem()
   implicit val mat = ActorMaterializer()
   implicit val ec = sys.dispatcher
   implicit val patience = PatienceConfig(timeout = 3.seconds, interval = 15.milliseconds)
 
+  val injector = new SimpleInjector(null, Map(
+    classOf[Materializer] -> mat))
+
+  val router = new GreeterServiceImpl(injector)
+
   "The generated Play Router" should {
 
-    "don't accept requests for other paths" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl())
-
+    "not accept requests for other paths" in {
       router.routes.isDefinedAt(playRequestFor(Uri("http://localhost/foo"))) shouldBe false
     }
 
     "by default accept requests using the service name as prefix" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl())
-
       val uri = Uri(s"http://localhost/${GreeterService.name}/SayHello")
       router.routes.isDefinedAt(playRequestFor(uri)) shouldBe true
 
@@ -53,21 +55,10 @@ class PlayRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with 
       reply.message shouldBe s"Hello, $name!"
     }
 
-    "allow specifying a different prefix" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl()).withPrefix("otherPrefix")
-
-      val uri = Uri(s"http://localhost/otherPrefix/SayHello")
-      router.routes.isDefinedAt(playRequestFor(uri)) shouldBe true
-
-      val name = "John"
-
-      val handler = router.routes(playRequestFor(uri)).asInstanceOf[AkkaHttpHandler]
-      val request = akkaHttpRequestFor(uri, HelloRequest(name))
-      val response = handler(request).futureValue
-      response.status shouldBe StatusCodes.OK
-
-      val reply = akkaHttpResponse[HelloReply](response).futureValue
-      reply.message shouldBe s"Hello, $name!"
+    "not allow specifying a different prefix" in {
+      intercept[UnsupportedOperationException] {
+        router.withPrefix("otherPrefix")
+      }
     }
 
     def akkaHttpRequestFor[T](uri: Uri, msg: T)(implicit serializer: ProtobufSerializer[T]) = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,7 +94,10 @@ object Dependencies {
     Compile.akkaHttpCore,
     Compile.akkaHttp,
     Compile.akkaHttp2Support,
-    Compile.akkaDiscovery
+    Compile.akkaDiscovery,
+    // these two are available when used through Play, which is also the only case when they are needed
+    Compile.play % "provided",
+    Compile.playAkkaHttpServer % "provided",
   ) ++ testing
 
   val mavenPlugin = l ++= Seq(

--- a/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.grpc.internal
+
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import akka.annotation.InternalApi
+import akka.dispatch.{ Dispatchers, ExecutionContexts }
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.stream.Materializer
+import play.api.inject.Injector
+import play.api.mvc.Handler
+import play.api.mvc.akkahttp.AkkaHttpHandler
+import play.api.routing.Router
+import play.api.routing.Router.Routes
+import play.mvc.Http
+
+import scala.concurrent.Future
+import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object PlayRouterHelper {
+  def handlerFor(javaHandler: akka.japi.Function[akka.http.javadsl.model.HttpRequest, CompletionStage[akka.http.javadsl.model.HttpResponse]]): HttpRequest => Future[HttpResponse] = AkkaHttpHandler.apply(req =>
+    javaHandler.apply(req.asInstanceOf[akka.http.javadsl.model.HttpRequest])
+      .toScala
+      .map(javaResp => javaResp.asInstanceOf[akka.http.scaladsl.model.HttpResponse])(ExecutionContexts.sameThreadExecutionContext))
+}
+
+/**
+ * Boiler plate needed for the generated Play routers allowing for adding a service implementation in a Play app,
+ * inherited by the generated abstract service router (both Java and Scala) which is then implemented by the user.
+ *
+ * INTERNAL API
+ */
+@InternalApi abstract class PlayRouter(injector: Injector, serviceName: String) extends play.api.routing.Router {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  protected def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse]
+
+  private val handler = new AkkaHttpHandler {
+    val handler = createHandler(serviceName, injector.instanceOf[Materializer])
+    override def apply(request: HttpRequest): Future[HttpResponse] = handler(request)
+  }
+
+  // Scala API
+  final override def routes: Routes = {
+    case rh if rh.path.startsWith(serviceName) ⇒ handler
+  }
+
+  final override def documentation: Seq[(String, String, String)] = Seq.empty
+
+  /**
+   * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification
+   * so therefore not supported.
+   */
+  final override def withPrefix(prefix: String): Router =
+    throw new UnsupportedOperationException("Prefixing gRPC services is not widely supported, " +
+      "strongly discouraged by the specification and therefore not supported")
+
+}

--- a/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
@@ -68,6 +68,7 @@ import scala.compat.java8.OptionConverters._
     if (prefix == this.prefix) this
     else
       throw new UnsupportedOperationException("Prefixing gRPC services is not widely supported by clients, " +
-        s"strongly discouraged by the specification and therefore not supported. Prefix was [$prefix]")
+        s"strongly discouraged by the specification and therefore not supported. Prefix was [$prefix] but" +
+        s"the only allowed prefix is [${this.prefix}]")
 
 }

--- a/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
@@ -1,6 +1,7 @@
 /**
- * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.grpc.internal
 
 import java.util.Optional


### PR DESCRIPTION
This allows for just one class, annotated as Singleton (or injected in some other way - no longer tied to Guice) referenced in the routes file like so:

```
@Singleton 
class MyWhateverNameILike @Inject() (i: Injector) extends AbstractGreeterServiceRouter(i) {
 ... gRPC method implementations ...
} 

in the routes file
->     /helloworld.GreeterService   whatever.package.MyWhateverNameILike
```

Originally conceived here: https://github.com/raboof/play-scala-grpc-server/pull/8/files