### PR TITLE
Fix initialization order problem in Play Java router code generation

### DIFF
--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -27,26 +27,21 @@ import io.grpc.Status;
    * Abstract base class for implementing @serviceName in Java and using as a play Router
    */
   public abstract class Abstract@{serviceName}Router extends PlayRouter implements @{serviceName} {
-    private final Function<ActorSystem, Function<Throwable, Status>> eHandler;
-    private final ActorSystem system;
+    public scala.Function1<HttpRequest, Future<HttpResponse>> respond;
 
     public Abstract@{serviceName}Router(Materializer mat, ActorSystem system) {
       this(mat, system, GrpcExceptionHandler.defaultMapper());
     }
 
     public Abstract@{serviceName}Router(Materializer mat, ActorSystem system, Function<ActorSystem, Function<Throwable, Status>> eHandler) {
-      super(mat, @{service.name}.name);
-      this.eHandler = eHandler;
-      this.system = system;
+      super(@{service.name}.name);
+      this.respond = akka.grpc.internal.PlayRouterHelper.handlerFor(
+        @{serviceName}HandlerFactory.create(this, serviceName(), mat, eHandler, system)
+      );
     }
 
-    /**
-     * INTERNAL API
-     */
-    final public scala.Function1<HttpRequest, Future<HttpResponse>> createHandler(String prefix, Materializer mat) {
-       return akka.grpc.internal.PlayRouterHelper.handlerFor(
-          @{serviceName}HandlerFactory.create(this, prefix, mat, eHandler, system)
-       );
+    public scala.Function1<HttpRequest, Future<HttpResponse>> respond() {
+      return respond;
     }
   }
 }

--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -27,7 +27,7 @@ import io.grpc.Status;
    * Abstract base class for implementing @serviceName in Java and using as a play Router
    */
   public abstract class Abstract@{serviceName}Router extends PlayRouter implements @{serviceName} {
-    public scala.Function1<HttpRequest, Future<HttpResponse>> respond;
+    private final scala.Function1<HttpRequest, Future<HttpResponse>> respond;
 
     public Abstract@{serviceName}Router(Materializer mat, ActorSystem system) {
       this(mat, system, GrpcExceptionHandler.defaultMapper());
@@ -40,6 +40,9 @@ import io.grpc.Status;
       );
     }
 
+    /**
+     * INTERNAL API
+     */
     public scala.Function1<HttpRequest, Future<HttpResponse>> respond() {
       return respond;
     }

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -20,9 +20,10 @@ import io.grpc.Status
   /**
    * Abstract base class for implementing @serviceName and using as a play Router
    */
-  abstract class Abstract@{serviceName}Router(mat: Materializer, system: ActorSystem, eHandler: ActorSystem => PartialFunction[Throwable, Status] = defaultMapper) extends PlayRouter(mat, @{service.name}.name) with @{serviceName} {
+  abstract class Abstract@{serviceName}Router(mat: Materializer, system: ActorSystem, eHandler: ActorSystem => PartialFunction[Throwable, Status] = defaultMapper)
+    extends PlayRouter(@{service.name}.name)
+    with @{serviceName} {
 
-    final override def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse] =
-      @{serviceName}Handler(this, serviceName, eHandler)(mat, system)
+    override val respond = @{serviceName}Handler(this, @{service.name}.name, eHandler)(mat, system)
   }
 }

--- a/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayScala/Router.scala.txt
@@ -24,6 +24,6 @@ import io.grpc.Status
     extends PlayRouter(@{service.name}.name)
     with @{serviceName} {
 
-    override val respond = @{serviceName}Handler(this, @{service.name}.name, eHandler)(mat, system)
+    override protected val respond = @{serviceName}Handler(this, @{service.name}.name, eHandler)(mat, system)
   }
 }

--- a/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
@@ -38,19 +38,19 @@ import scala.compat.java8.OptionConverters._
  *
  * INTERNAL API
  */
-@InternalApi abstract class PlayRouter(mat: Materializer, serviceName: String) extends play.api.routing.Router {
+@InternalApi abstract class PlayRouter(val serviceName: String) extends play.api.routing.Router {
 
   private val prefix = s"/$serviceName"
 
   /**
    * INTERNAL API
+   *
+   * To be provided by (generated) concrete routers
    */
-  @InternalApi
-  protected def createHandler(serviceName: String, mat: Materializer): HttpRequest => Future[HttpResponse]
+  val respond: HttpRequest => Future[HttpResponse]
 
   private val handler = new AkkaHttpHandler {
-    val handler = createHandler(serviceName, mat)
-    override def apply(request: HttpRequest): Future[HttpResponse] = handler(request)
+    override def apply(request: HttpRequest): Future[HttpResponse] = respond(request)
   }
 
   // Scala API

--- a/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/PlayRouter.scala
@@ -45,9 +45,9 @@ import scala.compat.java8.OptionConverters._
   /**
    * INTERNAL API
    *
-   * To be provided by (generated) concrete routers
+   * To be provided by (generated) concrete routers, only called internally
    */
-  val respond: HttpRequest => Future[HttpResponse]
+  protected val respond: HttpRequest => Future[HttpResponse]
 
   private val handler = new AkkaHttpHandler {
     override def apply(request: HttpRequest): Future[HttpResponse] = respond(request)


### PR DESCRIPTION
Before, the exception handler field would be initialized in the constructor,
but the method reading the field was called from the superconstructor so saw a
null value here, leading to a null exception handler further down the road.

Fixes #396