### PR TITLE
Gradle plugin defines correct sourcesets for java

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -25,6 +25,7 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
 
         project.configure(project) {
             boolean isScala = "${extension.language}".toLowerCase() == "scala"
+            boolean isJava = "${extension.language}".toLowerCase() == "java"
             File logFile = File.createTempFile("akka-grpc-gradle", ".log")
             logFile.deleteOnExit()
 
@@ -58,12 +59,18 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
                     }
                 }
 
-                if (isScala) {
-                    sourceSets {
-                        main {
+                sourceSets {
+                    main {
+                        if (isScala) {
                             scala {
                                 srcDir 'build/generated/source/proto/main/akkaGrpc'
                                 srcDir 'build/generated/source/proto/main/scalapb'
+                            }
+                        }
+                        if (isJava) {
+                            java {
+                                srcDir 'build/generated/source/proto/main/akkaGrpc'
+                                srcDir 'build/generated/source/proto/main/java'
                             }
                         }
                     }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

In a Gradle project, after generation of the protobuf files, these files should be available as generated source for the rest of the project.  This is the case with Scala projects, but not with Java projects.

This PR directs Gradle to add the correct generated source directories for Java projects.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #617 

## Changes

<!-- Bullets for important changes in this PR -->

- Source sets are now added for both scala and java

## Background Context

<!-- Why did you take this approach? -->
N/A - but #617 has a short discussion about how I came across this issue.


Edit: CLA signed.