### PR TITLE
Example of cross-cutting authentication/authorization example

### DIFF
--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterClient.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package example.myapp.helloworld
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.stream.ActorMaterializer
+import example.myapp.helloworld.grpc._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object AuthenticatedGreeterClient {
+
+  def main(args: Array[String]): Unit = {
+    // Boot akka
+    implicit val sys = ActorSystem("HelloWorldClient")
+    implicit val mat = ActorMaterializer()
+    implicit val ec = sys.dispatcher
+
+    // Take details how to connect to the service from the config.
+    val clientSettings = GrpcClientSettings.connectToServiceAt("127.0.0.1", 8082).withTls(false)
+    // Create a client-side stub for the service
+    val client: GreeterServiceClient = GreeterServiceClient(clientSettings)
+
+    val failureWhenUnauthenticated = Await.result(client.sayHello(HelloRequest("Alice")).failed, 10.seconds)
+    sys.log.warning(s"Call without authentication fails: $failureWhenUnauthenticated")
+
+    val replyWhenAuthenticated = Await.result(client.sayHello().addHeader("Token", "XYZ").invoke(HelloRequest("Alice")), 10.seconds)
+    sys.log.warning(s"Call with authentication succeeds: $replyWhenAuthenticated")
+  }
+
+}

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+//#full-server
+package example.myapp.helloworld
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.UseHttp2.Always
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.server.{ Directive0, Route, RouteResult }
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.{ Http, Http2, HttpConnectionContext }
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.typesafe.config.ConfigFactory
+import example.myapp.helloworld.grpc._
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+object AuthenticatedGreeterServer {
+
+  def main(args: Array[String]): Unit = {
+    // Important: enable HTTP/2 in ActorSystem's config
+    // We do it here programmatically, but you can also set it in the application.conf
+    val conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+      .withFallback(ConfigFactory.defaultApplication())
+    val system = ActorSystem("HelloWorld", conf)
+    new AuthenticatedGreeterServer(system).run()
+    // ActorSystem threads will keep the app alive until `system.terminate()` is called
+  }
+}
+
+class AuthenticatedGreeterServer(system: ActorSystem) {
+
+  def run(): Future[Http.ServerBinding] = {
+    // Akka boot up code
+    implicit val sys: ActorSystem = system
+    implicit val mat: Materializer = ActorMaterializer()
+    implicit val ec: ExecutionContext = sys.dispatcher
+
+    // Create service handlers
+    val handler: HttpRequest => Future[HttpResponse] =
+      GreeterServiceHandler(new GreeterServiceImpl())
+
+    // As a Route
+    val handlerRoute: Route = {
+      ctx => handler(ctx.request).map(RouteResult.Complete)
+    }
+
+    // A Route to authenticate with
+    val authenticationRoute: Route = path("login") {
+      get {
+        complete("Psst, please use token XYZ!")
+      }
+    }
+
+    // A directive to authorize calls
+    val authorizationDirective: Directive0 =
+      headerValueByName("token").flatMap { token =>
+        if (token == "XYZ") pass
+        else reject
+      }
+
+    val route = concat(
+      authenticationRoute,
+      authorizationDirective {
+        handlerRoute
+      }
+    )
+
+    // Bind service handler servers to localhost:8082
+    val binding = Http2().bindAndHandleAsync(
+      Route.asyncHandler(route),
+      interface = "127.0.0.1",
+      port = 8082,
+      connectionContext = HttpConnectionContext(http2 = Always))
+
+    // report successful binding
+    binding.foreach { binding =>
+      println(s"gRPC server bound to: ${binding.localAddress}")
+    }
+
+    binding
+  }
+}
+
+//#full-server


### PR DESCRIPTION
This is an example of a way to compose Akka gRPC with 'regular' Akka HTTP code
to achieve server-side authentication/authorization when it is a true
'cross-cutting concern': the implementation is still based on the regular API
trait (and does not need to know about the token), and is wrapped in a
Directive that performs the token verification.

This is not a complete example: documentation, a Java version and test coverage
are still missing, and authentication errors are reported as a 'normal' HTTP
400 response rather than a gRPC error code 7. Nonetheless it might be a good
starting point for further exploration.