### PR TITLE
WIP: Change Play router prefix behavior

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,6 +167,7 @@ lazy val playInteropTestScala = Project(
   .settings(commonSettings)
   .settings(Seq(
     ReflectiveCodeGen.reflectiveGeneratorClass := "akka.grpc.sbt.test.PlayScalaCompositeCodeGenerator",
+    fork in Test := true,
   ))
   .enablePlugins(akka.grpc.NoPublish)
   .enablePlugins(akka.grpc.ReflectiveCodeGen)
@@ -183,6 +184,7 @@ lazy val playInteropTestJava = Project(
   .settings(commonSettings)
   .settings(Seq(
     ReflectiveCodeGen.reflectiveGeneratorClass := "akka.grpc.sbt.test.PlayJavaCompositeCodeGenerator",
+    fork in Test := true,
   ))
   .enablePlugins(akka.grpc.NoPublish)
   .enablePlugins(akka.grpc.ReflectiveCodeGen)

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -15,13 +15,17 @@ import akka.stream.Materializer
 
 import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler
-import play.api.routing.Router
+import play.api.routing.{Router, SimpleRouter}
 import play.api.routing.Router.Routes
 
 @@Singleton
-class @{service.name}Router @@Inject()(impl: controllers.@{service.name}Impl)(implicit mat: Materializer)
-  extends Router {
-  protected val prefix = @{service.name}.name
+class @{service.name}Router(impl: controllers.@{service.name}Impl, prefix: String)(implicit mat: Materializer)
+  extends SimpleRouter {
+  require(prefix != null && !prefix.isEmpty && prefix.charAt(0) == '/')
+
+  @@Inject()
+  def this(impl: controllers.@{service.name}Impl)(implicit mat: Materializer) =
+    this(impl, "/" + @{service.name}.name)
 
   protected val handler = new AkkaHttpHandler {
     val h = @{service.name}Handler(impl, prefix)
@@ -37,20 +41,7 @@ class @{service.name}Router @@Inject()(impl: controllers.@{service.name}Impl)(im
 
   override def withPrefix(newPrefix: String): Router = {
     if (newPrefix == "/") this
-    else new @{service.name}Router(impl) {
-      override val prefix = newPrefix
-
-      // Needs to be overridden to point to new prefix due to initialization order
-      override val handler = new AkkaHttpHandler {
-        val h = @{service.name}Handler(impl, newPrefix)
-        override def apply(request: HttpRequest): Future[HttpResponse] = h(request)
-      }
-
-      override def withPrefix(additionalPrefix: String): Router = {
-        if (prefix == "/") this
-        else throw new IllegalStateException("Only one level of prefixes is supported for gRPC")
-      }
-    }
+    else new @{service.name}Router(impl, newPrefix)
   }
 
 }

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -6,6 +6,7 @@
 
 package @service.packageName
 
+import scala.annotation.tailrec
 import scala.concurrent.{ ExecutionContext, Future }
 
 import akka.grpc.scaladsl.{ GrpcExceptionHandler, GrpcMarshalling, ScalapbProtobufSerializer }
@@ -13,7 +14,6 @@ import akka.grpc.Codecs
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.Uri.Path.Segment
 
 import akka.stream.Materializer
 
@@ -62,6 +62,7 @@ object @{service.name}Handler {
    * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
    */
   def partial(implementation: @service.name, prefix: String)(implicit mat: Materializer): PartialFunction[HttpRequest, Future[HttpResponse]] = {
+
     implicit val ec: ExecutionContext = mat.executionContext
     import @{service.name}.Serializers._
 
@@ -76,11 +77,36 @@ object @{service.name}Handler {
       case m => Future.failed(new NotImplementedError(s"Not implemented: $m"))
     }
 
-    Function.unlift((req: HttpRequest) => req.uri.path match {
-      case Path.Slash(Segment(`prefix`, Path.Slash(Segment(method, Path.Empty)))) ⇒
-        Some(handle(req, method).recoverWith(GrpcExceptionHandler.default))
-      case _ =>
-        None
-    })
+    import Path._
+
+    val prefixPath: Path = {
+      val unslashed: Path = Path(prefix)
+      // Add slash automatically in the same way as Akka HTTP's `path` routing directive does.
+      unslashed match {
+        case p: Slash => p
+        case p => Slash(p)
+      }
+    }
+
+    def handlePath(req: HttpRequest): Option[Future[HttpResponse]] = {
+      @@tailrec
+      def handleRec(prefix0: Path, path0: Path): Option[Future[HttpResponse]] = (prefix0, path0) match {
+        case (Slash(prefix1), Slash(path1)) =>
+          println(s"$prefix0 is a prefix of $path0 - scanning subpath")
+          handleRec(prefix1, path1)
+        case (Segment(prefixSegment, prefix1), Segment(pathSegment, path1)) if prefixSegment == pathSegment =>
+          println(s"$prefix0 is a prefix of $path0 - scanning subpath")
+          handleRec(prefix1, path1)
+        case (_: SlashOrEmpty, Slash(Segment(method, Empty))) =>
+          println(s"$prefix0 is a prefix of $path0 - returning handler for $method")
+          Some(handle(req, method).recoverWith(GrpcExceptionHandler.default))
+        case _ =>
+          println(s"$prefix0 is NOT a prefix of $path0")
+          None
+      }
+      handleRec(prefixPath, req.uri.path)
+    }
+
+    Function.unlift(handlePath)
   }
 }

--- a/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayRouterSpec.scala
+++ b/play-interop-test-scala/src/test/scala/akka/grpc/gen/PlayRouterSpec.scala
@@ -54,7 +54,7 @@ class PlayRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with 
     }
 
     "allow specifying a different prefix" in {
-      val router = new GreeterServiceRouter(new GreeterServiceImpl()).withPrefix("otherPrefix")
+      val router = new GreeterServiceRouter(new GreeterServiceImpl()).withPrefix("/otherPrefix")
 
       val uri = Uri(s"http://localhost/otherPrefix/SayHello")
       router.routes.isDefinedAt(playRequestFor(uri)) shouldBe true
@@ -79,7 +79,7 @@ class PlayRouterSpec extends WordSpec with Matchers with BeforeAndAfterAll with 
     def playRequestFor(uri: Uri) = RequestFactory.plain.createRequest(
       RemoteConnection(uri.authority.host.address, secure = false, clientCertificateChain = None),
       "GET",
-      RequestTarget(uri.toString, uri.path.toString.tail, queryString = Map.empty),
+      RequestTarget(uri.toString, uri.path.toString, queryString = Map.empty),
       version = "42",
       Headers(),
       attrs = TypedMap.empty,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val akkaHttp = "10.1.3"
     val akkaDiscovery = "0.15.0"
 
-    val play = "2.7.0-M1"
+    val play = "2.7.0-M1" // FIXME: Update to M2
 
     val scalapb = "0.7.1"
     val grpc = "1.13.1"
@@ -18,6 +18,7 @@ object Dependencies {
     val sslConfig = "0.2.4"
 
     val scalaTest = "3.0.4"
+    val scalaTestPlusPlay = "4.0.0-M1" // FIXME: Update to M2 when we update Play to M2
     val scalaJava8Compat = "0.8.0"
 
     val maven = "3.5.3"
@@ -61,6 +62,8 @@ object Dependencies {
     val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest % "test" // ApacheV2
     val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % Versions.scalaJava8Compat % "test" // BSD 3-clause
     val junit = "junit" % "junit" % "4.12" % "test" // Common Public License 1.0
+    val play = "com.typesafe.play" %% "play-test" % Versions.play // Apache M2
+    val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % Versions.scalaTestPlusPlay % "test"
   }
 
   object Plugins {
@@ -126,5 +129,7 @@ object Dependencies {
     Compile.play,
     Compile.playGuice,
     Compile.playAkkaHttpServer,
+    Test.play,
+    Test.scalaTestPlusPlay
   ) ++ testing.map(_.withConfigurations(Some("compile")))
 }


### PR DESCRIPTION
I started writing some Play tests in order to test SSL but I ran into some problems with the way we're generating Play routers at the moment. The main issue was the lack of a slash for the router's prefix, but that led to a few other changes.

1. Change the generated router to default to "/" + the gRPC service name instead of just the gRPC service name. Play routers need to have a prefix starting with slash to work properly. Usually a router defaults to an empty "/" prefix, but I think we can let this slide so that users can include gRPC routers without needing to give a prefix, i.e.

    ```
    # No need to give the service name in the routes file if the router knows its own prefix
    -> / my.grpc.Router
    ```

2. Change the withPrefix method to properly prepend the new prefix to the existing prefix. While it's not recommended to change the prefix to be anything other than the gRPC service name, if we are going to support the `withPrefix` method we should do it consistently with other parts of Play.  **STILL TO DO**

3. Change the generated handler partial method to support full path instead of a prefix of just a single path segment. This is needed because of change 2.

These changes will make the router behave more like normal Play routers with the exception of point 1. The reason for point 1, as mentioned before, is to make it easier to include gRPC routers inside other routers. It saves the user typing out the prefix.

Thoughts or comments?