### PR TITLE
Make it easier to run tests in plaintext

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/interop/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/AkkaGrpcScalaClientTester.scala
@@ -38,6 +38,7 @@ class AkkaGrpcScalaClientTester(val settings: Settings)(implicit mat: Materializ
 
     val grpcSettings = GrpcClientSettings.connectToServiceAt(settings.serverHost, settings.serverPort)
       .withOverrideAuthority(settings.serverHostOverride)
+      .withTls(settings.useTls)
       .withSSLContext(SSLContextUtils.sslContextFromResource("/certs/ca.pem"))
     client = TestServiceClient(grpcSettings)
     clientUnimplementedService = UnimplementedServiceClient(grpcSettings)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,6 +63,10 @@ object Dependencies {
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test"
   }
 
+  object Runtime {
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % "runtime" // Eclipse 1.0
+  }
+
   object Plugins {
     val sbtProtoc = "com.thesamet" % "sbt-protoc" % "0.99.18"
   }
@@ -126,6 +130,7 @@ object Dependencies {
     Compile.akkaSlf4j,
     Compile.play,
     Compile.playAkkaHttpServer,
+    Runtime.logback,
   ) ++ testing.map(_.withConfigurations(Some("compile")))
 
   val pluginTester = l++= Seq(


### PR DESCRIPTION
Useful for viewing traffic with wireshark for diagnostics