### PR TITLE
Lookup service discovery mechanism by name

### DIFF
--- a/codegen/src/main/twirl/templates/PlayJava/ClientProvider.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJava/ClientProvider.scala.txt
@@ -33,6 +33,6 @@ public class @{service.name}ClientProvider implements Provider<@{service.name}Cl
   }
 
   public @{service.name}Client get() {
-    return @{service.name}Client.create(GrpcClientSettings.create(@{service.name}.name, sys), mat, sys.dispatcher());
+    return @{service.name}Client.create(GrpcClientSettings.fromConfig(@{service.name}.name, sys), mat, sys.dispatcher());
   }
 }

--- a/codegen/src/main/twirl/templates/PlayScala/ClientProvider.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/ClientProvider.scala.txt
@@ -24,6 +24,6 @@ import akka.stream.Materializer
 class @{service.name}ClientProvider @@Inject()(implicit sys: ActorSystem, mat: Materializer) extends Provider[@{service.name}Client]() {
   override def get(): @{service.name}Client = {
     implicit val ec: ExecutionContext = sys.dispatcher
-    @{service.name}Client(GrpcClientSettings(@{service.name}.name, sys))
+    @{service.name}Client(GrpcClientSettings(@{service.name}.name))
   }
 }

--- a/codegen/src/main/twirl/templates/PlayScala/ClientProvider.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/ClientProvider.scala.txt
@@ -24,6 +24,6 @@ import akka.stream.Materializer
 class @{service.name}ClientProvider @@Inject()(implicit sys: ActorSystem, mat: Materializer) extends Provider[@{service.name}Client]() {
   override def get(): @{service.name}Client = {
     implicit val ec: ExecutionContext = sys.dispatcher
-    @{service.name}Client(GrpcClientSettings(@{service.name}.name))
+    @{service.name}Client(GrpcClientSettings.fromConfig(@{service.name}.name))
   }
 }

--- a/docs/src/main/paradox/client.md
+++ b/docs/src/main/paradox/client.md
@@ -156,7 +156,82 @@ Maven
 mvn akka-grpc:generate compile exec:java -Dexec.mainClass=io.grpc.examples.helloworld.GreeterClient
 ```
 
+### Configuration 
 
+A gRPC client is configured with a `GrpcClientSettings` instance. There are a number of ways of creating one and the API
+docs are the best reference. 
+
+The simplest way to create a client is to provide a static host and port.
+
+Scala
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala) { #simple }
+
+Java
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #simple }
+
+Further settings can be added via the `with` methods
+
+Scala
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala) { #simple-programmatic }
+
+Java
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #simple-programmatic }
+
+Instead a client can be defined in configuration. All client configurations need to be under `akka.grpc.client`
+
+Scala
+:  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #client-config }
+
+Java
+:  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #client-config }
+
+Clients defined in configuration pick up defaults from `reference.conf`:
+
+Scala
+:  @@snip [reference]($root$/../runtime/src/main/resources/reference.conf) { #defaults }
+
+Java
+:  @@snip [reference]($root$/../runtime/src/main/resources/reference.conf) { #defaults }
+
+#### Service discovery
+
+The examples above all use a hard coded host and port for the location of the gRPC service. Alternatively 
+[Akka Service Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used.
+This allows a gRPC client to switch between discovering services via DNS, config, Kubernetes and Consul by just changing
+the configuration.
+
+To see how to config a particular service discovery mechanism see the [Akka Service Discovery docs](https://developer.lightbend.com/docs/akka-management/current/discovery.html).
+Once it is configured a service discovery instance can either be passed into settings or the name of the mechanism
+to lookup via an ActorSystem's configuration.
+
+Scala
+:  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #config-service-discovery }
+
+Java
+:  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #config-service-discovery }
+
+The above example configures the client `project.WithConfigServiceDiscovery` to use `config` based service discovery.
+
+Then to create the `GrpcClientSettings`:
+
+Scala
+:  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #sd-settings }
+
+Java
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #sd-settings }
+
+Alternatively if a `SimpleServiceDiscovery` is available else where in your system is can be passed in:
+
+Scala
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala) { #provide-sd }
+
+Java
+:  @@snip [GrpcClientSettingsCompileOnly]($root$/../runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #provide-sd }
+
+ 
+Currently service discovery is only queried on creation of the client. A client can be automatically re-created, and go via service discovery again,
+ if a connection can't established, see the lifecycle section.
+ 
 ### Lifecycle
 
 Instances of the generated client may be long-lived and can be used concurrently.

--- a/docs/src/main/paradox/client.md
+++ b/docs/src/main/paradox/client.md
@@ -159,7 +159,7 @@ mvn akka-grpc:generate compile exec:java -Dexec.mainClass=io.grpc.examples.hello
 ### Configuration 
 
 A gRPC client is configured with a `GrpcClientSettings` instance. There are a number of ways of creating one and the API
-docs are the best reference. 
+docs are the best reference. An `ActorSystem` is always required as it is used for default configuration and service discovery.
 
 The simplest way to create a client is to provide a static host and port.
 
@@ -195,14 +195,13 @@ Java
 
 #### Service discovery
 
-The examples above all use a hard coded host and port for the location of the gRPC service. Alternatively 
-[Akka Service Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used.
+The examples above all use a hard coded host and port for the location of the gRPC service which is the default if you do not configure a `service-discovery-mechanism`.
+Alternatively [Akka Service Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used.
 This allows a gRPC client to switch between discovering services via DNS, config, Kubernetes and Consul by just changing
 the configuration.
 
 To see how to config a particular service discovery mechanism see the [Akka Service Discovery docs](https://developer.lightbend.com/docs/akka-management/current/discovery.html).
-Once it is configured a service discovery instance can either be passed into settings or the name of the mechanism
-to lookup via an ActorSystem's configuration.
+Once it is configured a service discovery mechanism name can either be passed into settings or put in the client's configuration.
 
 Scala
 :  @@snip [GrpcClientSettingsSpec]($root$/../runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala) { #config-service-discovery }
@@ -230,7 +229,7 @@ Java
 
  
 Currently service discovery is only queried on creation of the client. A client can be automatically re-created, and go via service discovery again,
- if a connection can't established, see the lifecycle section.
+ if a connection can't be established, see the lifecycle section.
  
 ### Lifecycle
 

--- a/docs/src/main/paradox/client.md
+++ b/docs/src/main/paradox/client.md
@@ -193,14 +193,14 @@ Scala
 Java
 :  @@snip [reference]($root$/../runtime/src/main/resources/reference.conf) { #defaults }
 
-#### Service discovery
+#### Akka Discovery
 
 The examples above all use a hard coded host and port for the location of the gRPC service which is the default if you do not configure a `service-discovery-mechanism`.
-Alternatively [Akka Service Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used.
-This allows a gRPC client to switch between discovering services via DNS, config, Kubernetes and Consul by just changing
+Alternatively [Akka Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used.
+This allows a gRPC client to switch between discovering services via DNS, config, Kubernetes and Consul and others by just changing
 the configuration.
 
-To see how to config a particular service discovery mechanism see the [Akka Service Discovery docs](https://developer.lightbend.com/docs/akka-management/current/discovery.html).
+To see how to config a particular service discovery mechanism see the [Akka Discovery docs](https://developer.lightbend.com/docs/akka-management/current/discovery.html).
 Once it is configured a service discovery mechanism name can either be passed into settings or put in the client's configuration.
 
 Scala

--- a/interop-tests/src/main/java/com/lightbend/grpc/interop/AkkaGrpcClientJava.java
+++ b/interop-tests/src/main/java/com/lightbend/grpc/interop/AkkaGrpcClientJava.java
@@ -20,9 +20,9 @@ import java.util.concurrent.TimeUnit;
 
 public class AkkaGrpcClientJava extends GrpcClient {
 
-  private final Function3<Settings, Materializer, ExecutionContext, ClientTester> clientTesterFactory;
+  private final Function3<Settings, Materializer, ActorSystem, ClientTester> clientTesterFactory;
 
-  public AkkaGrpcClientJava(Function3<Settings, Materializer, ExecutionContext, ClientTester> clientTesterFactory) {
+  public AkkaGrpcClientJava(Function3<Settings, Materializer, ActorSystem, ClientTester> clientTesterFactory) {
     this.clientTesterFactory = clientTesterFactory;
   }
 
@@ -33,7 +33,7 @@ public class AkkaGrpcClientJava extends GrpcClient {
     final ActorSystem sys = ActorSystem.create("AkkaGrpcClientJava");
     final Materializer mat = ActorMaterializer.create(sys);
 
-    final TestServiceClient client = new TestServiceClient(clientTesterFactory.apply(settings, mat, sys.dispatcher()));
+    final TestServiceClient client = new TestServiceClient(clientTesterFactory.apply(settings, mat, sys));
     client.setUp();
 
     try {

--- a/interop-tests/src/main/scala/com/lightbend/grpc/interop/AkkaGrpcClientScala.scala
+++ b/interop-tests/src/main/scala/com/lightbend/grpc/interop/AkkaGrpcClientScala.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext }
 
 // TODO #151 use our own Settings object
-final case class AkkaGrpcClientScala(clientTesterFactory: Settings => Materializer => ExecutionContext => ClientTester) extends GrpcClient {
+final case class AkkaGrpcClientScala(clientTesterFactory: Settings => Materializer => ActorSystem => ClientTester) extends GrpcClient {
 
   override def run(args: Array[String]): Unit = {
     TestUtils.installConscryptIfAvailable()
@@ -23,7 +23,7 @@ final case class AkkaGrpcClientScala(clientTesterFactory: Settings => Materializ
     implicit val sys = ActorSystem()
     implicit val mat = ActorMaterializer()
 
-    val client = new TestServiceClient(clientTesterFactory(settings)(mat)(sys.dispatcher))
+    val client = new TestServiceClient(clientTesterFactory(settings)(mat)(sys))
     client.setUp()
 
     try

--- a/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/com/lightbend/grpc/interop/GrpcInteropSpec.scala
@@ -148,13 +148,13 @@ class GrpcInteropSpec extends WordSpec with GrpcInteropTests with Directives {
   object AkkaHttpClientProviderScala extends AkkaHttpClientProvider {
     val label: String = "akka-grpc scala client tester"
 
-    def client = AkkaGrpcClientScala(settings => implicit mat => implicit ec => new AkkaGrpcScalaClientTester(settings))
+    def client = AkkaGrpcClientScala(settings => implicit mat => implicit as => new AkkaGrpcScalaClientTester(settings))
   }
 
   object AkkaHttpClientProviderJava extends AkkaHttpClientProvider {
     val label: String = "akka-grpc java client tester"
 
-    def client = new AkkaGrpcClientJava((settings, mat, ec) => new AkkaGrpcJavaClientTester(settings, mat, ec))
+    def client = new AkkaGrpcClientJava((settings, mat, as) => new AkkaGrpcJavaClientTester(settings, mat, as))
   }
 
 }

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
@@ -54,7 +54,7 @@ public class AkkaGrpcJavaClientTester implements ClientTester {
   @Override
   public void setUp() {
     final GrpcClientSettings grpcSettings =
-        GrpcClientSettings.create(settings.serverHost(), settings.serverPort(), as)
+        GrpcClientSettings.connectToServiceAt(settings.serverHost(), settings.serverPort(), as)
           .withOverrideAuthority(settings.serverHostOverride())
           .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"));
     client = TestServiceClient.create(grpcSettings, mat, ec);

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/AkkaGrpcJavaClientTester.java
@@ -4,6 +4,7 @@
 
 package io.grpc.testing.integration;
 
+import akka.actor.ActorSystem;
 import akka.grpc.GrpcClientSettings;
 import akka.grpc.GrpcResponseMetadata;
 import akka.grpc.GrpcSingleResponse;
@@ -36,22 +37,24 @@ public class AkkaGrpcJavaClientTester implements ClientTester {
   private final Settings settings;
   private final Materializer mat;
   private final ExecutionContext ec;
+  private final ActorSystem as;
 
   private TestServiceClient client;
   private UnimplementedServiceClient clientUnimplementedService;
 
   private static int AWAIT_TIME_SECONDS = 3;
 
-  public AkkaGrpcJavaClientTester(Settings settings, Materializer mat, ExecutionContext ec) {
+  public AkkaGrpcJavaClientTester(Settings settings, Materializer mat, ActorSystem as) {
     this.settings = settings;
     this.mat = mat;
-    this.ec = ec;
+    this.as = as;
+    this.ec =  as.dispatcher();
   }
 
   @Override
   public void setUp() {
     final GrpcClientSettings grpcSettings =
-        GrpcClientSettings.create(settings.serverHost(), settings.serverPort())
+        GrpcClientSettings.create(settings.serverHost(), settings.serverPort(), as)
           .withOverrideAuthority(settings.serverHostOverride())
           .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"));
     client = TestServiceClient.create(grpcSettings, mat, ec);

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
@@ -6,6 +6,7 @@ package io.grpc.testing.integration.test
 
 import java.io.{ IOException, InputStream }
 
+import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings.getClass
 import akka.grpc.internal.NettyClientUtils
 import akka.grpc.{ GrpcClientSettings, GrpcResponseMetadata, SSLContextUtils }
@@ -26,10 +27,11 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.Failure
 import scala.util.control.NoStackTrace
 
-class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializer, ex: ExecutionContext) extends ClientTester {
+class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializer, as: ActorSystem) extends ClientTester {
 
   private var client: TestServiceClient = null
   private var clientUnimplementedService: UnimplementedServiceClient = null
+  private implicit val ec = as.dispatcher
 
   private val awaitTimeout = 3.seconds
 

--- a/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/io/grpc/testing/integration/test/AkkaGrpcScalaClientTester.scala
@@ -27,17 +27,17 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.Failure
 import scala.util.control.NoStackTrace
 
-class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializer, as: ActorSystem) extends ClientTester {
+class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializer, system: ActorSystem) extends ClientTester {
 
   private var client: TestServiceClient = null
   private var clientUnimplementedService: UnimplementedServiceClient = null
-  private implicit val ec = as.dispatcher
+  private implicit val ec = system.dispatcher
 
   private val awaitTimeout = 3.seconds
 
   def setUp(): Unit = {
 
-    val grpcSettings = GrpcClientSettings(settings.serverHost, settings.serverPort)
+    val grpcSettings = GrpcClientSettings.connectToServiceAt(settings.serverHost, settings.serverPort)
       .withOverrideAuthority(settings.serverHostOverride)
       .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"))
     client = TestServiceClient(grpcSettings)

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
@@ -29,7 +29,7 @@ class GreeterClient {
     ActorSystem system = ActorSystem.create("HelloWorldClient");
     Materializer materializer = ActorMaterializer.create(system);
 
-    GrpcClientSettings settings = GrpcClientSettings.create(GreeterService.name, system);
+    GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);
     GreeterServiceClient client = null;
     try {
       client = GreeterServiceClient.create(settings, materializer, system.dispatcher());

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
@@ -28,7 +28,7 @@ class LiftedGreeterClient {
     ActorSystem system = ActorSystem.create("HelloWorldClient");
     Materializer materializer = ActorMaterializer.create(system);
 
-    GrpcClientSettings settings = GrpcClientSettings.create(GreeterService.name, system);
+    GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);
     GreeterServiceClient client = null;
     try {
       client = GreeterServiceClient.create(settings, materializer, system.dispatcher());

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/RestartingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/RestartingGreeterClient.java
@@ -30,7 +30,7 @@ class RestartingGreeterClient {
 
         try {
             //#restarting-client
-            GrpcClientSettings settings = GrpcClientSettings.create(GreeterService.name, system);
+            GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);
 
             RestartingClient<GreeterServiceClient> client = new RestartingClient<>(
                     () -> GreeterServiceClient.create(settings, materializer, system.dispatcher()), system.dispatcher()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
@@ -24,7 +24,7 @@ object GreeterClient {
     implicit val mat = ActorMaterializer()
     implicit val ec = sys.dispatcher
 
-    val clientSettings = GrpcClientSettings.create(GreeterService.name, sys)
+    val clientSettings = GrpcClientSettings.fromConfig(GreeterService.name)
     val client = new GreeterServiceClient(clientSettings)
 
     singleRequestReply()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
@@ -24,7 +24,7 @@ object LiftedGreeterClient {
     implicit val mat = ActorMaterializer()
     implicit val ec = sys.dispatcher
 
-    val clientSettings = GrpcClientSettings.create(GreeterService.name, sys)
+    val clientSettings = GrpcClientSettings.fromConfig(GreeterService.name)
     val client = new GreeterServiceClient(clientSettings)
 
     singleRequestReply()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/RestartingGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/RestartingGreeterClient.scala
@@ -22,7 +22,7 @@ object RestartingGreeterClient {
 
     //#restarting-client
     // Function for creating a client
-    val clientSettings = GrpcClientSettings.create(GreeterService.name, sys)
+    val clientSettings = GrpcClientSettings.fromConfig(GreeterService.name)
     val clientConstructor = () => new GreeterServiceClient(clientSettings)
 
     // Wrapped in a restarting client

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -41,7 +41,7 @@ class GreeterSpec
     implicit val mat = ActorMaterializer.create(clientSystem)
     implicit val ec = clientSystem.dispatcher
     new GreeterServiceClient(
-      GrpcClientSettings("127.0.0.1", 8080)
+      GrpcClientSettings.connectToServiceAt("127.0.0.1", 8080)
         .withOverrideAuthority("foo.test.google.fr")
         .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem")))
   }

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -24,7 +24,7 @@ class GreeterSpec
 
   implicit val patience = PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
 
-  val serverSystem: ActorSystem = {
+  implicit val serverSystem: ActorSystem = {
     // important to enable HTTP/2 in server ActorSystem's config
     val conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   object Versions {
     val akka = "2.5.14"
     val akkaHttp = "10.1.3"
-    val akkaDiscovery = "0.15.0"
+    val akkaDiscovery = "0.17.0"
 
     val play = "2.7.0-M1"
 
@@ -61,6 +61,7 @@ object Dependencies {
     val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest % "test" // ApacheV2
     val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % Versions.scalaJava8Compat % "test" // BSD 3-clause
     val junit = "junit" % "junit" % "4.12" % "test" // Common Public License 1.0
+    val akkaDiscoveryConfig    = "com.lightbend.akka.discovery" %% "akka-discovery-config"     % Versions.akkaDiscovery % "test"
   }
 
   object Plugins {
@@ -98,6 +99,7 @@ object Dependencies {
     // these two are available when used through Play, which is also the only case when they are needed
     Compile.play % "provided",
     Compile.playAkkaHttpServer % "provided",
+    Test.akkaDiscoveryConfig
   ) ++ testing
 
   val mavenPlugin = l ++= Seq(

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -1,13 +1,29 @@
+//#defaults
 akka.grpc.client."*" {
-  host = ""
+  # host to use if service-discovery-mechaism is hardcoded
+  # otherwise the name to look up in service discovery
+  service-name = ""
+
+  # port to use if service-discovery-mechism is hardcoded or service discovery does not return a port
   port = 0
+
+  # timeout for service discovery resolving
   resolve-timeout = 1s
+
   deadline = infinite
   override-authority = ""
   trusted-ca-certificate = ""
   user-agent = ""
   # Pulls default configuration from ssl-config-core's reference.conf
   ssl-config = ${ssl-config}
+
   # TODO: Enforce HTTP/2 TLS restrictions: https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2
   connection-attempts = -1
+
+  # Service discovery mechamism to use. The default is to use a hard coded host
+  # and port that will be resolved via DNS.
+  # Any of the mechanisms described [here](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used
+  # including Kubernetes, Consul, AWS API
+  service-discovery-mechanism = "hardcoded"
 }
+//#defaults

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -1,10 +1,13 @@
 //#defaults
 akka.grpc.client."*" {
-  # host to use if service-discovery-mechaism is hardcoded
-  # otherwise the name to look up in service discovery
+
+  # Host to use if service-discovery-mechanism is set to static
+  host = ""
+
+  # Service name to use if a service-discovery-mechanism other than static
   service-name = ""
 
-  # port to use if service-discovery-mechism is hardcoded or service discovery does not return a port
+  # port to use if service-discovery-mechism is static or service discovery does not return a port
   port = 0
 
   # timeout for service discovery resolving
@@ -20,10 +23,10 @@ akka.grpc.client."*" {
   # TODO: Enforce HTTP/2 TLS restrictions: https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2
   connection-attempts = -1
 
-  # Service discovery mechamism to use. The default is to use a hard coded host
+  # Service discovery mechamism to use. The default is to use a static host
   # and port that will be resolved via DNS.
   # Any of the mechanisms described [here](https://developer.lightbend.com/docs/akka-management/current/discovery.html) can be used
   # including Kubernetes, Consul, AWS API
-  service-discovery-mechanism = "hardcoded"
+  service-discovery-mechanism = "static"
 }
 //#defaults

--- a/runtime/src/main/scala/akka/grpc/internal/HardcodedServiceDiscovery.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/HardcodedServiceDiscovery.scala
@@ -4,14 +4,13 @@
 
 package akka.grpc.internal
 
-import akka.discovery.SimpleServiceDiscovery
+import akka.discovery.{ Lookup, SimpleServiceDiscovery }
 import akka.discovery.SimpleServiceDiscovery.Resolved
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 class HardcodedServiceDiscovery(resolved: Resolved) extends SimpleServiceDiscovery {
-  override def lookup(name: String, resolveTimeout: FiniteDuration): Future[SimpleServiceDiscovery.Resolved] = {
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
     Future.successful(resolved)
-  }
 }

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -32,7 +32,7 @@ object NettyClientUtils {
   @InternalApi
   def createChannel(settings: GrpcClientSettings)(implicit ec: ExecutionContext): InternalChannel = {
     val promise = Promise[Done]()
-    val mc = settings.serviceDiscovery.lookup(settings.name, settings.resolveTimeout).flatMap { targets =>
+    val mc = settings.serviceDiscovery.lookup(settings.serviceName, settings.resolveTimeout).flatMap { targets =>
       if (targets.addresses.nonEmpty) {
         val target = targets.addresses(ThreadLocalRandom.current().nextInt(targets.addresses.size))
         var builder =
@@ -56,7 +56,7 @@ object NettyClientUtils {
         ChannelUtils.monitorChannel(promise, channel, settings.connectionAttempts)
         Future.successful(channel)
       } else {
-        Future.failed(new IllegalStateException("No targets returned for name: " + settings.name))
+        Future.failed(new IllegalStateException("No targets returned for name: " + settings.serviceName))
       }
     }
     new InternalChannel(mc, promise)

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -1,0 +1,44 @@
+package jdocs.akka.grpc.client;
+
+import akka.actor.ActorSystem;
+import akka.discovery.ServiceDiscovery;
+import akka.discovery.SimpleServiceDiscovery;
+import akka.grpc.GrpcClientSettings;
+
+import java.time.Duration;
+
+public class GrpcClientSettingsCompileOnly {
+    public static void sd() {
+
+        //#simple
+        GrpcClientSettings.create("localhost", 443);
+        //#simple
+
+        //#simple-programmatic
+        GrpcClientSettings.create("localhost", 443)
+                .withDeadline(Duration.ofSeconds(1))
+                .withTls(false);
+        //#simple-programmatic
+
+        ActorSystem actorSystem = ActorSystem.create();
+        //#provide-sd
+        // An ActorSystem's default service discovery mechanism
+        SimpleServiceDiscovery serviceDiscovery = ServiceDiscovery.get(actorSystem).discovery();
+
+        GrpcClientSettings.create(
+                "my-service",
+                443,
+                serviceDiscovery,
+                Duration.ofSeconds(10)
+        );
+        //#provide-sd
+
+        //#sd-settings
+        // sys is an ActorSystem which is required for service discovery
+        GrpcClientSettings.create(
+                "project.WithConfigServiceDiscovery", actorSystem
+        );
+        //#sd-settings
+
+    }
+}

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -5,8 +5,6 @@
 package jdocs.akka.grpc.client;
 
 import akka.actor.ActorSystem;
-import akka.discovery.ServiceDiscovery;
-import akka.discovery.SimpleServiceDiscovery;
 import akka.grpc.GrpcClientSettings;
 
 import java.time.Duration;
@@ -14,26 +12,24 @@ import java.time.Duration;
 public class GrpcClientSettingsCompileOnly {
     public static void sd() {
 
+        ActorSystem actorSystem = ActorSystem.create();
         //#simple
-        GrpcClientSettings.create("localhost", 443);
+        GrpcClientSettings.create("localhost", 443, actorSystem);
         //#simple
 
         //#simple-programmatic
-        GrpcClientSettings.create("localhost", 443)
+        GrpcClientSettings.create("localhost", 443, actorSystem)
                 .withDeadline(Duration.ofSeconds(1))
                 .withTls(false);
         //#simple-programmatic
 
-        ActorSystem actorSystem = ActorSystem.create();
         //#provide-sd
         // An ActorSystem's default service discovery mechanism
-        SimpleServiceDiscovery serviceDiscovery = ServiceDiscovery.get(actorSystem).discovery();
-
         GrpcClientSettings.create(
                 "my-service",
                 443,
-                serviceDiscovery,
-                Duration.ofSeconds(10)
+                "config", // config based service discovery must be defined in the ActorSystems' config
+                actorSystem
         );
         //#provide-sd
 

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package jdocs.akka.grpc.client;
 
 import akka.actor.ActorSystem;

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -14,18 +14,18 @@ public class GrpcClientSettingsCompileOnly {
 
         ActorSystem actorSystem = ActorSystem.create();
         //#simple
-        GrpcClientSettings.create("localhost", 443, actorSystem);
+        GrpcClientSettings.connectToServiceAt("localhost", 443, actorSystem);
         //#simple
 
         //#simple-programmatic
-        GrpcClientSettings.create("localhost", 443, actorSystem)
+        GrpcClientSettings.connectToServiceAt("localhost", 443, actorSystem)
                 .withDeadline(Duration.ofSeconds(1))
                 .withTls(false);
         //#simple-programmatic
 
         //#provide-sd
         // An ActorSystem's default service discovery mechanism
-        GrpcClientSettings.create(
+        GrpcClientSettings.discoverService(
                 "my-service",
                 443,
                 "config", // config based service discovery must be defined in the ActorSystems' config
@@ -35,7 +35,7 @@ public class GrpcClientSettingsCompileOnly {
 
         //#sd-settings
         // sys is an ActorSystem which is required for service discovery
-        GrpcClientSettings.create(
+        GrpcClientSettings.fromConfig(
                 "project.WithConfigServiceDiscovery", actorSystem
         );
         //#sd-settings

--- a/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
@@ -7,33 +7,73 @@ package akka.grpc
 import java.io.IOException
 
 import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery
+import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.config.ConfigSimpleServiceDiscovery
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ Matchers, WordSpec }
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.collection.{ immutable => im }
 
 class GrpcClientSettingsSpec extends WordSpec with Matchers with ScalaFutures {
   "The gRPC client settings spec" should {
+    val clientWithServiceDiscovery = ConfigFactory.parseString(
+      """
+        //#config-service-discovery
+        akka.grpc.client {
+          "project.WithConfigServiceDiscovery" {
+            service-discovery-mechanism = "config"
+            service-name = "from-config"
+            port = 43
+          }
+        }
+        //#config-service-discovery
+
+        akka.discovery.config.services = {
+           from-config {
+             endpoints = [
+               {
+                 host = "cat"
+                 port = 1234
+               }
+             ]
+           },
+           from-config-no-port  {
+              endpoints = [
+                {
+                  host = "dog"
+                }
+              ]
+           }
+         }
+        """)
+
     val sys = ActorSystem("test", ConfigFactory.parseString(
       """
-        |akka.grpc.client {
-        |  "project.WithSpecificConfiguration" {
-        |    host = "myhost"
-        |    port = 42
-        |    override-authority = "google.fr"
-        |    deadline = 10m
-        |    user-agent = "Akka-gRPC"
-        |  }
-        |}
-      """.stripMargin).withFallback(ConfigFactory.load()))
+        //#client-config
+        akka.grpc.client {
+          "project.WithSpecificConfiguration" {
+            service-name = "myhost"
+            port = 42
+            override-authority = "google.fr"
+            deadline = 10m
+            user-agent = "Akka-gRPC"
+          }
+        }
+        //#client-config
+      """)
+      .withFallback(clientWithServiceDiscovery)
+      .withFallback(ConfigFactory.load()))
 
     def sysWithCert(certFileName: String) = {
       val clientConfig = ConfigFactory.parseString(
         s"""
         akka.grpc.client {
           "project.WithSpecificConfiguration" {
-            host = "myhost"
+            service-name = "myhost"
             port = 42
             override-authority = "google.fr"
             ssl-config {
@@ -49,19 +89,21 @@ class GrpcClientSettingsSpec extends WordSpec with Matchers with ScalaFutures {
           }
         }
       """)
+
       val defaultConfig = ConfigFactory.load()
-      ActorSystem("test", clientConfig.withFallback(defaultConfig))
+      ActorSystem("test", clientConfig.withFallback(defaultConfig).withFallback(clientWithServiceDiscovery))
     }
 
-    "fall back to the default configuration if no specific configuration is found" in {
-      // Should not crash:
-      GrpcClientSettings("project.WithoutSpecificConfiguration", sys)
+    "provide a useful error message if configuration missing" in {
+      intercept[IllegalArgumentException] {
+        GrpcClientSettings("project.MissingConfiguration", sys)
+      }.getMessage should be("requirement failed: Config path `akka.grpc.client.project.MissingConfiguration` does not exist")
     }
 
     "parse configuration values" in {
       val parsed = GrpcClientSettings("project.WithSpecificConfiguration", sys)
-      parsed.name should be("myhost")
-      val Seq(discovered) = parsed.serviceDiscovery.lookup(parsed.name, 1.second).futureValue.addresses
+      parsed.serviceName should be("myhost")
+      val Seq(discovered) = parsed.serviceDiscovery.lookup(parsed.serviceName, 1.second).futureValue.addresses
       discovered.host should be("myhost")
       discovered.port should be(Some(42))
       parsed.overrideAuthority should be(Some("google.fr"))
@@ -75,6 +117,23 @@ class GrpcClientSettingsSpec extends WordSpec with Matchers with ScalaFutures {
         GrpcClientSettings("project.WithSpecificConfiguration", sysWithCert("no-such-cert.pem"))
       // We want a good message since missing classpath resources are difficult to debug
       thrown.getMessage should include("certs/no-such-cert.pem")
+    }
+
+    "load a user defined service discovery mechanism" in {
+      //#sd-settings
+      // sys is an ActorSystem which is required for service discovery
+      val settings = GrpcClientSettings(
+        clientName = "project.WithConfigServiceDiscovery",
+        actorSystem = sys)
+      //#sd-settings
+
+      settings.serviceDiscovery shouldBe a[ConfigSimpleServiceDiscovery]
+
+      val resolvedWithPort = settings.serviceDiscovery.lookup("from-config", 1.second).futureValue
+      resolvedWithPort should be(Resolved("from-config", im.Seq(ResolvedTarget("cat", Some(1234)))))
+
+      val resolvedWithNoPort = settings.serviceDiscovery.lookup("from-config-no-port", 1.second).futureValue
+      resolvedWithNoPort should be(Resolved("from-config-no-port", im.Seq(ResolvedTarget("dog", None))))
     }
   }
 }

--- a/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
@@ -7,14 +7,12 @@ package akka.grpc
 import java.io.IOException
 
 import akka.actor.ActorSystem
-import akka.discovery.SimpleServiceDiscovery
 import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
 import akka.discovery.config.ConfigSimpleServiceDiscovery
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ Matchers, WordSpec }
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.{ immutable => im }
 

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration._
 
 object GrpcClientSettingsCompileOnly {
 
+  implicit val actorSystem = ActorSystem()
   //#simple
   GrpcClientSettings("localhost", 443)
   //#simple
@@ -22,15 +23,11 @@ object GrpcClientSettingsCompileOnly {
     .withTls(false)
   //#simple-programmatic
 
-  val actorSystem = ActorSystem()
   //#provide-sd
   // An ActorSystem's default service discovery mechanism
-  val serviceDiscovery: SimpleServiceDiscovery = ServiceDiscovery(actorSystem).discovery
-
   GrpcClientSettings(
     serviceName = "my-service",
     defaultPort = 443,
-    serviceDiscovery = serviceDiscovery,
-    10.seconds)
+    serviceDiscoveryMechanism = "config")
   //#provide-sd
 }

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package docs.akka.grpc.client
 
 import akka.actor.ActorSystem

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -14,18 +14,18 @@ object GrpcClientSettingsCompileOnly {
 
   implicit val actorSystem = ActorSystem()
   //#simple
-  GrpcClientSettings("localhost", 443)
+  GrpcClientSettings.connectToServiceAt("localhost", 443)
   //#simple
 
   //#simple-programmatic
-  GrpcClientSettings("localhost", 443)
+  GrpcClientSettings.connectToServiceAt("localhost", 443)
     .withDeadline(1.second)
     .withTls(false)
   //#simple-programmatic
 
   //#provide-sd
   // An ActorSystem's default service discovery mechanism
-  GrpcClientSettings(
+  GrpcClientSettings.discoverService(
     serviceName = "my-service",
     defaultPort = 443,
     serviceDiscoveryMechanism = "config")

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -1,0 +1,32 @@
+package docs.akka.grpc.client
+
+import akka.actor.ActorSystem
+import akka.discovery.{ ServiceDiscovery, SimpleServiceDiscovery }
+import akka.grpc.GrpcClientSettings
+
+import scala.concurrent.duration._
+
+object GrpcClientSettingsCompileOnly {
+
+  //#simple
+  GrpcClientSettings("localhost", 443)
+  //#simple
+
+  //#simple-programmatic
+  GrpcClientSettings("localhost", 443)
+    .withDeadline(1.second)
+    .withTls(false)
+  //#simple-programmatic
+
+  val actorSystem = ActorSystem()
+  //#provide-sd
+  // An ActorSystem's default service discovery mechanism
+  val serviceDiscovery: SimpleServiceDiscovery = ServiceDiscovery(actorSystem).discovery
+
+  GrpcClientSettings(
+    serviceName = "my-service",
+    defaultPort = 443,
+    serviceDiscovery = serviceDiscovery,
+    10.seconds)
+  //#provide-sd
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
@@ -31,7 +31,7 @@ class AkkaGrpcClientTester(val settings: Settings)(implicit mat: Materializer, s
   private val awaitTimeout = 7.seconds
 
   def setUp(): Unit = {
-    val grpcSettings = GrpcClientSettings(settings.serverHost, settings.serverPort)
+    val grpcSettings = GrpcClientSettings.connectToServiceAt(settings.serverHost, settings.serverPort)
       .withOverrideAuthority(settings.serverHostOverride)
       .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"))
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/com/lightbend/grpc/interop/AkkaGrpcClientTester.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 
 import akka.grpc.{GrpcClientSettings, GrpcResponseMetadata, GrpcServiceException, SSLContextUtils}
 import akka.stream.Materializer
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.google.protobuf.ByteString
 import io.grpc.testing.integration.messages.{Payload, ResponseParameters, SimpleRequest, StreamingOutputCallRequest, StreamingOutputCallResponse, _}
@@ -21,10 +22,11 @@ import scala.util.control.NoStackTrace
 import io.grpc.testing.integration.test.{ TestServiceClient, UnimplementedServiceClient }
 
 
-class AkkaGrpcClientTester(val settings: Settings)(implicit mat: Materializer, ex: ExecutionContext) extends ClientTester {
+class AkkaGrpcClientTester(val settings: Settings)(implicit mat: Materializer, sys: ActorSystem) extends ClientTester {
 
   private var client: TestServiceClient = null
   private var clientUnimplementedService: UnimplementedServiceClient = null
+  private implicit val ec = sys.dispatcher
 
   private val awaitTimeout = 7.seconds
 


### PR DESCRIPTION
* Documentation for GrpcClientSettings
* Clarify between a "clientName" for looking up a particular client's
configuration and "serviceName" for the name to look up in service
discovery for a service's host/port

Closes #281 

Note I made it illegal to create a client form configuration that doesn't exist. I don't think that makes sense with the distinction between clientName and serviceName WDYT? 