### PR TITLE
Bump ScalaPB to 0.8.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val codegen = Project(
     buildInfoKeys += "runtimeArtifactName" -> akkaGrpcRuntimeName,
     buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
+    buildInfoKeys += "grpcVersion" → Dependencies.Versions.grpc,
     buildInfoPackage := "akka.grpc.gen",
     artifact in (Compile, assembly) := {
       val art = (artifact in (Compile, assembly)).value

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
@@ -39,7 +39,7 @@ trait JavaClientCodeGenerator extends JavaCodeGenerator {
   override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(
     Artifact(BuildInfo.organization, BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix, BuildInfo.version),
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
-    Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion))
+    Artifact("io.grpc", "grpc-stub", BuildInfo.grpcVersion))
 }
 
 object JavaClientCodeGenerator extends JavaClientCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
-import akka.grpc.gen.{ CodeGenerator, Logger }
+import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import scalapb.compiler.GeneratorParams
 import protocbridge.Artifact
@@ -25,7 +25,7 @@ trait ScalaClientCodeGenerator extends ScalaCodeGenerator {
 
   override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) =>
     // TODO: remove grpc-stub dependency once we have a akka-http based client #193
-    Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion) +: super.suggestedDependencies(scalaBinaryVersion)
+    Artifact("io.grpc", "grpc-stub", BuildInfo.grpcVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 }
 
 object ScalaClientCodeGenerator extends ScalaClientCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -17,7 +17,7 @@ case class Service(packageName: String, name: String, grpcName: String, methods:
 
 object Service {
   def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor): Service = {
-    implicit val ops = new DescriptorImplicits(generatorParams, List(fileDesc))
+    implicit val ops = new DescriptorImplicits(generatorParams, fileDesc.getDependencies.asScala :+ fileDesc)
     import ops._
 
     val serviceClassName = serviceDescriptor.getName

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@ object Dependencies {
 
     val play = "2.7.0-RC3"
 
-    val scalapb = "0.8.0"
     val grpc = "1.16.1" // checked synced by GrpcVersionSyncCheckPlugin
     val config = "1.3.3"
     val sslConfig = "0.3.6"
@@ -31,8 +30,8 @@ object Dependencies {
     val akkaHttp2Support = "com.typesafe.akka"            %% "akka-http2-support" % Versions.akkaHttp
     val akkaDiscovery    = "com.typesafe.akka"            %% "akka-discovery"     % Versions.akka
 
-    val scalapbCompilerPlugin = "com.thesamet.scalapb" %% "compilerplugin"  % Versions.scalapb
-    val scalapbRuntime        = "com.thesamet.scalapb" %% "scalapb-runtime" % Versions.scalapb exclude("io.grpc", "grpc-netty")
+    val scalapbCompilerPlugin = "com.thesamet.scalapb" %% "compilerplugin"  % scalapb.compiler.Version.scalapbVersion
+    val scalapbRuntime        = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion exclude("io.grpc", "grpc-netty")
 
     val grpcCore           = "io.grpc" % "grpc-core"            % Versions.grpc
     val grpcStub           = "io.grpc" % "grpc-stub"            % Versions.grpc

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,8 +15,7 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 // scripted testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-// FIXME hmm, we only use it to get the "right" version of the netty thingy nowadays (in this top level project)
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.4"
 
 // #java-agent-plugin
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")


### PR DESCRIPTION
Follow-up to https://github.com/akka/akka-grpc/pull/473

ScalaPB 0.8.2 introduced [package-level options](https://scalapb.github.io/customizations.html#package-scoped-options), which means that `DescriptorImplicits` must now be initialized with an exhaustive list of file descriptors (like https://github.com/scalapb/ScalaPB/blob/v0.8.4/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala#L1852-L1858) for the generation to go through and the feature to work.

One could argue that this logic shouldn't be at the call site - I'll follow up on the ScalaPB repository, but I guess it doesn't hurt to unlock the bump with this.