### PR TITLE
Don't allow Java 11 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ env:
     - TRAVIS_JDK=adopt@1.8.202-08
     - TRAVIS_JDK=adopt@1.11.0-2
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: TRAVIS_JDK=adopt@1.11.0-2 # not fully supported but allows problem discovery
-
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 


### PR DESCRIPTION
The tests are passing, so let's keep it that way.