### PR TITLE
Removes unused settings

### DIFF
--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -22,7 +22,6 @@ akka.grpc.client."*" {
 
   deadline = infinite
   override-authority = ""
-  trusted-ca-certificate = ""
   user-agent = ""
   # Pulls default configuration from ssl-config-core's reference.conf
   ssl-config = ${ssl-config}


### PR DESCRIPTION
This seems like a leftover from previous implementations (SSL trust is now altered via SSLContext injection).