### PR TITLE
Re-add generators objects

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
@@ -9,6 +9,8 @@ import akka.grpc.gen.javadsl.{ JavaCodeGenerator, Service }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.PlayJavaServer.txt.Router
 
+object PlayJavaServerCodeGenerator extends PlayJavaServerCodeGenerator(powerApis = false)
+
 case class PlayJavaServerCodeGenerator(powerApis: Boolean = false) extends JavaCodeGenerator {
   override def name: String = "akka-grpc-play-server-java"
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaServerCodeGenerator.scala
@@ -9,6 +9,8 @@ import akka.grpc.gen.scaladsl.{ ScalaCodeGenerator, ScalaServerCodeGenerator, Se
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.PlayScala.txt._
 
+object PlayScalaServerCodeGenerator extends PlayScalaServerCodeGenerator(powerApis = false)
+
 case class PlayScalaServerCodeGenerator(powerApis: Boolean = false) extends ScalaCodeGenerator {
   override def name: String = "akka-grpc-play-server-scala"
 


### PR DESCRIPTION
Power users can create instances of the case classes with `powerApis = true`, so no need to add another object here.

This keeps things consistent with how the generators are used in `build.sbt`.