### PR TITLE
Skip publishing interop-tests, update sbt-whitesource

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,6 +131,11 @@ lazy val interopTests = Project(
   .settings(
     ReflectiveCodeGen.generatedLanguages := Seq("Scala", "Java"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
+
+    // setting 'skip in publish' would be more elegant, but we need
+    // to be able to `publishLocal` to run the interop tests as an
+    // sbt scripted test
+    whitesourceIgnore := true,
   )
   // proto files from "io.grpc" % "grpc-interop-testing" contain duplicate Empty definitions;
   // * google/protobuf/empty.proto

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.12")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.12")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 


### PR DESCRIPTION
To clean up the dependency report, refs #483 