### PR TITLE
Drop unnecessary Akka HTTP core dependency declaration

### DIFF
--- a/benchmark-java/project/build.properties
+++ b/benchmark-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.1

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,6 @@ object Dependencies {
   )
 
   val playTestkit = l ++= Seq(
-    Compile.akkaHttpCore,
     Compile.play
   ) ++ (Seq(
     Compile.play,
@@ -150,7 +149,6 @@ object Dependencies {
   ) ++ testing
 
   val playInteropTestScala = l ++= Seq(
-    Compile.akkaHttpCore,
     // TODO #193
     Compile.grpcStub,
     Compile.play,
@@ -161,7 +159,6 @@ object Dependencies {
   ) ++ testing
 
   val playInteropTestJava = l ++= Seq(
-    Compile.akkaHttpCore,
     // TODO #193
     Compile.grpcStub,
     Compile.play,


### PR DESCRIPTION
These were only there to force the version:

c2c0e491f1da52a303ec063012d0e9016618adbe
40af58218270a9ead94cc8c8d4c23903168435f4