### PR TITLE
Bumps ssl-config 0.3.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val scalapb = "0.8.0"
     val grpc = "1.14.0"
     val config = "1.3.3"
-    val sslConfig = "0.3.4"
+    val sslConfig = "0.3.6"
 
     val scalaTest = "3.0.5"
     val scalaTestPlusPlay = "4.0.0-M3"


### PR DESCRIPTION
`0.3.5` defaulted to `PKCS12` format for the auto-generated key stores. The `ssl-config` library doesn't support setting the trustStore password which is required in `PKCS12` format to read the trusted certificates. As a consequence generated stores could not be used as truststores.

Related to https://github.com/playframework/playframework/pull/8691 and https://github.com/lagom/lagom/pull/1619