### PR TITLE
Use protoc settings for server_power_apis and use_play_actions

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/Main.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Main.scala
@@ -37,8 +37,6 @@ object Main extends App {
 
   private val generatePlay: Boolean = reqLowerCase.contains("generate_play=true")
 
-  private val serverPowerApis: Boolean = reqLowerCase.contains("server_power_apis=true")
-
   private val usePlayActions: Boolean = reqLowerCase.contains("use_play_actions=true")
 
   val LogFileRegex = """(?:.*,)logfile=([^,]+)(?:,.*)?""".r
@@ -52,29 +50,29 @@ object Main extends App {
       if (!generatePlay) {
         if (languageScala) {
           // Scala
-          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, ScalaClientCodeGenerator, ScalaServerCodeGenerator(serverPowerApis))
+          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, ScalaClientCodeGenerator, ScalaServerCodeGenerator)
           else if (generateClient) Seq(ScalaTraitCodeGenerator, ScalaClientCodeGenerator)
-          else if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator(serverPowerApis))
+          else if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator)
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         } else {
           // Java
-          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, JavaServerCodeGenerator(serverPowerApis))
+          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, JavaServerCodeGenerator)
           else if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator)
-          else if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator(serverPowerApis))
+          else if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator)
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         }
       } else {
         if (languageScala) {
           // Scala
-          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator(serverPowerApis, usePlayActions))
+          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions))
           else if (generateClient) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator)
-          else if (generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaServerCodeGenerator(serverPowerApis, usePlayActions))
+          else if (generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions))
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         } else {
           // Java
-          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator, PlayJavaServerCodeGenerator(serverPowerApis, usePlayActions))
+          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions))
           else if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator)
-          else if (generateServer) Seq(JavaInterfaceCodeGenerator, PlayJavaServerCodeGenerator(serverPowerApis, usePlayActions))
+          else if (generateServer) Seq(JavaInterfaceCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions))
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         }
       }

--- a/codegen/src/main/scala/akka/grpc/gen/Main.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Main.scala
@@ -37,8 +37,6 @@ object Main extends App {
 
   private val generatePlay: Boolean = reqLowerCase.contains("generate_play=true")
 
-  private val usePlayActions: Boolean = reqLowerCase.contains("use_play_actions=true")
-
   val LogFileRegex = """(?:.*,)logfile=([^,]+)(?:,.*)?""".r
   private val logger = req.getParameter match {
     case LogFileRegex(path) => new FileLogger(path)
@@ -64,15 +62,15 @@ object Main extends App {
       } else {
         if (languageScala) {
           // Scala
-          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions))
+          if (generateClient && generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator)
           else if (generateClient) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator)
-          else if (generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions))
+          else if (generateServer) Seq(ScalaTraitCodeGenerator, PlayScalaServerCodeGenerator)
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         } else {
           // Java
-          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions))
+          if (generateClient && generateServer) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator, PlayJavaServerCodeGenerator)
           else if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator, PlayJavaClientCodeGenerator)
-          else if (generateServer) Seq(JavaInterfaceCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions))
+          else if (generateServer) Seq(JavaInterfaceCodeGenerator, PlayJavaServerCodeGenerator)
           else throw new IllegalArgumentException("At least one of generateClient or generateServer must be enabled")
         }
       }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaClientCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.javadsl
 
+import scala.collection.immutable
 import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
@@ -12,27 +13,27 @@ import templates.JavaClient.txt.{ Client, ClientPowerApi }
 trait JavaClientCodeGenerator extends JavaCodeGenerator {
   override def name = "akka-grpc-javadsl-client"
 
-  override def perServiceContent: Set[(Logger, Service) ⇒ CodeGeneratorResponse.File] =
+  override def perServiceContent: Set[(Logger, Service) ⇒ immutable.Seq[CodeGeneratorResponse.File]] =
     super.perServiceContent +
       generateInterface +
       generateRaw
 
-  def generateInterface(logger: Logger, service: Service): CodeGeneratorResponse.File = {
+  def generateInterface(logger: Logger, service: Service): immutable.Seq[CodeGeneratorResponse.File] = {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(Client(service).body)
     val clientPath = s"${service.packageDir}/${service.name}Client.java"
     b.setName(clientPath)
     logger.info(s"Generating Akka gRPC Client [${service.packageName}.${service.name}]")
-    b.build
+    immutable.Seq(b.build)
   }
 
-  def generateRaw(logger: Logger, service: Service): CodeGeneratorResponse.File = {
+  def generateRaw(logger: Logger, service: Service): immutable.Seq[CodeGeneratorResponse.File] = {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(ClientPowerApi(service).body)
     val clientPath = s"${service.packageDir}/${service.name}ClientPowerApi.java"
     b.setName(clientPath)
     logger.info(s"Generating Akka gRPC Lifted Client interface[${service.packageName}.${service.name}]")
-    b.build
+    immutable.Seq(b.build)
   }
 
   override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) => Seq(

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
@@ -34,16 +34,17 @@ abstract class JavaCodeGenerator extends CodeGenerator {
           acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps))
       }
 
-    // Currently a per-invocation option, intended to become a per-service option eventually
+    // Currently per-invocation options, intended to become per-service options eventually
     // https://github.com/akka/akka-grpc/issues/451
     val params = request.getParameter.toLowerCase
     val serverPowerApi = params.contains("server_power_apis") && !params.contains("server_power_apis=false")
+    val usePlayActions = params.contains("use_play_actions") && !params.contains("use_play_actions=false")
 
     val services = (for {
       file ← request.getFileToGenerateList.asScala
       fileDesc = fileDescByName(file)
       serviceDesc ← fileDesc.getServices.asScala
-    } yield Service(fileDesc, serviceDesc, serverPowerApi)).toVector
+    } yield Service(fileDesc, serviceDesc, serverPowerApi, usePlayActions)).toVector
 
     for {
       service <- services

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaInterfaceCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaInterfaceCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.javadsl
 
+import scala.collection.immutable
 import akka.grpc.gen.Logger
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.JavaCommon.txt.ApiInterface
@@ -11,13 +12,13 @@ import templates.JavaCommon.txt.ApiInterface
 object JavaInterfaceCodeGenerator extends JavaCodeGenerator {
   override def name = "akka-grpc-javadsl-interface"
 
-  override def perServiceContent: Set[(Logger, Service) ⇒ CodeGeneratorResponse.File] = super.perServiceContent + generateServiceFile
+  override def perServiceContent: Set[(Logger, Service) ⇒ immutable.Seq[CodeGeneratorResponse.File]] = super.perServiceContent + generateServiceFile
 
-  val generateServiceFile: (Logger, Service) ⇒ CodeGeneratorResponse.File = (logger, service) ⇒ {
+  val generateServiceFile: (Logger, Service) ⇒ immutable.Seq[CodeGeneratorResponse.File] = (logger, service) ⇒ {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(ApiInterface(service).body)
     b.setName(s"${service.packageDir}/${service.name}.java")
     logger.info(s"Generating Akka gRPC service interface for [${service.packageName}.${service.name}]")
-    b.build
+    immutable.Seq(b.build)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
@@ -9,17 +9,18 @@ import com.google.protobuf.Descriptors.{ FileDescriptor, ServiceDescriptor }
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 
-final case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method]) {
+final case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean) {
   def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
   def packageDir = packageName.replace('.', '/')
 }
 
 object Service {
-  def apply(fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor): Service = {
+  def apply(fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean): Service = {
     Service(
       fileDesc.getOptions.getJavaPackage,
       serviceDescriptor.getName,
       fileDesc.getPackage + "." + serviceDescriptor.getName,
-      serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq])
+      serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq],
+      serverPowerApi)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
@@ -9,18 +9,19 @@ import com.google.protobuf.Descriptors.{ FileDescriptor, ServiceDescriptor }
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 
-final case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean) {
+final case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean, usePlayActions: Boolean) {
   def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
   def packageDir = packageName.replace('.', '/')
 }
 
 object Service {
-  def apply(fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean): Service = {
+  def apply(fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean, usePlayActions: Boolean): Service = {
     Service(
       fileDesc.getOptions.getJavaPackage,
       serviceDescriptor.getName,
       fileDesc.getPackage + "." + serviceDescriptor.getName,
       serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq],
-      serverPowerApi)
+      serverPowerApi,
+      usePlayActions)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaClientCodeGenerator.scala
@@ -11,6 +11,7 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.PlayJava.txt.{ AkkaGrpcClientModule, ClientProvider }
 
 import scala.annotation.tailrec
+import scala.collection.immutable
 import akka.grpc.gen.scaladsl.play.PlayScalaClientCodeGenerator
 
 object PlayJavaClientCodeGenerator extends PlayJavaClientCodeGenerator
@@ -20,12 +21,12 @@ trait PlayJavaClientCodeGenerator extends JavaCodeGenerator {
 
   override def perServiceContent = super.perServiceContent + generateClientProvider
 
-  private val generateClientProvider: (Logger, Service) => CodeGeneratorResponse.File = (logger, service) => {
+  private val generateClientProvider: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(ClientProvider(service).body)
     b.setName(s"${service.packageName.replace('.', '/')}/${service.name}ClientProvider.java")
     logger.info(s"Generating Akka gRPC play client provider for ${service.packageName}.${service.name}")
-    b.build
+    immutable.Seq(b.build)
   }
 
   override def staticContent(logger: Logger, allServices: Seq[Service]): Set[CodeGeneratorResponse.File] = {

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
@@ -11,17 +11,17 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.PlayJavaServer.txt.Router
 import templates.PlayJavaServer.txt.RouterUsingActions
 
-case class PlayJavaServerCodeGenerator(usePlayActions: Boolean = false) extends JavaCodeGenerator {
+abstract class PlayJavaServerCodeGenerator extends JavaCodeGenerator {
   override def name: String = "akka-grpc-play-server-java"
 
-  override def perServiceContent = super.perServiceContent ++ (
-    if (usePlayActions) Set(generatePlainRouterUsingActions, generatePowerRouterUsingActions)
-    else Set(generatePlainRouter, generatePowerRouter)
-  )
+  override def perServiceContent = super.perServiceContent + generatePlainRouter + generatePowerRouter
 
   private val generatePlainRouter: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
-    b.setContent(Router(service, powerApis = false).body)
+
+    if (service.usePlayActions) b.setContent(RouterUsingActions(service, powerApis = false).body)
+    else b.setContent(Router(service, powerApis = false).body)
+
     b.setName(s"${service.packageDir}/Abstract${service.name}Router.java")
     logger.info(s"Generating Akka gRPC service play router for ${service.packageName}.${service.name}")
     immutable.Seq(b.build)
@@ -30,28 +30,14 @@ case class PlayJavaServerCodeGenerator(usePlayActions: Boolean = false) extends 
   private val generatePowerRouter: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     if (service.serverPowerApi) {
       val b = CodeGeneratorResponse.File.newBuilder()
-      b.setContent(Router(service, powerApis = true).body)
+
+      if (service.usePlayActions) b.setContent(RouterUsingActions(service, powerApis = true).body)
+      else b.setContent(Router(service, powerApis = true).body)
+
       b.setName(s"${service.packageDir}/Abstract${service.name}PowerApiRouter.java")
       logger.info(s"Generating Akka gRPC service power API play router for ${service.packageName}.${service.name}")
       immutable.Seq(b.build)
     } else immutable.Seq.empty
   }
-
-  private val generatePlainRouterUsingActions: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
-    val b = CodeGeneratorResponse.File.newBuilder()
-    b.setContent(RouterUsingActions(service, powerApis = false).body)
-    b.setName(s"${service.packageDir}/Abstract${service.name}Router.java")
-    logger.info(s"Generating Akka gRPC service play router for ${service.packageName}.${service.name}")
-    immutable.Seq(b.build)
-  }
-
-  private val generatePowerRouterUsingActions: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
-    if (service.serverPowerApi) {
-      val b = CodeGeneratorResponse.File.newBuilder()
-      b.setContent(RouterUsingActions(service, powerApis = true).body)
-      b.setName(s"${service.packageDir}/AbstractPowerApiRouter.java")
-      logger.info(s"Generating Akka gRPC service power API play router for ${service.packageName}.${service.name}")
-      immutable.Seq(b.build)
-    } else immutable.Seq.empty
-  }
 }
+object PlayJavaServerCodeGenerator extends PlayJavaServerCodeGenerator

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/play/PlayJavaServerCodeGenerator.scala
@@ -4,35 +4,54 @@
 
 package akka.grpc.gen.javadsl.play
 
+import scala.collection.immutable
 import akka.grpc.gen.Logger
 import akka.grpc.gen.javadsl.{ JavaCodeGenerator, Service }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.PlayJavaServer.txt.Router
 import templates.PlayJavaServer.txt.RouterUsingActions
 
-case class PlayJavaServerCodeGenerator(powerApis: Boolean = false, usePlayActions: Boolean = false) extends JavaCodeGenerator {
+case class PlayJavaServerCodeGenerator(usePlayActions: Boolean = false) extends JavaCodeGenerator {
   override def name: String = "akka-grpc-play-server-java"
 
   override def perServiceContent = super.perServiceContent ++ (
-    if (powerApis && usePlayActions) Set(generateRouterUsingActions(), generateRouterUsingActions(powerApis))
-    else if (powerApis) Set(generateRouter(), generateRouter(powerApis))
-    else if (usePlayActions) Set(generateRouterUsingActions())
-    else Set(generateRouter())
+    if (usePlayActions) Set(generatePlainRouterUsingActions, generatePowerRouterUsingActions)
+    else Set(generatePlainRouter, generatePowerRouter)
   )
 
-  private def generateRouter(powerApis: Boolean = false): (Logger, Service) => CodeGeneratorResponse.File = (logger, service) => {
+  private val generatePlainRouter: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
-    b.setContent(Router(service, powerApis).body)
-    b.setName(s"${service.packageDir}/Abstract${service.name}${if (powerApis) "PowerApi" else ""}Router.java")
-    logger.info(s"Generating Akka gRPC service${if (powerApis) " power API" else ""} play router for ${service.packageName}.${service.name}")
-    b.build
+    b.setContent(Router(service, powerApis = false).body)
+    b.setName(s"${service.packageDir}/Abstract${service.name}Router.java")
+    logger.info(s"Generating Akka gRPC service play router for ${service.packageName}.${service.name}")
+    immutable.Seq(b.build)
   }
 
-  private def generateRouterUsingActions(powerApis: Boolean = false): (Logger, Service) => CodeGeneratorResponse.File = (logger, service) => {
+  private val generatePowerRouter: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
+    if (service.serverPowerApi) {
+      val b = CodeGeneratorResponse.File.newBuilder()
+      b.setContent(Router(service, powerApis = true).body)
+      b.setName(s"${service.packageDir}/Abstract${service.name}PowerApiRouter.java")
+      logger.info(s"Generating Akka gRPC service power API play router for ${service.packageName}.${service.name}")
+      immutable.Seq(b.build)
+    } else immutable.Seq.empty
+  }
+
+  private val generatePlainRouterUsingActions: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
-    b.setContent(RouterUsingActions(service, powerApis).body)
-    b.setName(s"${service.packageDir}/Abstract${service.name}${if (powerApis) "PowerApi" else ""}Router.java")
-    logger.info(s"Generating Akka gRPC service${if (powerApis) " power API" else ""} play router for ${service.packageName}.${service.name}")
-    b.build
+    b.setContent(RouterUsingActions(service, powerApis = false).body)
+    b.setName(s"${service.packageDir}/Abstract${service.name}Router.java")
+    logger.info(s"Generating Akka gRPC service play router for ${service.packageName}.${service.name}")
+    immutable.Seq(b.build)
+  }
+
+  private val generatePowerRouterUsingActions: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
+    if (service.serverPowerApi) {
+      val b = CodeGeneratorResponse.File.newBuilder()
+      b.setContent(RouterUsingActions(service, powerApis = true).body)
+      b.setName(s"${service.packageDir}/AbstractPowerApiRouter.java")
+      logger.info(s"Generating Akka gRPC service power API play router for ${service.packageName}.${service.name}")
+      immutable.Seq(b.build)
+    } else immutable.Seq.empty
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
+import scala.collection.immutable
 import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import scalapb.compiler.GeneratorParams
@@ -15,12 +16,12 @@ trait ScalaClientCodeGenerator extends ScalaCodeGenerator {
 
   override def perServiceContent = super.perServiceContent + generateStub
 
-  def generateStub(logger: Logger, service: Service): CodeGeneratorResponse.File = {
+  def generateStub(logger: Logger, service: Service): immutable.Seq[CodeGeneratorResponse.File] = {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(Client(service).body)
     b.setName(s"${service.packageDir}/${service.name}Client.scala")
     logger.info(s"Generating Akka gRPC client for ${service.packageName}.${service.name}")
-    b.build
+    immutable.Seq(b.build)
   }
 
   override val suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) =>

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -15,7 +15,7 @@ import templates.ScalaCommon.txt._
 
 abstract class ScalaCodeGenerator extends CodeGenerator {
   // Override this to add generated files per service
-  def perServiceContent: Set[(Logger, Service) ⇒ CodeGeneratorResponse.File] = Set.empty
+  def perServiceContent: Set[(Logger, Service) ⇒ immutable.Seq[CodeGeneratorResponse.File]] = Set.empty
 
   // Override these to add service-independent generated files
   def staticContent(logger: Logger): Set[CodeGeneratorResponse.File] = Set.empty
@@ -34,18 +34,24 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
           acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps))
       }
 
+    // Currently a per-invocation option, intended to become a per-service option eventually
+    // https://github.com/akka/akka-grpc/issues/451
+    val params = request.getParameter.toLowerCase
+    val serverPowerApi = params.contains("server_power_apis") && !params.contains("server_power_apis=false")
+
     val services =
       (for {
         file ← request.getFileToGenerateList.asScala
         fileDesc = fileDescByName(file)
         serviceDesc ← fileDesc.getServices.asScala
-      } yield Service(parseParameters(request.getParameter), fileDesc, serviceDesc)).toSeq
+      } yield Service(parseParameters(request.getParameter), fileDesc, serviceDesc, serverPowerApi)).toSeq
 
     for {
       service <- services
-      generator ← perServiceContent
+      generator <- perServiceContent
+      generated <- generator(logger, service)
     } {
-      b.addFile(generator(logger, service))
+      b.addFile(generated)
     }
 
     staticContent(logger).map(b.addFile)

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -34,17 +34,18 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
           acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps))
       }
 
-    // Currently a per-invocation option, intended to become a per-service option eventually
+    // Currently per-invocation options, intended to become per-service options eventually
     // https://github.com/akka/akka-grpc/issues/451
     val params = request.getParameter.toLowerCase
     val serverPowerApi = params.contains("server_power_apis") && !params.contains("server_power_apis=false")
+    val usePlayActions = params.contains("use_play_actions") && !params.contains("use_play_actions=false")
 
     val services =
       (for {
         file ← request.getFileToGenerateList.asScala
         fileDesc = fileDescByName(file)
         serviceDesc ← fileDesc.getServices.asScala
-      } yield Service(parseParameters(request.getParameter), fileDesc, serviceDesc, serverPowerApi)).toSeq
+      } yield Service(parseParameters(request.getParameter), fileDesc, serviceDesc, serverPowerApi, usePlayActions)).toSeq
 
     for {
       service <- services

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaMarshallersCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
+import scala.collection.immutable
 import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
@@ -21,11 +22,11 @@ trait ScalaMarshallersCodeGenerator extends ScalaCodeGenerator {
   override def suggestedDependencies = (scalaBinaryVersion: CodeGenerator.ScalaBinaryVersion) =>
     Artifact("com.typesafe.akka", s"akka-http_${scalaBinaryVersion.prefix}", BuildInfo.akkaHttpVersion) +: super.suggestedDependencies(scalaBinaryVersion)
 
-  def generateMarshalling(logger: Logger, service: Service): CodeGeneratorResponse.File = {
+  def generateMarshalling(logger: Logger, service: Service): immutable.Seq[CodeGeneratorResponse.File] = {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(Marshallers(service).body)
     b.setName(s"${service.packageDir}/${service.name}Marshallers.scala")
-    b.build
+    immutable.Seq(b.build)
   }
 }
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaTraitCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaTraitCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.scaladsl
 
+import scala.collection.immutable
 import akka.grpc.gen.Logger
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import templates.ScalaCommon.txt.ApiTrait
@@ -13,11 +14,11 @@ object ScalaTraitCodeGenerator extends ScalaCodeGenerator {
 
   override def perServiceContent = super.perServiceContent + generateServiceFile
 
-  val generateServiceFile: (Logger, Service) => CodeGeneratorResponse.File = (logger, service) => {
+  val generateServiceFile: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(ApiTrait(service).body)
     b.setName(s"${service.packageDir}/${service.name}.scala")
     logger.info(s"Generating Akka gRPC service interface for ${service.packageName}.${service.name}")
-    b.build
+    immutable.Seq(b.build)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -10,13 +10,13 @@ import scala.collection.JavaConverters._
 import com.google.protobuf.Descriptors._
 import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
-case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean) {
+case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean, usePlayActions: Boolean) {
   def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
   def packageDir = packageName.replace('.', '/')
 }
 
 object Service {
-  def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean): Service = {
+  def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean, usePlayActions: Boolean): Service = {
     implicit val ops = new DescriptorImplicits(generatorParams, fileDesc.getDependencies.asScala :+ fileDesc)
     import ops._
 
@@ -27,6 +27,7 @@ object Service {
       serviceClassName,
       fileDesc.getPackage + "." + serviceDescriptor.getName,
       serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq],
-      serverPowerApi)
+      serverPowerApi,
+      usePlayActions)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -10,13 +10,13 @@ import scala.collection.JavaConverters._
 import com.google.protobuf.Descriptors._
 import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
-case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method]) {
+case class Service(packageName: String, name: String, grpcName: String, methods: immutable.Seq[Method], serverPowerApi: Boolean) {
   def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
   def packageDir = packageName.replace('.', '/')
 }
 
 object Service {
-  def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor): Service = {
+  def apply(generatorParams: GeneratorParams, fileDesc: FileDescriptor, serviceDescriptor: ServiceDescriptor, serverPowerApi: Boolean): Service = {
     implicit val ops = new DescriptorImplicits(generatorParams, fileDesc.getDependencies.asScala :+ fileDesc)
     import ops._
 
@@ -26,6 +26,7 @@ object Service {
       fileDesc.scalaPackageName,
       serviceClassName,
       fileDesc.getPackage + "." + serviceDescriptor.getName,
-      serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq])
+      serviceDescriptor.getMethods.asScala.map(method ⇒ Method(method)).to[immutable.Seq],
+      serverPowerApi)
   }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGenerator.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.gen.scaladsl.play
 
+import scala.collection.immutable
 import akka.grpc.gen.Logger
 import akka.grpc.gen.scaladsl.{ ScalaCodeGenerator, Service }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
@@ -21,12 +22,12 @@ trait PlayScalaClientCodeGenerator extends ScalaCodeGenerator {
 
   override def perServiceContent = super.perServiceContent + generateClientProvider
 
-  private val generateClientProvider: (Logger, Service) => CodeGeneratorResponse.File = (logger, service) => {
+  private val generateClientProvider: (Logger, Service) => immutable.Seq[CodeGeneratorResponse.File] = (logger, service) => {
     val b = CodeGeneratorResponse.File.newBuilder()
     b.setContent(ClientProvider(service).body)
     b.setName(s"${service.packageName.replace('.', '/')}/${service.name}ClientProvider.scala")
     logger.info(s"Generating Akka gRPC play client provider for ${service.packageName}.${service.name}")
-    b.build
+    immutable.Seq(b.build)
   }
 
   override def staticContent(logger: Logger, allServices: Seq[Service]): Set[CodeGeneratorResponse.File] = {

--- a/codegen/src/test/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGeneratorSpec.scala
+++ b/codegen/src/test/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGeneratorSpec.scala
@@ -13,21 +13,21 @@ class PlayScalaClientCodeGeneratorSpec extends WordSpec with Matchers {
 
     "choose the single package name" in {
       PlayScalaClientCodeGenerator
-        .packageForSharedModuleFile(Seq(Service("a.b", "MyService", "???", Nil, false))) should ===("a.b")
+        .packageForSharedModuleFile(Seq(Service("a.b", "MyService", "???", Nil, false, false))) should ===("a.b")
     }
 
     "choose the longest common package name" in {
       PlayScalaClientCodeGenerator
         .packageForSharedModuleFile(Seq(
-          Service("a.b.c", "MyService", "???", Nil, false),
-          Service("a.b.e", "OtherService", "???", Nil, false))) should ===("a.b")
+          Service("a.b.c", "MyService", "???", Nil, false, false),
+          Service("a.b.e", "OtherService", "???", Nil, false, false))) should ===("a.b")
     }
 
     "choose the root package if no common packages" in {
       PlayScalaClientCodeGenerator
         .packageForSharedModuleFile(Seq(
-          Service("a.b.c", "MyService", "???", Nil, false),
-          Service("c.d.e", "OtherService", "???", Nil, false))) should ===("")
+          Service("a.b.c", "MyService", "???", Nil, false, false),
+          Service("c.d.e", "OtherService", "???", Nil, false, false))) should ===("")
     }
   }
 

--- a/codegen/src/test/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGeneratorSpec.scala
+++ b/codegen/src/test/scala/akka/grpc/gen/scaladsl/play/PlayScalaClientCodeGeneratorSpec.scala
@@ -13,21 +13,21 @@ class PlayScalaClientCodeGeneratorSpec extends WordSpec with Matchers {
 
     "choose the single package name" in {
       PlayScalaClientCodeGenerator
-        .packageForSharedModuleFile(Seq(Service("a.b", "MyService", "???", Nil))) should ===("a.b")
+        .packageForSharedModuleFile(Seq(Service("a.b", "MyService", "???", Nil, false))) should ===("a.b")
     }
 
     "choose the longest common package name" in {
       PlayScalaClientCodeGenerator
         .packageForSharedModuleFile(Seq(
-          Service("a.b.c", "MyService", "???", Nil),
-          Service("a.b.e", "OtherService", "???", Nil))) should ===("a.b")
+          Service("a.b.c", "MyService", "???", Nil, false),
+          Service("a.b.e", "OtherService", "???", Nil, false))) should ===("a.b")
     }
 
     "choose the root package if no common packages" in {
       PlayScalaClientCodeGenerator
         .packageForSharedModuleFile(Seq(
-          Service("a.b.c", "MyService", "???", Nil),
-          Service("c.d.e", "OtherService", "???", Nil))) should ===("")
+          Service("a.b.c", "MyService", "???", Nil, false),
+          Service("c.d.e", "OtherService", "???", Nil, false))) should ===("")
     }
   }
 

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -131,12 +131,12 @@ class GenerateMojo @Inject() (project: MavenProject, buildContext: BuildContext)
     if (schemas.isEmpty) {
       getLog.info("No changed or new .proto-files found in [%s], skipping code generation".format(generatedSourcesDir))
     } else {
-      val settings = akkaGrpcCodeGeneratorSettings :+ s"server_power_apis=$serverPowerApis"
+      val settings = akkaGrpcCodeGeneratorSettings :+ s"server_power_apis=$serverPowerApis" :+ s"use_play_actions=$usePlayActions"
       val targets = language match {
         case Java ⇒
           val glueGenerators = Seq(
             if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator) else Seq.empty,
-            if (generatePlayServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions)) else Seq.empty,
+            if (generatePlayServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator, PlayJavaServerCodeGenerator) else Seq.empty,
             if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator) else Seq.empty,
             if (generatePlayClient) Seq(JavaInterfaceCodeGenerator, PlayJavaClientCodeGenerator) else Seq.empty
           ).flatten.distinct
@@ -145,7 +145,7 @@ class GenerateMojo @Inject() (project: MavenProject, buildContext: BuildContext)
         case Scala ⇒
           val glueGenerators = Seq(
             if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator) else Seq.empty,
-            if (generatePlayServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions)) else Seq.empty,
+            if (generatePlayServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator, PlayScalaServerCodeGenerator) else Seq.empty,
             if (generateClient) Seq(ScalaTraitCodeGenerator, ScalaClientCodeGenerator) else Seq.empty,
             if (generatePlayClient) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator) else Seq.empty
           ).flatten.distinct

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -131,27 +131,27 @@ class GenerateMojo @Inject() (project: MavenProject, buildContext: BuildContext)
     if (schemas.isEmpty) {
       getLog.info("No changed or new .proto-files found in [%s], skipping code generation".format(generatedSourcesDir))
     } else {
-
+      val settings = akkaGrpcCodeGeneratorSettings :+ s"server_power_apis=$serverPowerApis"
       val targets = language match {
         case Java ⇒
           val glueGenerators = Seq(
-            if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator(serverPowerApis)) else Seq.empty,
-            if (generatePlayServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator(serverPowerApis), PlayJavaServerCodeGenerator(serverPowerApis, usePlayActions)) else Seq.empty,
+            if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator) else Seq.empty,
+            if (generatePlayServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator, PlayJavaServerCodeGenerator(usePlayActions)) else Seq.empty,
             if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator) else Seq.empty,
             if (generatePlayClient) Seq(JavaInterfaceCodeGenerator, PlayJavaClientCodeGenerator) else Seq.empty
           ).flatten.distinct
           Seq[Target](protocbridge.gens.java -> generatedSourcesDir) ++
-            glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, akkaGrpcCodeGeneratorSettings))
+            glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, settings))
         case Scala ⇒
           val glueGenerators = Seq(
-            if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator(serverPowerApis)) else Seq.empty,
-            if (generatePlayServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator(serverPowerApis), PlayScalaServerCodeGenerator(serverPowerApis, usePlayActions)) else Seq.empty,
+            if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator) else Seq.empty,
+            if (generatePlayServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator, PlayScalaServerCodeGenerator(usePlayActions)) else Seq.empty,
             if (generateClient) Seq(ScalaTraitCodeGenerator, ScalaClientCodeGenerator) else Seq.empty,
             if (generatePlayClient) Seq(ScalaTraitCodeGenerator, PlayScalaClientCodeGenerator) else Seq.empty
           ).flatten.distinct
           Seq[Target](
             (JvmGenerator("scala", ScalaPbCodeGenerator), akkaGrpcCodeGeneratorSettings) → generatedSourcesDir) ++
-            glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, akkaGrpcCodeGeneratorSettings))
+            glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, settings))
       }
 
       val runProtoc: Seq[String] ⇒ Int = args => com.github.os72.protocjar.Protoc.runProtoc(protocVersion +: args.toArray)


### PR DESCRIPTION
This is a step towards configuring whether or not to generate Power API's
on a service-by-service basis rather than globally, as well as specifying
and configuring external generators in Maven and Gradle