### PR TITLE
expose akka version for suggested akka-stream dep in service traits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val codegen = Project(
   .settings(Seq(
     buildInfoKeys ++= BuildInfoKey.ofN(organization, name, version, scalaVersion, sbtVersion),
     buildInfoKeys += "runtimeArtifactName" -> akkaGrpcRuntimeName,
+    buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
     buildInfoPackage := "akka.grpc.gen",
     artifact in (Compile, assembly) := {


### PR DESCRIPTION
In a multi-module environment, I am generating protobuf messages, fields & services in one `-api` module, and actual (Play server) gRPC implementation in the `-impl` one, and trying to keep dependencies to a minimum in the `-api` one.

Since generated service traits import `akka-stream` classes (for representing non-unary/streaming RPCs), I want to add it as a suggested dependency for my custom `ScalaCodeGenerator` that maps `ScalaCodeGenerator.generateServiceFile()` (in order to generate service traits only), and therefore reuse the actual version that the codegen needs instead of redefining it.