### PR TITLE
Upgrade to sbt 1.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,8 +90,8 @@ lazy val sbtPlugin = Project(
   )
   .settings(commonSettings)
   .settings(Dependencies.sbtPlugin)
+  .enablePlugins(SbtPlugin)
   .settings(
-    Keys.sbtPlugin := true,
     publishMavenStyle := false,
     bintrayPackage := "sbt-akka-grpc",
     bintrayRepository := "sbt-plugin-releases",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.1


### PR DESCRIPTION
My IntelliJ EAP / Scala Plugin nightly usage wants to (try to) use sbt 1.2.1 to import the build, which doesn't work because of the breaking change in sbt 1.2.0 of making ScriptedPlugin no longer auto-trigger.

So let's upgrade, with the necessary breakage fixes.