### PR TITLE
Factory method to use default service discovery in the actor system.

### DIFF
--- a/docs/src/main/paradox/client/configuration.md
+++ b/docs/src/main/paradox/client/configuration.md
@@ -65,7 +65,7 @@ Scala
 Java
 :  @@snip [GrpcClientSettingsCompileOnly](/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #sd-settings }
 
-Alternatively if a `SimpleServiceDiscovery` is available else where in your system is can be passed in:
+Alternatively if a `SimpleServiceDiscovery` instance is available elsewhere in your system it can be passed in:
 
 Scala
 :  @@snip [GrpcClientSettingsCompileOnly](/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala) { #provide-sd }

--- a/docs/src/main/paradox/client/details.md
+++ b/docs/src/main/paradox/client/details.md
@@ -8,7 +8,7 @@ avoid leaking in the latter case, you should call `.close()` on the client.
 
 When the connection breaks, the client will start failing requests and try reconnecting
 to the server automatically.  If a connection can not be established after the configured number of attempts then
-the client closes its self. When this happens the @scala[`Future`]@java[`CompletionStage`] 
+the client closes itself. When this happens the @scala[`Future`]@java[`CompletionStage`] 
 returned by `closed()` will complete with a failure. You do not need to call `close()` in
 this case. The default number of reconnection attempts is infinite.
 
@@ -28,7 +28,7 @@ Java
 
 
 To use the client use `withClient`. The actual client isn't exposed as it should not be stored
-any where as it can be replaced when a failure happens.
+anywhere as it can be replaced when a failure happens.
 
 Scala
 :  @@snip [RestartingGreeterClient.scala](/plugin-tester-scala/src/main/scala/example/myapp/helloworld/RestartingGreeterClient.scala) { #usage }

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -5,7 +5,10 @@
 package jdocs.akka.grpc.client;
 
 import akka.actor.ActorSystem;
+import akka.discovery.ServiceDiscovery$;
+import akka.discovery.SimpleServiceDiscovery;
 import akka.grpc.GrpcClientSettings;
+import scala.Some;
 
 import java.time.Duration;
 
@@ -23,12 +26,13 @@ public class GrpcClientSettingsCompileOnly {
                 .withTls(false);
         //#simple-programmatic
 
+        SimpleServiceDiscovery serviceDiscovery= ServiceDiscovery$.MODULE$.apply(actorSystem).discovery();
+
         //#provide-sd
         // An ActorSystem's default service discovery mechanism
-        GrpcClientSettings.discoverService(
+        GrpcClientSettings.connectTo(
                 "my-service",
-                443,
-                "config", // config based service discovery must be defined in the ActorSystems' config
+                serviceDiscovery,
                 actorSystem
         );
         //#provide-sd

--- a/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
+++ b/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java
@@ -5,6 +5,7 @@
 package jdocs.akka.grpc.client;
 
 import akka.actor.ActorSystem;
+import akka.discovery.ServiceDiscovery;
 import akka.discovery.ServiceDiscovery$;
 import akka.discovery.SimpleServiceDiscovery;
 import akka.grpc.GrpcClientSettings;
@@ -26,15 +27,13 @@ public class GrpcClientSettingsCompileOnly {
                 .withTls(false);
         //#simple-programmatic
 
-        SimpleServiceDiscovery serviceDiscovery= ServiceDiscovery$.MODULE$.apply(actorSystem).discovery();
+        SimpleServiceDiscovery serviceDiscovery = ServiceDiscovery.get(actorSystem).discovery();
 
         //#provide-sd
         // An ActorSystem's default service discovery mechanism
-        GrpcClientSettings.connectTo(
-                "my-service",
-                serviceDiscovery,
-                actorSystem
-        );
+        GrpcClientSettings
+                .usingServiceDiscovery("my-service", actorSystem)
+                .withServicePortName("https"); // (optional) refine the lookup operation to only https ports
         //#provide-sd
 
         //#sd-settings

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -23,11 +23,12 @@ object GrpcClientSettingsCompileOnly {
     .withTls(false)
   //#simple-programmatic
 
+  val serviceDiscovery: SimpleServiceDiscovery = ServiceDiscovery(actorSystem).discovery
+
   //#provide-sd
   // An ActorSystem's default service discovery mechanism
-  GrpcClientSettings.discoverService(
+  GrpcClientSettings.connectTo(
     serviceName = "my-service",
-    defaultPort = 443,
-    serviceDiscoveryMechanism = "config")
+    serviceDiscovery)
   //#provide-sd
 }

--- a/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
+++ b/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala
@@ -23,12 +23,12 @@ object GrpcClientSettingsCompileOnly {
     .withTls(false)
   //#simple-programmatic
 
-  val serviceDiscovery: SimpleServiceDiscovery = ServiceDiscovery(actorSystem).discovery
+  val serviceDiscovery: SimpleServiceDiscovery = ServiceDiscovery.get(actorSystem).discovery
 
   //#provide-sd
   // An ActorSystem's default service discovery mechanism
-  GrpcClientSettings.connectTo(
-    serviceName = "my-service",
-    serviceDiscovery)
+  GrpcClientSettings
+    .usingServiceDiscovery(serviceName = "my-service")
+    .withServicePortName("https") // (optional) refine the lookup operation to only https ports
   //#provide-sd
 }


### PR DESCRIPTION
Fixes #399

Required by https://github.com/lagom/akka-grpc-lagom-quickstart-scala/pull/7