### PR TITLE
Use fully qualified imports for Source, Done, NotUsed

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
@@ -40,12 +40,12 @@ final case class Method(
   }
 
   def getParameterType =
-    if (inputStreaming) s"Source<${getMessageType(inputType)}, NotUsed>"
+    if (inputStreaming) s"akka.stream.javadsl.Source<${getMessageType(inputType)}, akka.NotUsed>"
     else getMessageType(inputType)
 
   def getReturnType =
-    if (outputStreaming) s"Source<${getMessageType(outputType)}, NotUsed>"
-    else s"CompletionStage<${getMessageType(outputType)}>"
+    if (outputStreaming) s"akka.stream.javadsl.Source<${getMessageType(outputType)}, akka.NotUsed>"
+    else s"java.util.concurrent.CompletionStage<${getMessageType(outputType)}>"
 }
 
 object Method {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -29,15 +29,15 @@ case class Method(
     else "GrpcMarshalling.marshal"
 
   def parameterType =
-    if (inputStreaming) s"Source[${messageType(inputType)}, NotUsed]"
+    if (inputStreaming) s"akka.stream.scaladsl.Source[${messageType(inputType)}, akka.NotUsed]"
     else messageType(inputType)
 
   def inputTypeUnboxed = messageType(inputType)
   def outputTypeUnboxed = messageType(outputType)
 
   def returnType =
-    if (outputStreaming) s"Source[${messageType(outputType)}, NotUsed]"
-    else s"Future[${messageType(outputType)}]"
+    if (outputStreaming) s"akka.stream.scaladsl.Source[${messageType(outputType)}, akka.NotUsed]"
+    else s"scala.concurrent.Future[${messageType(outputType)}]"
 
   val methodType: MethodType = {
     (inputStreaming, outputStreaming) match {

--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -16,19 +16,14 @@ import akka.grpc.javadsl.StreamResponseRequestBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
-import akka.stream.Materializer;
 
-import io.grpc.*;
-import io.grpc.stub.*;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
-
 import scala.concurrent.ExecutionContext;
 import scala.compat.java8.FutureConverters;
-import scala.concurrent.Future;
-import scala.concurrent.Promise;
-
 
 public abstract class @{service.name}Client extends @{service.name}ClientPowerApi implements @{service.name}, AkkaGrpcClient {
   public static final @{service.name}Client create(GrpcClientSettings settings, Materializer mat, ExecutionContext ec) {
@@ -39,7 +34,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
 
       private final ClientState clientState;
       private final GrpcClientSettings settings;
-      private final CallOptions options;
+      private final io.grpc.CallOptions options;
       private final Materializer mat;
       private final ExecutionContext ec;
 
@@ -57,23 +52,23 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
 
   @for(method <- service.methods) {
     @if(method.methodType == akka.grpc.gen.Unary) {
-      private final SingleResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+      private final SingleResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}RequestBuilder(scala.concurrent.Future<ManagedChannel> channel){
         return new JavaUnaryRequestBuilder<>(@{method.name}Descriptor, channel, options, settings, ec);
       }
     } else {
       @defining(service.grpcName + "." + method.grpcName){ fqName =>
         @if(method.methodType == akka.grpc.gen.ClientStreaming){
-          private final SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+          private final SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(scala.concurrent.Future<ManagedChannel> channel){
             return new JavaClientStreamingRequestBuilder<>(
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, mat, ec);
           }
         } else if(method.methodType == akka.grpc.gen.ServerStreaming){
-          private final StreamResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+          private final StreamResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}RequestBuilder(scala.concurrent.Future<ManagedChannel> channel){
             return new JavaServerStreamingRequestBuilder<>(
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, ec);
           }
         } else if(method.methodType == akka.grpc.gen.BidiStreaming){
-          private final StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+          private final StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(scala.concurrent.Future<ManagedChannel> channel){
             return new JavaBidirectionalStreamingRequestBuilder<>(
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, ec);
           }

--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -7,8 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import akka.NotUsed;
-import akka.Done;
 import akka.annotation.*;
 import akka.grpc.internal.*;
 import akka.grpc.GrpcClientSettings;
@@ -18,9 +16,6 @@ import akka.grpc.javadsl.StreamResponseRequestBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
-import akka.stream.javadsl.Flow;
-import akka.stream.javadsl.Sink;
-import akka.stream.javadsl.Source;
 import akka.stream.Materializer;
 
 import io.grpc.*;
@@ -29,7 +24,6 @@ import io.grpc.stub.*;
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
 
-import java.util.concurrent.CompletionStage;
 import scala.concurrent.ExecutionContext;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
@@ -69,7 +63,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
     } else {
       @defining(service.grpcName + "." + method.grpcName){ fqName =>
         @if(method.methodType == akka.grpc.gen.ClientStreaming){
-          private final SingleResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+          private final SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
             return new JavaClientStreamingRequestBuilder<>(
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, mat, ec);
           }
@@ -79,7 +73,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, ec);
           }
         } else if(method.methodType == akka.grpc.gen.BidiStreaming){
-          private final StreamResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
+          private final StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}RequestBuilder(Future<ManagedChannel> channel){
             return new JavaBidirectionalStreamingRequestBuilder<>(
                                  @{method.name}Descriptor, "@fqName", channel, options, settings, ec);
           }
@@ -104,11 +98,11 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
         @if(method.methodType == akka.grpc.gen.Unary) {
           public SingleResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
         }else if(method.methodType == akka.grpc.gen.ClientStreaming){
-          public SingleResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}()
+          public SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
         }else if(method.methodType == akka.grpc.gen.ServerStreaming){
           public StreamResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
         }else if(method.methodType == akka.grpc.gen.BidiStreaming){
-          public StreamResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}()
+          public StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
         }
         {
           return clientState.withChannel( this::@{method.name}RequestBuilder);
@@ -129,7 +123,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
       /**
        * Initiates a shutdown in which preexisting and new calls are cancelled.
        */
-      public CompletionStage<Done> close() {
+      public java.util.concurrent.CompletionStage<akka.Done> close() {
         return clientState.closeCS() ;
       }
 
@@ -137,7 +131,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
       * Returns a CompletionState that completes successfully when shutdown via close()
       * or exceptionally if a connection can not be established after maxConnectionAttempts.
       */
-      public CompletionStage<Done> closed() {
+      public java.util.concurrent.CompletionStage<akka.Done> closed() {
         return clientState.closedCS();
       }
   }

--- a/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
@@ -7,29 +7,12 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import akka.annotation.*;
-import akka.grpc.internal.*;
-import akka.grpc.GrpcClientSettings;
-import akka.grpc.javadsl.AkkaGrpcClient;
 import akka.grpc.javadsl.SingleResponseRequestBuilder;
 import akka.grpc.javadsl.StreamResponseRequestBuilder;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
-import akka.stream.OverflowStrategy;
-import akka.stream.Materializer;
-
-import io.grpc.*;
-import io.grpc.stub.*;
 
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
-
-import scala.concurrent.ExecutionContext;
-import scala.compat.java8.FutureConverters;
-import scala.concurrent.Future;
-import scala.concurrent.Promise;
-
-public abstract class  @{service.name}ClientPowerApi {
+public abstract class @{service.name}ClientPowerApi {
   @for(method <- service.methods) {
     /**
      * Lower level "lifted" version of the method, giving access to request metadata etc.

--- a/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
@@ -7,8 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import akka.NotUsed;
-import akka.Done;
 import akka.annotation.*;
 import akka.grpc.internal.*;
 import akka.grpc.GrpcClientSettings;
@@ -18,9 +16,6 @@ import akka.grpc.javadsl.StreamResponseRequestBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
-import akka.stream.javadsl.Flow;
-import akka.stream.javadsl.Sink;
-import akka.stream.javadsl.Source;
 import akka.stream.Materializer;
 
 import io.grpc.*;
@@ -29,7 +24,6 @@ import io.grpc.stub.*;
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
 
-import java.util.concurrent.CompletionStage;
 import scala.concurrent.ExecutionContext;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
@@ -44,11 +38,11 @@ public abstract class  @{service.name}ClientPowerApi {
     @if(method.methodType == akka.grpc.gen.Unary) {
       public SingleResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
     }else if(method.methodType == akka.grpc.gen.ClientStreaming){
-      public SingleResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}()
+      public SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
     }else if(method.methodType == akka.grpc.gen.ServerStreaming){
       public StreamResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
     }else if(method.methodType == akka.grpc.gen.BidiStreaming){
-      public StreamResponseRequestBuilder<Source<@method.inputTypeUnboxed, NotUsed>, @method.outputTypeUnboxed> @{method.name}()
+      public StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
     }
     {
         throw new java.lang.UnsupportedOperationException();

--- a/codegen/src/main/twirl/templates/JavaCommon/ApiInterface.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaCommon/ApiInterface.scala.txt
@@ -7,11 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import java.util.concurrent.CompletionStage;
-
-import akka.NotUsed;
-import akka.stream.javadsl.Source;
-
 import akka.grpc.ProtobufSerializer;
 import akka.grpc.javadsl.GoogleProtobufSerializer;
 

--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -26,8 +26,6 @@ import akka.grpc.javadsl.Metadata;
 import akka.grpc.javadsl.MetadataImpl;
 import akka.grpc.javadsl.package$;
 
-import io.grpc.Status;
-
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
 @defining(if (powerApis) service.name + "PowerApi" else service.name) { serviceName =>
@@ -54,7 +52,7 @@ import static @{service.packageName}.@{service.name}.Serializers.*;
      * Use `akka.grpc.scaladsl.ServiceHandler.concatOrNotFound` with `@{service.name}Handler.partial` when combining
      * several services.
      */
-    public static Function<HttpRequest, CompletionStage<HttpResponse>> create(@serviceName implementation, Materializer mat, Function<ActorSystem, Function<Throwable, Status>> eHandler, ActorSystem system) {
+    public static Function<HttpRequest, CompletionStage<HttpResponse>> create(@serviceName implementation, Materializer mat, Function<ActorSystem, Function<Throwable, io.grpc.Status>> eHandler, ActorSystem system) {
       return create(implementation, @{service.name}.name, mat, eHandler, system);
     }
 
@@ -80,7 +78,7 @@ import static @{service.packageName}.@{service.name}.Serializers.*;
      *
      * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
      */
-    public static Function<HttpRequest, CompletionStage<HttpResponse>> create(@serviceName implementation, String prefix, Materializer mat, Function<ActorSystem, Function<Throwable, Status>> eHandler, ActorSystem system) {
+    public static Function<HttpRequest, CompletionStage<HttpResponse>> create(@serviceName implementation, String prefix, Materializer mat, Function<ActorSystem, Function<Throwable, io.grpc.Status>> eHandler, ActorSystem system) {
       return partial(implementation, prefix, mat, eHandler, system);
     }
 
@@ -100,7 +98,7 @@ import static @{service.packageName}.@{service.name}.Serializers.*;
      *
      * Use `akka.grpc.javadsl.ServiceHandler.concatOrNotFound` when combining several services.
      */
-    public static Function<HttpRequest, CompletionStage<HttpResponse>> partial(@serviceName implementation, String prefix, Materializer mat, Function<ActorSystem, Function<Throwable, Status>> eHandler, ActorSystem system) {
+    public static Function<HttpRequest, CompletionStage<HttpResponse>> partial(@serviceName implementation, String prefix, Materializer mat, Function<ActorSystem, Function<Throwable, io.grpc.Status>> eHandler, ActorSystem system) {
       return (req -> {
         Iterator<String> segments = req.getUri().pathSegments().iterator();
         if (segments.hasNext() && segments.next().equals(prefix) && segments.hasNext()) {
@@ -117,7 +115,7 @@ import static @{service.packageName}.@{service.name}.Serializers.*;
         return @{service.name}.name;
       }
 
-    private static CompletionStage<HttpResponse> handle(HttpRequest request, String method, @serviceName implementation, Materializer mat, Function<ActorSystem, Function<Throwable, Status>> eHandler, ActorSystem system) {
+    private static CompletionStage<HttpResponse> handle(HttpRequest request, String method, @serviceName implementation, Materializer mat, Function<ActorSystem, Function<Throwable, io.grpc.Status>> eHandler, ActorSystem system) {
       Codec responseCodec = Codecs.negotiate(request);
       @{if(powerApis) { "Metadata metadata = new MetadataImpl(request.getHeaders());" } else { "" }}
       switch(method) {

--- a/codegen/src/main/twirl/templates/JavaServer/PowerApiInterface.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/PowerApiInterface.scala.txt
@@ -7,11 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import java.util.concurrent.CompletionStage;
-
-import akka.NotUsed;
-import akka.stream.javadsl.Source;
-
 import akka.grpc.ProtobufSerializer;
 import akka.grpc.javadsl.GoogleProtobufSerializer;
 import akka.grpc.javadsl.Metadata;

--- a/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
+++ b/codegen/src/main/twirl/templates/PlayJavaServer/Router.scala.txt
@@ -10,7 +10,6 @@ package @service.packageName;
 import java.util.concurrent.CompletionStage;
 
 import akka.japi.Function;
-import scala.concurrent.Future;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
@@ -27,7 +26,7 @@ import io.grpc.Status;
    * Abstract base class for implementing @serviceName in Java and using as a play Router
    */
   public abstract class Abstract@{serviceName}Router extends PlayRouter implements @{serviceName} {
-    private final scala.Function1<HttpRequest, Future<HttpResponse>> respond;
+    private final scala.Function1<HttpRequest, scala.concurrent.Future<HttpResponse>> respond;
 
     public Abstract@{serviceName}Router(Materializer mat, ActorSystem system) {
       this(mat, system, GrpcExceptionHandler.defaultMapper());
@@ -43,7 +42,7 @@ import io.grpc.Status;
     /**
      * INTERNAL API
      */
-    public scala.Function1<HttpRequest, Future<HttpResponse>> respond() {
+    public scala.Function1<HttpRequest, scala.concurrent.Future<HttpResponse>> respond() {
       return respond;
     }
   }

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -7,14 +7,11 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName
 
-import akka.NotUsed
-import akka.Done
 import akka.grpc.GrpcClientSettings
 import akka.grpc.internal._
 import akka.grpc.scaladsl._
-import akka.stream.scaladsl.Source
 import akka.stream.Materializer
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ ExecutionContext, Promise }
 
 import io.grpc._
 
@@ -33,7 +30,7 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
   private val clientState = new ClientState(settings)
 
   @for(method <- service.methods) {
-    private def @{method.name}RequestBuilder(channel:Future[ManagedChannel]) = {
+    private def @{method.name}RequestBuilder(channel:scala.concurrent.Future[ManagedChannel]) = {
       @if(method.methodType == akka.grpc.gen.Unary) {
         new ScalaUnaryRequestBuilder(@{method.name}Descriptor, channel, options, settings)
       } else {
@@ -69,8 +66,8 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
       @{method.name}().invoke(in)
   }
 
-  override def close(): Future[Done] = clientState.close()
-  override def closed(): Future[Done] = clientState.closed()
+  override def close(): scala.concurrent.Future[akka.Done] = clientState.close()
+  override def closed(): scala.concurrent.Future[akka.Done] = clientState.closed()
 
 }
 

--- a/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
@@ -7,11 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName
 
-import scala.concurrent.Future
-
-import akka.NotUsed
-import akka.stream.scaladsl.Source
-
 trait @{service.name} {
   @for(method <- service.methods) {
   def @{method.name}(in: @method.parameterType): @method.returnType

--- a/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
@@ -34,6 +34,6 @@ object @{service.name}Marshallers {
   implicit def marshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[T] =
     Marshaller.opaque((response: T) ⇒ GrpcMarshalling.marshal(response)(serializer, mat, codec, system))
 
-  implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[akka.stream.scaladsl.Source[T, _root_.akka.NotUsed]] =
+  implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[akka.stream.scaladsl.Source[T, akka.NotUsed]] =
     Marshaller.opaque((response: akka.stream.scaladsl.Source[T, akka.NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec, system))
 }

--- a/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
@@ -8,11 +8,8 @@
 package @service.packageName
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
-import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
 import akka.stream.Materializer
 import akka.grpc.Codec
 import akka.grpc.ProtobufSerializer
@@ -31,12 +28,12 @@ object @{service.name}Marshallers {
   implicit def unmarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer): FromRequestUnmarshaller[T] =
     Unmarshaller((ec: ExecutionContext) ⇒ (req: HttpRequest) ⇒ GrpcMarshalling.unmarshal(req)(serializer, mat))
 
-  implicit def toSourceUnmarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer): FromRequestUnmarshaller[Source[T, NotUsed]] =
+  implicit def toSourceUnmarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer): FromRequestUnmarshaller[akka.stream.scaladsl.Source[T, akka.NotUsed]] =
     Unmarshaller((ec: ExecutionContext) ⇒ (req: HttpRequest) ⇒ GrpcMarshalling.unmarshalStream(req)(serializer, mat))
 
   implicit def marshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[T] =
     Marshaller.opaque((response: T) ⇒ GrpcMarshalling.marshal(response)(serializer, mat, codec, system))
 
-  implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[Source[T, NotUsed]] =
-    Marshaller.opaque((response: Source[T, NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec, system))
+  implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[akka.stream.scaladsl.Source[T, _root_.akka.NotUsed]] =
+    Marshaller.opaque((response: akka.stream.scaladsl.Source[T, akka.NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec, system))
 }

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -7,12 +7,10 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
-import akka.grpc.scaladsl
 import akka.grpc.scaladsl.{ GrpcExceptionHandler, GrpcMarshalling, ScalapbProtobufSerializer, Metadata, MetadataImpl }
-import akka.grpc.{Codecs, GrpcServiceException }
-import io.grpc.Status
+import akka.grpc.{ Codecs, GrpcServiceException }
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.http.scaladsl.model.Uri.Path
@@ -22,7 +20,7 @@ import akka.stream.Materializer
 
 @defining(if (powerApis) service.name + "PowerApi" else service.name) { serviceName =>
   object @{serviceName}Handler {
-    private val notFound = Future.successful(HttpResponse(StatusCodes.NotFound))
+    private val notFound = scala.concurrent.Future.successful(HttpResponse(StatusCodes.NotFound))
 
     /**
      * Creates a `HttpRequest` to `HttpResponse` handler that can be used in for example `Http().bindAndHandleAsync`
@@ -31,7 +29,7 @@ import akka.stream.Materializer
      * Use `akka.grpc.scaladsl.ServiceHandler.concatOrNotFound` with `@{service.name}Handler.partial` when combining
      * several services.
      */
-    def apply(implementation: @serviceName)(implicit mat: Materializer, system: ActorSystem): HttpRequest => Future[HttpResponse] =
+    def apply(implementation: @serviceName)(implicit mat: Materializer, system: ActorSystem): HttpRequest => scala.concurrent.Future[HttpResponse] =
       partial(implementation).orElse { case _ => notFound }
 
     /**
@@ -41,7 +39,7 @@ import akka.stream.Materializer
      * Use `akka.grpc.scaladsl.ServiceHandler.concatOrNotFound` with `@{service.name}Handler.partial` when combining
      * several services.
      */
-    def apply(implementation: @serviceName, eHandler: ActorSystem => PartialFunction[Throwable, Status])(implicit mat: Materializer, system: ActorSystem): HttpRequest => Future[HttpResponse] =
+    def apply(implementation: @serviceName, eHandler: ActorSystem => PartialFunction[Throwable, io.grpc.Status])(implicit mat: Materializer, system: ActorSystem): HttpRequest => scala.concurrent.Future[HttpResponse] =
       partial(implementation, @{service.name}.name, eHandler).orElse { case _ => notFound }
 
     /**
@@ -53,7 +51,7 @@ import akka.stream.Materializer
      *
      * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
      */
-    def apply(implementation: @serviceName, prefix: String)(implicit mat: Materializer, system: ActorSystem): HttpRequest => Future[HttpResponse] =
+    def apply(implementation: @serviceName, prefix: String)(implicit mat: Materializer, system: ActorSystem): HttpRequest => scala.concurrent.Future[HttpResponse] =
       partial(implementation, prefix).orElse { case _ => notFound }
 
     /**
@@ -65,7 +63,7 @@ import akka.stream.Materializer
      *
      * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
      */
-    def apply(implementation: @serviceName, prefix: String, eHandler: ActorSystem => PartialFunction[Throwable, Status])(implicit mat: Materializer, system: ActorSystem): HttpRequest => Future[HttpResponse] =
+    def apply(implementation: @serviceName, prefix: String, eHandler: ActorSystem => PartialFunction[Throwable, io.grpc.Status])(implicit mat: Materializer, system: ActorSystem): HttpRequest => scala.concurrent.Future[HttpResponse] =
       partial(implementation, prefix, eHandler).orElse { case _ => notFound }
 
     /**
@@ -77,11 +75,11 @@ import akka.stream.Materializer
      *
      * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
      */
-    def partial(implementation: @serviceName, prefix: String = @{service.name}.name, eHandler: ActorSystem => PartialFunction[Throwable, Status] = GrpcExceptionHandler.defaultMapper)(implicit mat: Materializer, system: ActorSystem): PartialFunction[HttpRequest, Future[HttpResponse]] = {
+    def partial(implementation: @serviceName, prefix: String = @{service.name}.name, eHandler: ActorSystem => PartialFunction[Throwable, io.grpc.Status] = GrpcExceptionHandler.defaultMapper)(implicit mat: Materializer, system: ActorSystem): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] = {
       implicit val ec: ExecutionContext = mat.executionContext
       import @{service.name}.Serializers._
 
-      def handle(request: HttpRequest, method: String): Future[HttpResponse] = method match {
+      def handle(request: HttpRequest, method: String): scala.concurrent.Future[HttpResponse] = method match {
         @for(method <- service.methods) {
         case "@method.grpcName" =>
           val responseCodec = Codecs.negotiate(request)
@@ -90,7 +88,7 @@ import akka.stream.Materializer
             .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.name}(_@{if(powerApis) { ", metadata" } else { "" }}))
             .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, mat, responseCodec, system))
         }
-        case m => Future.failed(new NotImplementedError(s"Not implemented: $m"))
+        case m => scala.concurrent.Future.failed(new NotImplementedError(s"Not implemented: $m"))
       }
 
       Function.unlift((req: HttpRequest) => req.uri.path match {

--- a/codegen/src/main/twirl/templates/ScalaServer/PowerApiTrait.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/PowerApiTrait.scala.txt
@@ -7,10 +7,6 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName
 
-import scala.concurrent.Future
-
-import akka.NotUsed
-import akka.stream.scaladsl.Source
 import akka.grpc.scaladsl.Metadata
 import akka.grpc.GrpcServiceException
 


### PR DESCRIPTION
This is a partial fix for #552, fixing uses of `Source`, `Done` and `NotUsed`. It also has some uses of `Future` and `CompletionStage` fixed.

Note although I have tried to be comprehensive, I'm not that familiar with the code, so I hope the tests exercise this well enough to ensure I haven't missed any names that need to become fully qualified.