### PR TITLE
Fix junit deprecation warning.

### DIFF
--- a/runtime/src/test/java/akka/grpc/javadsl/ConcatOrNotFoundTest.java
+++ b/runtime/src/test/java/akka/grpc/javadsl/ConcatOrNotFoundTest.java
@@ -8,7 +8,7 @@ import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/runtime/src/test/scala/akka/grpc/JUnitEventually.scala
+++ b/runtime/src/test/scala/akka/grpc/JUnitEventually.scala
@@ -5,7 +5,7 @@
 package akka.grpc
 
 import org.scalatest.concurrent.Eventually
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 import org.scalatest.time.{ Millis, Span }
 
 abstract class JUnitEventually extends JUnitSuite with Eventually {


### PR DESCRIPTION
The junit related packages were moved under org.scalatestplus.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->

## Background Context

<!-- Why did you take this approach? -->
The changed occurred since scalatest 3.0.6 version, see [changelog](https://github.com/scalatest/scalatest/releases)