### PR TITLE
Extends the docs on how to tune ScalaPB and sbt-protoc

### DIFF
--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -14,6 +14,11 @@ What language to generate stubs for is also configurable:
 
 ## Passing parameters to the generator
 
+The sbt plugin for Akka-gRPC uses ScalaPB and `sbt-protoc`. Is is possible to tune these libraries if the provided defaults
+don't suit your needs.
+
+### ScalaPB settings
+
 Passing generator parameters to the underlying ScalaPB generators can be done through `akkaGrpcCodeGeneratorSettings`
 setting, any specified options will be passed to all underlying generators that are enabled. By default this setting
 contains the `flat_package` parameter.
@@ -24,7 +29,20 @@ akkaGrpcCodeGeneratorSettings += "single_line_to_proto_string"
 
 Available parameters are listed in the [ScalaPB documentation](https://scalapb.github.io/sbt-settings.html).
 
-## Proto source directory
+### `sbt-protoc` settings
+
+To tune the [`sbt-protoc` additional options](https://github.com/thesamet/sbt-protoc#additional-options) such as the proto source directory
+you will need the following setting:
+
+
+```scala
+  .settings(
+    inConfig(Compile)(Seq(
+      excludeFilter in PB.generate := "descriptor.proto"
+    ))
+  )
+```
+The above, for example, removes `descriptor.proto` from the list of files to be processed.
 
 By default protobuf files are looked for in `src/main/protobuf` (and `src/main/proto`).
 You can configure where your .proto files are located like this:

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -32,7 +32,7 @@ Available parameters are listed in the [ScalaPB documentation](https://scalapb.g
 ### `sbt-protoc` settings
 
 To tune the [`sbt-protoc` additional options](https://github.com/thesamet/sbt-protoc#additional-options) such as the proto source directory
-you will need the following setting:
+you can configure them like this:
 
 
 ```scala

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -14,7 +14,7 @@ What language to generate stubs for is also configurable:
 
 ## Passing parameters to the generator
 
-The sbt plugin for Akka-gRPC uses ScalaPB and `sbt-protoc`. Is is possible to tune these libraries if the provided defaults
+The sbt plugin for Akka-gRPC uses ScalaPB and `sbt-protoc`. It is possible to tune these libraries if the provided defaults
 don't suit your needs.
 
 ### ScalaPB settings


### PR DESCRIPTION
Adds another example of a `sbt-protoc` setup. 