### PR TITLE
[WIP]: Fix code generation problems for Play

### DIFF
--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -15,6 +15,8 @@ import scala.concurrent.Future;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import akka.grpc.javadsl.GrpcExceptionHandler;
+
+import akka.actor.ActorSystem;
 import akka.stream.Materializer;
 
 import akka.grpc.internal.PlayRouter;
@@ -25,15 +27,17 @@ import io.grpc.Status;
  * Abstract base class for implementing @{service.name} in Java and using as a play Router
  */
 public abstract class Abstract@{service.name}Router extends PlayRouter implements @{service.name} {
-  private final Function<Throwable, Status> eHandler;
+  private final ActorSystem actorSystem;
+  private final Function<ActorSystem, Function<Throwable, Status>> eHandler;
 
-  public Abstract@{service.name}Router(Materializer mat) {
-    this(mat, GrpcExceptionHandler.defaultMapper());
+  public Abstract@{service.name}Router(Materializer mat, ActorSystem actorSystem) {
+    this(mat, actorSystem, GrpcExceptionHandler.defaultMapper());
   }
 
-  public Abstract@{service.name}Router(Materializer mat, Function<Throwable, Status> eHandler) {
-    this.eHandler = eHandler;
+  public Abstract@{service.name}Router(Materializer mat, ActorSystem actorSystem, Function<ActorSystem, Function<Throwable, Status>> eHandler) {
     super(mat, @{service.name}.name);
+    this.eHandler = eHandler;
+    this.actorSystem = actorSystem;
   }
 
   /**
@@ -41,7 +45,7 @@ public abstract class Abstract@{service.name}Router extends PlayRouter implement
    */
   final public scala.Function1<HttpRequest, Future<HttpResponse>> createHandler(String prefix, Materializer mat) {
      return akka.grpc.internal.PlayRouterHelper.handlerFor(
-        @{service.name}HandlerFactory.create(this, prefix, mat, eHandler)
+        @{service.name}HandlerFactory.create(this, prefix, mat, eHandler, this.actorSystem)
      );
   }
 }

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -11,15 +11,19 @@ import scala.concurrent.Future
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.grpc.scaladsl.GrpcExceptionHandler.defaultMapper
+
+import akka.actor.ActorSystem
 import akka.stream.Materializer
 
 import akka.grpc.internal.PlayRouter
 
+import io.grpc.Status
+
 /**
  * Abstract base class for implementing @{service.name} and using as a play Router
  */
-abstract class Abstract@{service.name}Router(mat: Materializer, eHandler: PartialFunction[Throwable, Status] = defaultMapper) extends PlayRouter(mat, @{service.name}.name) with @{service.name} {
+abstract class Abstract@{service.name}Router(mat: Materializer, actorSystem: ActorSystem, eHandler: ActorSystem => PartialFunction[Throwable, Status] = defaultMapper) extends PlayRouter(mat, @{service.name}.name) with @{service.name} {
 
   final override def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse] =
-    @{service.name}Handler(this, serviceName, eHandler)(mat)
+    @{service.name}Handler(this, serviceName, eHandler)(mat, actorSystem)
 }


### PR DESCRIPTION
Release 0.5.0 is not generating valid code. This fixes the templates to adapt them to the recent API changes.

Fixes #523.

## Status

WIP since the code now compiles, but the tests for play-grpc fail when using a local build of akka-grpc. To reproduce, just check out https://github.com/playframework/play-grpc/pull/45 and run the tests.