### PR TITLE
Enable flat_package as default in maven plugin.

### DIFF
--- a/docs/src/main/paradox/buildtools/maven.md
+++ b/docs/src/main/paradox/buildtools/maven.md
@@ -38,7 +38,7 @@ Scala
 ### Generating server "power APIs"
 
 To additionally generate server "power APIs" that have access to request metata, as described
-@ref[here](../server/walkthrough.md#accessing-request-metadata), set the `server_power_apis` option:
+@ref[here](../server/walkthrough.md#accessing-request-metadata), set the `serverPowerApis` tag as true:
 
 Java
 :   ```xml
@@ -47,7 +47,7 @@ Java
         <configuration>
           ...
           <generatorSettings>
-            <generatorSetting>server_power_apis</generatorSetting>
+            <serverPowerApis>true</serverPowerApis>
           </generatorSettings>
         </configuration>
     </plugin>
@@ -61,8 +61,7 @@ Scala
           ...
           <language>Scala</language>
           <generatorSettings>
-            <generatorSetting>flat_package</generatorSetting>
-            <generatorSetting>server_power_apis</generatorSetting>
+            <serverPowerApis>true</serverPowerApis>
           </generatorSettings>
         </configuration>
     </plugin>

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -70,6 +70,19 @@ object GenerateMojo {
       case unknown =>
         throw new IllegalArgumentException("[$unknown] is not a supported language, supported are java or scala")
     }
+
+  /**
+   * Turns generatorSettings into sequence of strings, including to:
+   * 1. Filter keys if the values are not false.
+   * 2. Make camelCase into snake_case
+   * e.g. { "flatPackage": "true", "serverPowerApis": "false" } -> ["flat_package"]
+   */
+  def parseGeneratorSettings(generatorSettings: java.util.Map[String, String]): Seq[String] = {
+    import scala.collection.JavaConverters._
+    generatorSettings.asScala.filter(_._2.toLowerCase() != "false").keys.toSeq.map { params =>
+      "[A-Z]".r.replaceAllIn(params, (s => s"_${s.group(0).toLowerCase()}"))
+    }
+  }
 }
 
 class GenerateMojo @Inject()(project: MavenProject, buildContext: BuildContext) extends AbstractMojo {
@@ -96,7 +109,7 @@ class GenerateMojo @Inject()(project: MavenProject, buildContext: BuildContext) 
 
   import scala.collection.JavaConverters._
   @BeanProperty
-  var generatorSettings: java.util.ArrayList[String] = _
+  var generatorSettings: java.util.Map[String, String] = _
 
   @BeanProperty
   var extraGenerators: java.util.ArrayList[String] = _
@@ -131,18 +144,21 @@ class GenerateMojo @Inject()(project: MavenProject, buildContext: BuildContext) 
       getLog.info("No changed or new .proto-files found in [%s], skipping code generation".format(generatedSourcesDir))
     } else {
       val loadedExtraGenerators =
-        extraGenerators.asScala.map(cls => Class.forName(cls).newInstance().asInstanceOf[CodeGenerator])
+        extraGenerators.asScala.map(cls =>
+          Class.forName(cls).getDeclaredConstructor().newInstance().asInstanceOf[CodeGenerator])
       val targets = language match {
         case Java =>
           val glueGenerators = loadedExtraGenerators ++ Seq(
-            if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator) else Seq.empty,
-            if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator) else Seq.empty).flatten.distinct
+              if (generateServer) Seq(JavaInterfaceCodeGenerator, JavaServerCodeGenerator) else Seq.empty,
+              if (generateClient) Seq(JavaInterfaceCodeGenerator, JavaClientCodeGenerator) else Seq.empty).flatten.distinct
           Seq[Target](protocbridge.gens.java -> generatedSourcesDir) ++
-          glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, generatorSettings.asScala))
+          glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, parseGeneratorSettings(generatorSettings)))
         case Scala =>
-          // Initialize generatorSettings after bean is injected via Mojo setup.
-          // Add flat_package option as default.
-          generatorSettings.add("flat_package")
+          // Add flatPackage option as default if it's not absent.
+          generatorSettings.putIfAbsent("flatPackage", "true")
+
+          val scalaGeneratorSettings = parseGeneratorSettings(generatorSettings)
+          println(scalaGeneratorSettings)
 
           val glueGenerators = Seq(
             if (generateServer) Seq(ScalaTraitCodeGenerator, ScalaServerCodeGenerator) else Seq.empty,
@@ -151,10 +167,10 @@ class GenerateMojo @Inject()(project: MavenProject, buildContext: BuildContext) 
           Seq[Target](
             (
               JvmGenerator("scala", ScalaPbCodeGenerator),
-              generatorSettings.asScala
+              scalaGeneratorSettings
                 .filterNot(_ == "server_power_apis")
                 .filterNot(_ == "use_play_actions")) -> generatedSourcesDir) ++
-          glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, generatorSettings.asScala))
+          glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, scalaGeneratorSettings))
       }
 
       val runProtoc: Seq[String] => Int = args =>

--- a/maven-plugin/src/test/scala/akka/grpc/maven/ProtocSpec.scala
+++ b/maven-plugin/src/test/scala/akka/grpc/maven/ProtocSpec.scala
@@ -21,4 +21,18 @@ class ProtocSpec extends WordSpec with Matchers {
     }
   }
 
+  import scala.collection.JavaConverters._
+
+  "Parsing generator settings" should {
+    "filter out the false values" in {
+      val settings = Map("1" -> "true", "2" -> "false", "3" -> "False", "4" -> "")
+      GenerateMojo.parseGeneratorSettings(settings.asJava) shouldBe Seq("1", "4")
+    }
+
+    "convert camelCase into snake_case of keys" in {
+      val settings = Map("flatPackage" -> "true", "serverPowerApis" -> "true")
+      GenerateMojo.parseGeneratorSettings(settings.asJava) shouldBe Seq("flat_package", "server_power_apis")
+    }
+  }
+
 }

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -51,7 +51,7 @@
         </executions>
         <configuration>
           <generatorSettings>
-            <generatorSetting>server_power_apis</generatorSetting>
+            <serverPowerApis>true</serverPowerApis>
           </generatorSettings>
         </configuration>
       </plugin>

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -77,7 +77,7 @@
         <configuration>
           <language>Scala</language>
           <generatorSettings>
-            <generatorSetting>server_power_apis</generatorSetting>
+            <serverPowerApis>true</serverPowerApis>
           </generatorSettings>
         </configuration>
         <executions>

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -77,7 +77,6 @@
         <configuration>
           <language>Scala</language>
           <generatorSettings>
-            <generatorSetting>flat_package</generatorSetting>
             <generatorSetting>server_power_apis</generatorSetting>
           </generatorSettings>
         </configuration>


### PR DESCRIPTION


* Fix the wrong initialization of generatorSettings.
* Remove flat_package option in plugin testing for validation.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
Enable `flat_package` option in maven plugin.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #623 

## Changes

<!-- Bullets for important changes in this PR -->
The `generatorSettings` bean is injected by Maven plugin dependency injection. Hence, the prior initialization was not correct. 
Add `flat_package` option at the execution call, and remove the config in `plugin-tester-scala` for plugin test.


## Background Context

<!-- Why did you take this approach? -->