### PR TITLE
Upgrade scalapb to 0.8.0

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -6,14 +6,14 @@ package akka.grpc.gen.scaladsl
 
 import com.google.protobuf.Descriptors.{Descriptor, MethodDescriptor}
 import akka.grpc.gen._
-import scalapb.compiler.DescriptorPimps
+import scalapb.compiler.DescriptorImplicits
 
 case class Method(name: String,
                   grpcName: String,
                   inputType: Descriptor,
                   inputStreaming: Boolean,
                   outputType: Descriptor,
-                  outputStreaming: Boolean)(implicit ops: DescriptorPimps) {
+                  outputStreaming: Boolean)(implicit ops: DescriptorImplicits) {
   import Method._
 
   def deserializer = Serializer(inputType)
@@ -50,7 +50,7 @@ case class Method(name: String,
 
 
 object Method {
-  def apply(descriptor: MethodDescriptor)(implicit ops: DescriptorPimps): Method = {
+  def apply(descriptor: MethodDescriptor)(implicit ops: DescriptorImplicits): Method = {
     Method(
       name = methodName(descriptor.getName),
       grpcName = descriptor.getName,
@@ -64,7 +64,7 @@ object Method {
   private def methodName(name: String) =
     name.head.toLower +: name.tail
 
-  def messageType(messageType: Descriptor)(implicit ops: DescriptorPimps) = {
+  def messageType(messageType: Descriptor)(implicit ops: DescriptorImplicits) = {
     import ops._
     messageType.scalaTypeName
   }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Serializer.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Serializer.scala
@@ -5,12 +5,12 @@
 package akka.grpc.gen.scaladsl
 
 import com.google.protobuf.Descriptors.Descriptor
-import scalapb.compiler.DescriptorPimps
+import scalapb.compiler.DescriptorImplicits
 
 case class Serializer(name: String, init: String)
 
 object Serializer {
-  def apply(messageType: Descriptor)(implicit ops: DescriptorPimps): Serializer = Serializer(
+  def apply(messageType: Descriptor)(implicit ops: DescriptorImplicits): Serializer = Serializer(
     messageType.getName + "Serializer",
     s"new ScalapbProtobufSerializer(${Method.messageType(messageType)}.messageCompanion)")
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 
 import scala.collection.JavaConverters._
 import com.google.protobuf.Descriptors._
-import scalapb.compiler.{ DescriptorPimps, GeneratorParams }
+import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
 case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method]) {
   def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
@@ -17,9 +17,7 @@ case class Service(packageName: String, name: String, grpcName: String, methods:
 
 object Service {
   def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor): Service = {
-    implicit val ops = new DescriptorPimps() {
-      override def params: GeneratorParams = generatorParams
-    }
+    implicit val ops = new DescriptorImplicits(generatorParams, List(fileDesc))
     import ops._
 
     val serviceClassName = serviceDescriptor.getName

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
     val play = "2.7.0-M3"
 
-    val scalapb = "0.7.1"
+    val scalapb = "0.8.0"
     val grpc = "1.14.0"
     val config = "1.3.3"
     val sslConfig = "0.2.4"


### PR DESCRIPTION
There was one breaking change from 0.7.x: `DescriptorPimps` was renamed to `DescriptorImplicits` with a slight difference in constructor API.