### PR TITLE
Respect TLS command line

### DIFF
--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/Utils.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/Utils.java
@@ -194,7 +194,7 @@ public final class Utils {
           .withOverrideAuthority(TestUtils.TEST_SERVER_HOST)
           .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"));
     else
-      return settings;
+      return settings.withTls(false);
 
   }
 }


### PR DESCRIPTION
When running the AsyncClient in akka.grpc.benchmarks.qps.AsyncClient, the `--tls` flag is meant to enable TLS, but if not specified, the expected behavior is to use plaintext (insecure) channel. However, the `GrpcClientSettings` case class defaults its `useTls` boolean to true. This PR simply sets up the GrpcClientSettings case class correctly based on the command line configuration.