### PR TITLE
Fix Code Generation with Gradle on Windows (see #602)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val codegen = Project(id = "akka-grpc-codegen", base = file("codegen"))
     },
     mainClass in assembly := Some("akka.grpc.gen.Main"),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-        prependShellScript = Some(sbtassembly.AssemblyPlugin.defaultShellScript)),
+        prependShellScript = Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     crossScalaVersions -= scala213))
   .settings(addArtifact(artifact in (Compile, assembly), assembly))
 
@@ -40,7 +40,7 @@ lazy val scalapbProtocPlugin = Project(id = "akka-grpc-scalapb-protoc-plugin", b
     },
     mainClass in assembly := Some("akka.grpc.scalapb.Main"),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-        prependShellScript = Some(sbtassembly.AssemblyPlugin.defaultShellScript)),
+        prependShellScript = Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     crossScalaVersions := Seq(scala212)))
   .settings(addArtifact(artifact in (Compile, assembly), assembly))
 


### PR DESCRIPTION
The purpose of this PR is to fix #602 which currently affects code generation on Windows. It is based on #621. At the moment it does the following (see e146bf63d6d9fa43c95adf0fb6270d60abc47570):

1. Remove the logfile option, as this requires further tweaking to work
on Windows.
2. Add a hack for Windows that copies JAR assemblies to BAT files,
  skipping the preamble after the shebang, in order to make them
  directly executable.

While these tweaks work for me, I think there is still some work to do, to arrive at a technically viable solution. Your feedback regarding the following points would therefore be highly appreciated:

1.) could probably be fixed properly by investing some more time to make logging work on Windows. Is the log file important?

Regarding 2.) I think that it would be better to create a temporary bash script, that references the assembly JAR, and pass that to `protoc`, instead of creating copies in the local Maven repo that rely on the assembly to be in a particular format. However, since my experience in this area is rather limited, I'm not exactly sure how to do that in
```gradle
plugins {
    akkaGrpc {
        artifact = "com.lightbend.akka.grpc:akka-grpc-codegen_2.12:${pluginVersion}:assembly@${assemblySuffix}"
    }
    if (isScala) {
        scalapb {
            artifact = "com.lightbend.akka.grpc:akka-grpc-scalapb-protoc-plugin_2.12:${pluginVersion}:assembly@${assemblySuffix}"
        }
    }
}
``` 
How can I pass a temporary script instead of an artifact?