### PR TITLE
Makes RestartingClient an AkkaGrpcClient

### DIFF
--- a/runtime/src/main/scala/akka/grpc/javadsl/AkkaGrpcClient.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/AkkaGrpcClient.scala
@@ -12,6 +12,15 @@ import akka.annotation.DoNotInherit
 /** Common trait of all generated Akka gRPC clients. Not for user extension. */
 @DoNotInherit
 trait AkkaGrpcClient {
+  /**
+   * Initiates a shutdown in which preexisting and new calls are cancelled.
+   */
   def close(): CompletionStage[Done]
+
+  /**
+   * Returns a CompletionStage that completes successfully when shutdown via close()
+   * or exceptionally if a connection can not be established or reestablished
+   * after maxConnectionAttempts.
+   */
   def closed(): CompletionStage[Done]
 }

--- a/runtime/src/main/scala/akka/grpc/scaladsl/AkkaGrpcClient.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/AkkaGrpcClient.scala
@@ -12,6 +12,15 @@ import akka.annotation.DoNotInherit
 /** Common trait of all generated Akka gRPC clients. Not for user extension. */
 @DoNotInherit
 trait AkkaGrpcClient {
+  /**
+   * Initiates a shutdown in which preexisting and new calls are cancelled.
+   */
   def close(): Future[Done]
+
+  /**
+   * Returns a Future that completes successfully when shutdown via close()
+   * or exceptionally if a connection can not be established or reestablished
+   * after maxConnectionAttempts.
+   */
   def closed(): Future[Done]
 }

--- a/runtime/src/main/scala/akka/grpc/scaladsl/RestartingClient.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/RestartingClient.scala
@@ -13,7 +13,7 @@ import akka.grpc.scaladsl.RestartingClient.ClientClosedException
 import play.libs.F.PromiseTimeoutException
 
 import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Failure
 
 object RestartingClient {
@@ -21,23 +21,23 @@ object RestartingClient {
     new RestartingClient[T](createClient)
 
   /**
-    * Thrown if a withClient call is called after
-    */
+   * Thrown if a withClient call is called after
+   */
   class ClientClosedException() extends RuntimeException("withClient called after close()")
 
 }
 
 /**
-  * Wraps a Akka gRPC  client and restarts it if a [ClientConnectionException] is thrown.
-  * All other exceptions result in closing and any calls to withClient throwing
-  * a [ClientClosedException].
-  */
+ * Wraps a Akka gRPC  client and restarts it if a [ClientConnectionException] is thrown.
+ * All other exceptions result in closing and any calls to withClient throwing
+ * a [ClientClosedException].
+ */
 
 @ApiMayChange
 final class RestartingClient[T <: AkkaGrpcClient](createClient: () => T)(implicit ec: ExecutionContext) extends AkkaGrpcClient {
 
   private val clientRef = new AtomicReference[T](create())
-  private val closeDemand : Promise[Done] = Promise[Done]()
+  private val closeDemand: Promise[Done] = Promise[Done]()
 
   def withClient[A](f: T => A): A = {
     val c = clientRef.get()
@@ -66,11 +66,11 @@ final class RestartingClient[T <: AkkaGrpcClient](createClient: () => T)(implici
     // Once there's demand, the `closed` future will redeem flatMapping with the `closed()`
     // future of the clientRef that's active at that moment.
     closeDemand.future.flatMap { _ =>
-        val c = clientRef.get()
-        if (c != null)
-          c.closed()
-        else
-          Future.successful(Done)
+      val c = clientRef.get()
+      if (c != null)
+        c.closed()
+      else
+        Future.successful(Done)
     }
   }
 

--- a/runtime/src/test/scala/akka/grpc/scaladsl/RestartingClientSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/scaladsl/RestartingClientSpec.scala
@@ -122,7 +122,9 @@ class RestartingClientSpec extends WordSpec with Matchers with ScalaFutures with
       firstClient.succeed()
       closed.isCompleted should be(false)
       restartingClient.close()
-      closed.isCompleted should be(true)
+      eventually {
+        closed.isCompleted should be(true)
+      }
     }
 
     "not catch user exceptions on creation" in {

--- a/runtime/src/test/scala/akka/grpc/scaladsl/RestartingClientSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/scaladsl/RestartingClientSpec.scala
@@ -120,6 +120,8 @@ class RestartingClientSpec extends WordSpec with Matchers with ScalaFutures with
 
       closed.isCompleted should be(false)
       firstClient.succeed()
+      closed.isCompleted should be(false)
+      restartingClient.close()
       closed.isCompleted should be(true)
     }
 


### PR DESCRIPTION
`RestartingClient[T]` already provided `def close` and only differed from `AkkaGrpcClient` in not providing `def closed`. This turns `RestartingClient[T]` into a subclass of `AkkaGrpcClient`.

Once this and #442 are merged it'll be possible to implement a `RestartingTServiceClient` using the `RestartingClient[T]` improved here and implementing the `TServiceClient` `trait` introduced in #442. 

Related to #413 