### PR TITLE
Ensure authority override is applied when TLS isn't being used

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -47,10 +47,9 @@ object NettyClientUtils {
             builder = settings.sslContext
               .map(javaCtx => builder.negotiationType(NegotiationType.TLS).sslContext(nettyHttp2SslContext(javaCtx)))
               .getOrElse(builder.negotiationType(NegotiationType.PLAINTEXT))
-
-            builder = settings.overrideAuthority.map(builder.overrideAuthority(_)).getOrElse(builder)
           }
 
+          builder = settings.overrideAuthority.map(builder.overrideAuthority(_)).getOrElse(builder)
           builder = settings.userAgent.map(builder.userAgent(_)).getOrElse(builder)
           builder = settings.channelBuilderOverrides(builder)
 


### PR DESCRIPTION
Not sure why the authority override setting was only being applied if using TLS, but it should be applied regardless of whether you're using TLS. This is necessary when speaking to reverse proxies on an IP address that don't have a hostname configured - eg, common when testing things like Istio and Knative in the cloud.