### PR TITLE
add netty channel builder overrides

### DIFF
--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -5,7 +5,7 @@
 package akka.grpc
 
 import akka.actor.ActorSystem
-import akka.annotation.InternalApi
+import akka.annotation.{ ApiMayChange, InternalApi }
 import akka.discovery.{ Discovery, ServiceDiscovery }
 import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import akka.grpc.internal.HardcodedServiceDiscovery
@@ -214,8 +214,10 @@ final class GrpcClientSettings private (
     copy(connectionAttempts = Some(value))
 
   /**
-    * To override any default channel configurations used by netty. Only for power users.
-    */
+   * To override any default channel configurations used by netty. Only for power users.
+   * API may change when io.grpc:grpc-netty-shaded is replaced by io.grpc:grpc-core and Akka HTTP.
+   */
+  @ApiMayChange
   def withChannelBuilderOverrides(builderOverrides: NettyChannelBuilder => NettyChannelBuilder): GrpcClientSettings =
     copy(channelBuilderOverrides = builderOverrides)
 

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -52,6 +52,7 @@ object NettyClientUtils {
           }
 
           builder = settings.userAgent.map(builder.userAgent(_)).getOrElse(builder)
+          builder = settings.channelBuilderOverrides(builder)
 
           val channel = builder.build()
           ChannelUtils.monitorChannel(promise, channel, settings.connectionAttempts)


### PR DESCRIPTION
Power users should have control over the netty channel configurations at this can drastically improve performance.