### PR TITLE
Add support to Scala binary version propagation from the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val codegen = Project(
   .settings(commonSettings)
   .settings(Seq(
     buildInfoKeys ++= BuildInfoKey.ofN(organization, name, version, scalaVersion, sbtVersion),
-    buildInfoKeys += "runtimeArtifactName" -> s"${akkaGrpcRuntimeName}_${scalaBinaryVersion.value}",
+    buildInfoKeys += "runtimeArtifactName" -> akkaGrpcRuntimeName,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
     buildInfoPackage := "akka.grpc.gen",
     artifact in (Compile, assembly) := {

--- a/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
@@ -12,15 +12,21 @@ import protocbridge.Artifact
  * Code generator trait that is not directly bound to scala-pb or protoc (other than the types).
  */
 trait CodeGenerator {
+  import CodeGenerator._
 
   /** Generator name; example: `akka-grpc-scala` */
   def name: String
 
   def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse
 
-  /** Takes Scala binary version (ex.: "2.12") and returns suggested dependency Seq **/
-  def suggestedDependencies: String => Seq[Artifact]
+  /** Takes Scala binary version and returns suggested dependency Seq **/
+  def suggestedDependencies: ScalaBinaryVersion => Seq[Artifact]
 
   final def run(request: Array[Byte], logger: Logger): Array[Byte] =
     run(CodeGeneratorRequest.parseFrom(request), logger: Logger).toByteArray
+}
+
+object CodeGenerator {
+  /** Holds the prefix of a given Scala binary version **/
+  case class ScalaBinaryVersion(prefix: String)
 }

--- a/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
@@ -18,7 +18,8 @@ trait CodeGenerator {
 
   def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse
 
-  def suggestedDependencies: Seq[Artifact]
+  /** Takes Scala binary version (ex.: "2.12") and returns suggested dependency Seq **/
+  def suggestedDependencies: String => Seq[Artifact]
 
   final def run(request: Array[Byte], logger: Logger): Array[Byte] =
     run(CodeGeneratorRequest.parseFrom(request), logger: Logger).toByteArray

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
@@ -24,8 +24,8 @@ trait JavaClientCodeGenerator extends JavaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName, BuildInfo.version),
+  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version),
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
     Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion))
 }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.javadsl
 
-import akka.grpc.gen.{ BuildInfo, Logger }
+import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
 import templates.JavaClient.txt.Client
@@ -24,8 +24,8 @@ trait JavaClientCodeGenerator extends JavaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version),
+  override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix, BuildInfo.version),
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
     Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion))
 }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
@@ -4,9 +4,9 @@
 
 package akka.grpc.gen.javadsl
 
-import akka.grpc.gen.{BuildInfo, CodeGenerator, Logger}
+import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.Descriptors._
-import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
+import com.google.protobuf.compiler.PluginProtos.{ CodeGeneratorRequest, CodeGeneratorResponse }
 import protocbridge.Artifact
 import templates.JavaCommon.txt.ApiInterface
 
@@ -39,7 +39,6 @@ abstract class JavaCodeGenerator extends CodeGenerator {
       serviceDesc ← fileDesc.getServices.asScala
     } yield Service(fileDesc, serviceDesc)).toVector
 
-
     for {
       service <- services
       generator ← perServiceContent
@@ -60,9 +59,8 @@ abstract class JavaCodeGenerator extends CodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName, BuildInfo.version),
-  )
+  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
 }
 
 object JavaCodeGenerator {

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
@@ -59,8 +59,8 @@ abstract class JavaCodeGenerator extends CodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
+  override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix, BuildInfo.version))
 }
 
 object JavaCodeGenerator {

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaServerCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.javadsl
 
-import akka.grpc.gen.{BuildInfo, Logger}
+import akka.grpc.gen.{ BuildInfo, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
 import templates.JavaServer.txt.Handler
@@ -24,9 +24,8 @@ trait JavaServerCodeGenerator extends JavaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName, BuildInfo.version),
-  )
+  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
 }
 
 object JavaServerCodeGenerator extends JavaServerCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaServerCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.javadsl
 
-import akka.grpc.gen.{ BuildInfo, Logger }
+import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
 import templates.JavaServer.txt.Handler
@@ -24,8 +24,8 @@ trait JavaServerCodeGenerator extends JavaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = (scalaBinaryVersion: String) => Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
+  override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix, BuildInfo.version))
 }
 
 object JavaServerCodeGenerator extends JavaServerCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
@@ -5,14 +5,15 @@
 package akka.grpc.gen.javadsl
 
 import akka.grpc.gen._
-import com.google.protobuf.Descriptors.{Descriptor, MethodDescriptor}
+import com.google.protobuf.Descriptors.{ Descriptor, MethodDescriptor }
 
-final case class Method(name: String,
-                  grpcName: String,
-                  inputType: Descriptor,
-                  inputStreaming: Boolean,
-                  outputType: Descriptor,
-                  outputStreaming: Boolean) {
+final case class Method(
+  name: String,
+  grpcName: String,
+  inputType: Descriptor,
+  inputStreaming: Boolean,
+  outputType: Descriptor,
+  outputStreaming: Boolean) {
   import Method._
 
   def deserializer = Serializer(inputType)
@@ -32,9 +33,9 @@ final case class Method(name: String,
   val methodType: MethodType = {
     (inputStreaming, outputStreaming) match {
       case (false, false) => Unary
-      case (true, false)  => ClientStreaming
-      case (false, true)  => ServerStreaming
-      case (true, true)   => BidiStreaming
+      case (true, false) => ClientStreaming
+      case (false, true) => ServerStreaming
+      case (true, true) => BidiStreaming
     }
   }
 
@@ -47,7 +48,6 @@ final case class Method(name: String,
     else s"CompletionStage<${getMessageType(outputType)}>"
 }
 
-
 object Method {
   def apply(descriptor: MethodDescriptor): Method = {
     Method(
@@ -56,8 +56,7 @@ object Method {
       descriptor.getInputType,
       descriptor.toProto.getClientStreaming,
       descriptor.getOutputType,
-      descriptor.toProto.getServerStreaming,
-    )
+      descriptor.toProto.getServerStreaming)
   }
 
   private def methodName(name: String) =

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -4,16 +4,17 @@
 
 package akka.grpc.gen.scaladsl
 
-import com.google.protobuf.Descriptors.{Descriptor, MethodDescriptor}
+import com.google.protobuf.Descriptors.{ Descriptor, MethodDescriptor }
 import akka.grpc.gen._
 import scalapb.compiler.DescriptorPimps
 
-case class Method(name: String,
-                  grpcName: String,
-                  inputType: Descriptor,
-                  inputStreaming: Boolean,
-                  outputType: Descriptor,
-                  outputStreaming: Boolean)(implicit ops: DescriptorPimps) {
+case class Method(
+  name: String,
+  grpcName: String,
+  inputType: Descriptor,
+  inputStreaming: Boolean,
+  outputType: Descriptor,
+  outputStreaming: Boolean)(implicit ops: DescriptorPimps) {
   import Method._
 
   def deserializer = Serializer(inputType)
@@ -41,13 +42,12 @@ case class Method(name: String,
   val methodType: MethodType = {
     (inputStreaming, outputStreaming) match {
       case (false, false) => Unary
-      case (true, false)  => ClientStreaming
-      case (false, true)  => ServerStreaming
-      case (true, true)   => BidiStreaming
+      case (true, false) => ClientStreaming
+      case (false, true) => ServerStreaming
+      case (true, true) => BidiStreaming
     }
   }
 }
-
 
 object Method {
   def apply(descriptor: MethodDescriptor)(implicit ops: DescriptorPimps): Method = {
@@ -57,8 +57,7 @@ object Method {
       descriptor.getInputType,
       descriptor.toProto.getClientStreaming,
       descriptor.getOutputType,
-      descriptor.toProto.getServerStreaming,
-    )
+      descriptor.toProto.getServerStreaming)
   }
 
   private def methodName(name: String) =
@@ -68,7 +67,6 @@ object Method {
     import ops._
     messageType.scalaTypeName
   }
-
 
   private def outerClass(t: Descriptor) = {
     if (t.getFile.toProto.getOptions.getJavaMultipleFiles) ""

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
@@ -23,9 +23,9 @@ trait ScalaClientCodeGenerator extends ScalaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies =
+  override val suggestedDependencies = (scalaBinaryVersion: String) =>
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
-    Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion) +: super.suggestedDependencies
+    Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 }
 
 object ScalaClientCodeGenerator extends ScalaClientCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
-import akka.grpc.gen.Logger
+import akka.grpc.gen.{ CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import scalapb.compiler.GeneratorParams
 import protocbridge.Artifact
@@ -23,7 +23,7 @@ trait ScalaClientCodeGenerator extends ScalaCodeGenerator {
     b.build
   }
 
-  override val suggestedDependencies = (scalaBinaryVersion: String) =>
+  override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) =>
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
     Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -21,7 +21,8 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
   def staticContent(logger: Logger): Set[CodeGeneratorResponse.File] = Set.empty
   def staticContent(logger: Logger, allServices: Seq[Service]): Set[CodeGeneratorResponse.File] = Set.empty
 
-  override def suggestedDependencies = Seq(Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName, BuildInfo.version))
+  override def suggestedDependencies = (scalaBinaryVersion: String) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
 
   // generate services code here, the data types we want to leave to scalapb
   override def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse = {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -21,8 +21,8 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
   def staticContent(logger: Logger): Set[CodeGeneratorResponse.File] = Set.empty
   def staticContent(logger: Logger, allServices: Seq[Service]): Set[CodeGeneratorResponse.File] = Set.empty
 
-  override def suggestedDependencies = (scalaBinaryVersion: String) => Seq(
-    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion, BuildInfo.version))
+  override def suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(
+    Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix, BuildInfo.version))
 
   // generate services code here, the data types we want to leave to scalapb
   override def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse = {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
-import akka.grpc.gen.{ BuildInfo, Logger }
+import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
 import templates.ScalaCommon.txt._
@@ -18,8 +18,8 @@ trait ScalaMarshallersCodeGenerator extends ScalaCodeGenerator {
 
   override def perServiceContent = Set(generateMarshalling)
 
-  override def suggestedDependencies = (scalaBinaryVersion: String) =>
-    Artifact("com.typesafe.akka", s"akka-http_$scalaBinaryVersion", BuildInfo.akkaHttpVersion) +: super.suggestedDependencies(scalaBinaryVersion)
+  override def suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) =>
+    Artifact("com.typesafe.akka", s"akka-http_${scalaBinaryVersion.prefix}", BuildInfo.akkaHttpVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 
   def generateMarshalling(logger: Logger, service: Service): CodeGeneratorResponse.File = {
     val b = CodeGeneratorResponse.File.newBuilder()

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
@@ -18,9 +18,8 @@ trait ScalaMarshallersCodeGenerator extends ScalaCodeGenerator {
 
   override def perServiceContent = Set(generateMarshalling)
 
-  override def suggestedDependencies: Seq[Artifact] =
-    // FIXME Scala version missing in artifact name here
-    Artifact("com.typesafe.akka", "akka-http", BuildInfo.akkaHttpVersion) +: super.suggestedDependencies
+  override def suggestedDependencies = (scalaBinaryVersion: String) =>
+    Artifact("com.typesafe.akka", s"akka-http_$scalaBinaryVersion", BuildInfo.akkaHttpVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 
   def generateMarshalling(logger: Logger, service: Service): CodeGeneratorResponse.File = {
     val b = CodeGeneratorResponse.File.newBuilder()

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -206,7 +206,8 @@ class GenerateMojo @Inject() (project: MavenProject, buildContext: BuildContext)
       def warn(text: String): Unit = getLog.warn(text)
       def error(text: String): Unit = getLog.error(text)
     }
-    val adapted = new ProtocBridgeCodeGenerator(generator, logger)
+    // scala binary version is not used from here, as gradle protoc plugin does not use suggested dependencies
+    val adapted = new ProtocBridgeCodeGenerator(generator, CodeGenerator.ScalaBinaryVersion("2.12"), logger)
     val jvmGenerator = JvmGenerator(generator.name, adapted)
     (jvmGenerator, settings) -> targetPath
   }

--- a/maven-plugin/src/main/scala/akka/grpc/maven/ProtocBridgeCodeGenerator.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/ProtocBridgeCodeGenerator.scala
@@ -10,8 +10,8 @@ import protocbridge.Artifact
 /**
  * Adapts existing [[akka.grpc.gen.CodeGenerator]] into the protocbridge required type
  */
-class ProtocBridgeCodeGenerator(impl: akka.grpc.gen.CodeGenerator, logger: Logger) extends protocbridge.ProtocCodeGenerator {
+class ProtocBridgeCodeGenerator(impl: akka.grpc.gen.CodeGenerator, scalaBinaryVersion: akka.grpc.gen.CodeGenerator.ScalaBinaryVersion, logger: Logger) extends protocbridge.ProtocCodeGenerator {
   override def run(request: Array[Byte]): Array[Byte] = impl.run(request, logger)
-  override def suggestedDependencies: Seq[Artifact] = impl.suggestedDependencies
+  override def suggestedDependencies: Seq[Artifact] = impl.suggestedDependencies(scalaBinaryVersion)
   override def toString = s"ProtocBridgeSbtPluginCodeGenerator(${impl.name}: $impl)"
 }

--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -53,7 +53,8 @@ object ReflectiveCodeGen extends AutoPlugin {
         extraGenerators.value,
         sourceManaged.value,
         codeGeneratorSettings.value,
-        PB.targets.value.asInstanceOf[ListBuffer[Target]]
+        PB.targets.value.asInstanceOf[ListBuffer[Target]],
+        scalaBinaryVersion.value,
       ),
       PB.recompile ~= (_ => true),
       PB.protoSources in Compile := Seq(PB.externalIncludePath.value, sourceDirectory.value / "proto")
@@ -77,6 +78,7 @@ object ReflectiveCodeGen extends AutoPlugin {
       targetPath: File,
       generatorSettings: Seq[String],
       targets: ListBuffer[Target],
+      scalaBinaryVersion: String
   ): Unit = {
     val languages = languages0 mkString ", "
     val sources = sources0 mkString ", "
@@ -96,16 +98,18 @@ object ReflectiveCodeGen extends AutoPlugin {
           |import AkkaGrpc._
           |import akka.grpc.gen.scaladsl._
           |import akka.grpc.gen.javadsl._
+          |import akka.grpc.gen.CodeGenerator.ScalaBinaryVersion
           |
           |val languages: Seq[AkkaGrpc.Language] = Seq($languages)
           |val sources: Seq[AkkaGrpc.GeneratedSource] = Seq($sources)
+          |val scalaBinaryVersion = ScalaBinaryVersion("$scalaBinaryVersion")
           |
           |val logger = akka.grpc.gen.StdoutLogger
           |
           |(targetPath: java.io.File, settings: Seq[String]) => {
           |  val generators =
-          |    AkkaGrpcPlugin.generatorsFor(sources, languages, logger) ++
-          |    Seq($extraGenerators).map(gen => AkkaGrpcPlugin.toGenerator(gen, akka.grpc.gen.StdoutLogger))
+          |    AkkaGrpcPlugin.generatorsFor(sources, languages, scalaBinaryVersion, logger) ++
+          |    Seq($extraGenerators).map(gen => AkkaGrpcPlugin.toGenerator(gen, scalaBinaryVersion, akka.grpc.gen.StdoutLogger))
           |  AkkaGrpcPlugin.targetsFor(targetPath, settings, generators)
           |}
         """.stripMargin

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaGrpcClientFactory.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaGrpcClientFactory.scala
@@ -12,15 +12,13 @@ import akka.grpc.scaladsl.AkkaGrpcClient
 import akka.stream.Materializer
 
 object AkkaGrpcClientFactory {
-  def create[T <: AkkaGrpcClient : ClassTag](settings: GrpcClientSettings)
-      (implicit mat: Materializer, ex: ExecutionContext): T = {
+  def create[T <: AkkaGrpcClient: ClassTag](settings: GrpcClientSettings)(implicit mat: Materializer, ex: ExecutionContext): T = {
     classTag[T].runtimeClass.asInstanceOf[Class[T]]
-        .getConstructor(
-          classOf[GrpcClientSettings],
-          classOf[Materializer],
-          classOf[ExecutionContext],
-        )
-        .newInstance(settings, mat, ex)
+      .getConstructor(
+        classOf[GrpcClientSettings],
+        classOf[Materializer],
+        classOf[ExecutionContext])
+      .newInstance(settings, mat, ex)
   }
 
   /**
@@ -33,8 +31,9 @@ object AkkaGrpcClientFactory {
   }
 
   /** Bind configuration to a [[AkkaGrpcClientFactory]], creating a [[Configured]]. */
-  def configure[T <: AkkaGrpcClient : ClassTag](
-      clientSettings: GrpcClientSettings,
-  )(implicit mat: Materializer, ec: ExecutionContext): Configured[T] =
-    () => AkkaGrpcClientFactory.create[T](clientSettings)
+  def configure[T <: AkkaGrpcClient: ClassTag](
+    clientSettings: GrpcClientSettings)(implicit mat: Materializer, ec: ExecutionContext): Configured[T] =
+    new Configured[T] {
+      def create() = AkkaGrpcClientFactory.create[T](clientSettings)
+    }
 }

--- a/runtime/src/main/scala/akka/grpc/internal/ChannelUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ChannelUtils.scala
@@ -60,14 +60,16 @@ object ChannelUtils {
         if (currentState == ConnectivityState.SHUTDOWN) {
           done.trySuccess(Done)
         } else {
-          channel.notifyWhenStateChanged(currentState, () => {
-            if (currentState == ConnectivityState.TRANSIENT_FAILURE) {
-              monitor(currentState, connectionAttempts + 1)
-            } else if (currentState == ConnectivityState.READY) {
-              monitor(currentState, 0)
-            } else {
-              // IDLE / CONNECTING / SHUTDOWN
-              monitor(currentState, connectionAttempts)
+          channel.notifyWhenStateChanged(currentState, new Runnable {
+            def run() = {
+              if (currentState == ConnectivityState.TRANSIENT_FAILURE) {
+                monitor(currentState, connectionAttempts + 1)
+              } else if (currentState == ConnectivityState.READY) {
+                monitor(currentState, 0)
+              } else {
+                // IDLE / CONNECTING / SHUTDOWN
+                monitor(currentState, connectionAttempts)
+              }
             }
           })
         }

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
@@ -7,9 +7,9 @@ package akka.grpc.internal
 import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.grpc.scaladsl.headers
-import akka.grpc.{Codec, Grpc, GrpcServiceException, ProtobufSerializer}
+import akka.grpc.{ Codec, Grpc, GrpcServiceException, ProtobufSerializer }
 import akka.http.scaladsl.model.HttpEntity.LastChunk
-import akka.http.scaladsl.model.{HttpEntity, HttpHeader, HttpResponse}
+import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpResponse }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import io.grpc.Status
@@ -53,8 +53,7 @@ object GrpcResponseHelpers {
 
     HttpResponse(
       headers = immutable.Seq(headers.`Message-Encoding`(codec.name)),
-      entity = HttpEntity.Chunked(Grpc.contentType, outChunks),
-    )
+      entity = HttpEntity.Chunked(Grpc.contentType, outChunks))
   }
 
   def status(status: Status): HttpResponse =

--- a/runtime/src/main/scala/akka/grpc/internal/RequestBuilderImpl.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/RequestBuilderImpl.scala
@@ -287,7 +287,7 @@ final class ScalaServerStreamingRequestBuilder[I, O](
       case Some(Success(c)) => invokeWithMetadata(source, c)
       case Some(Failure(t)) => Future.failed(t)
       case None => channel.flatMap(c => invokeWithMetadata(source, c))
-    }).mapMaterializedValue(_.flatten)
+    }).mapMaterializedValue(_.flatMap(identity))
   }
 
   private def invokeWithMetadata(source: I, c: Channel) = {
@@ -387,7 +387,7 @@ final class ScalaBidirectionalStreamingRequestBuilder[I, O](
       case Some(Success(c)) => invokeWithMetadata(source, c)
       case Some(Failure(t)) => Future.failed(t)
       case None => channel.flatMap(c => invokeWithMetadata(source, c))
-    }).mapMaterializedValue(_.flatten)
+    }).mapMaterializedValue(_.flatMap(identity))
   }
 
   private def invokeWithMetadata(source: Source[I, NotUsed], c: Channel) = {

--- a/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
@@ -31,13 +31,13 @@ object ServiceHandler {
       remainingHandlers match {
         case Nil => response
         case head :: tail =>
-          response.thenCompose { rsp =>
+          response.thenCompose(javaFunction { rsp =>
             if (rsp.status == StatusCodes.NOT_FOUND) {
               val nextResponse = head(req)
               cont(req, nextResponse, tail)
             } else
               response
-          }
+          })
       }
     }
 

--- a/runtime/src/main/scala/akka/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/package.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc
 
 package object javadsl {

--- a/runtime/src/main/scala/akka/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/package.scala
@@ -1,0 +1,21 @@
+package akka.grpc
+
+package object javadsl {
+  /**
+   * Helper for creating akka.japi.function.Function instances from Scala
+   * functions as Scala 2.11 does not know about SAMs.
+   */
+  def japiFunction[A, B](f: A => B): akka.japi.function.Function[A, B] =
+    new akka.japi.function.Function[A, B]() {
+      override def apply(a: A): B = f(a)
+    }
+
+  /**
+   * Helper for creating java.util.function.Function instances from Scala
+   * functions as Scala 2.11 does not know about SAMs.
+   */
+  def javaFunction[A, B](f: A => B): java.util.function.Function[A, B] =
+    new java.util.function.Function[A, B]() {
+      override def apply(a: A): B = f(a)
+    }
+}

--- a/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/GrpcClientSettingsSpec.scala
@@ -5,15 +5,15 @@
 package akka.grpc
 
 import akka.actor.ActorSystem
-import akka.discovery.{Lookup, ServiceDiscovery, SimpleServiceDiscovery}
-import akka.discovery.SimpleServiceDiscovery.{Resolved, ResolvedTarget}
+import akka.discovery.{ Lookup, ServiceDiscovery, SimpleServiceDiscovery }
+import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
 import akka.discovery.config.ConfigSimpleServiceDiscovery
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.concurrent.duration._
-import scala.collection.{immutable => im}
+import scala.collection.{ immutable => im }
 import scala.concurrent.Future
 
 class GrpcClientSettingsSpec extends WordSpec with Matchers with ScalaFutures {
@@ -197,6 +197,6 @@ class GrpcClientSettingsSpec extends WordSpec with Matchers with ScalaFutures {
 
   }
 }
-class FakeServiceDiscovery extends SimpleServiceDiscovery{
+class FakeServiceDiscovery extends SimpleServiceDiscovery {
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = ???
 }


### PR DESCRIPTION
To support other Scala version in the runtime (like 2.11 or the upcoming 2.13) the Scala binary version from the project that is using akka-grpc needs to be propagated to the akka-grpc sbt plugin and eventually to `suggestedDependencies` which is then used by the protoc sbt plugin to add additional `libraryDependencies`.

This PR adds support for that.

~WIP because Gradle and Maven plugins have not yet been updated.~ See https://github.com/akka/akka-grpc/pull/414#issuecomment-424026521

Towards #345