### PR TITLE
On demand import statements generation.

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/Logging.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Logging.scala
@@ -4,9 +4,7 @@
 
 package akka.grpc.gen
 
-import java.io.{ FileWriter, PrintWriter }
-import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Path }
+import java.io.PrintWriter
 
 // specific to gen so that the build tools can implement their own
 trait Logger {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaClientCodeGenerator.scala
@@ -7,7 +7,6 @@ package akka.grpc.gen.scaladsl
 import scala.collection.immutable
 import akka.grpc.gen.{ BuildInfo, CodeGenerator, Logger }
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
-import scalapb.compiler.GeneratorParams
 import protocbridge.Artifact
 import templates.ScalaClient.txt._
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -11,7 +11,6 @@ import com.google.protobuf.Descriptors._
 import com.google.protobuf.compiler.PluginProtos.{ CodeGeneratorRequest, CodeGeneratorResponse }
 import scalapb.compiler.GeneratorParams
 import protocbridge.Artifact
-import templates.ScalaCommon.txt._
 
 abstract class ScalaCodeGenerator extends CodeGenerator {
   // Override this to add generated files per service

--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -7,15 +7,11 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import akka.annotation.*;
 import akka.grpc.internal.*;
 import akka.grpc.GrpcClientSettings;
 import akka.grpc.javadsl.AkkaGrpcClient;
-import akka.grpc.javadsl.SingleResponseRequestBuilder;
-import akka.grpc.javadsl.StreamResponseRequestBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import akka.stream.OverflowStrategy;
 
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
@@ -23,7 +19,8 @@ import io.grpc.MethodDescriptor;
 import static @{service.packageName}.@{service.name}.Serializers.*;
 
 import scala.concurrent.ExecutionContext;
-import scala.compat.java8.FutureConverters;
+
+@GenMethodImports(service)
 
 public abstract class @{service.name}Client extends @{service.name}ClientPowerApi implements @{service.name}, AkkaGrpcClient {
   public static final @{service.name}Client create(GrpcClientSettings settings, Materializer mat, ExecutionContext ec) {

--- a/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/ClientPowerApi.scala.txt
@@ -7,10 +7,7 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName;
 
-import akka.grpc.javadsl.SingleResponseRequestBuilder;
-import akka.grpc.javadsl.StreamResponseRequestBuilder;
-
-import static @{service.packageName}.@{service.name}.Serializers.*;
+@GenMethodImports(service)
 
 public abstract class @{service.name}ClientPowerApi {
   @for(method <- service.methods) {
@@ -20,11 +17,11 @@ public abstract class @{service.name}ClientPowerApi {
      */
     @if(method.methodType == akka.grpc.gen.Unary) {
       public SingleResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
-    }else if(method.methodType == akka.grpc.gen.ClientStreaming){
+    } else if(method.methodType == akka.grpc.gen.ClientStreaming){
       public SingleResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
-    }else if(method.methodType == akka.grpc.gen.ServerStreaming){
+    } else if(method.methodType == akka.grpc.gen.ServerStreaming){
       public StreamResponseRequestBuilder<@method.inputTypeUnboxed, @method.outputTypeUnboxed> @{method.name}()
-    }else if(method.methodType == akka.grpc.gen.BidiStreaming){
+    } else if(method.methodType == akka.grpc.gen.BidiStreaming){
       public StreamResponseRequestBuilder<akka.stream.javadsl.Source<@method.inputTypeUnboxed, akka.NotUsed>, @method.outputTypeUnboxed> @{method.name}()
     }
     {

--- a/codegen/src/main/twirl/templates/JavaClient/GenMethodImports.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/GenMethodImports.scala.txt
@@ -1,0 +1,16 @@
+@*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ *@
+
+@(service: akka.grpc.gen.javadsl.Service)
+
+@{
+  val singleResponse = "import akka.grpc.javadsl.SingleResponseRequestBuilder;"
+  val streamResponse = "import akka.grpc.javadsl.StreamResponseRequestBuilder;"
+  service.methods.map(_.methodType).map {
+      case akka.grpc.gen.Unary => singleResponse
+      case akka.grpc.gen.ClientStreaming => singleResponse
+      case akka.grpc.gen.ServerStreaming => streamResponse
+      case akka.grpc.gen.BidiStreaming => streamResponse
+  }.toSet.mkString("\n")
+}

--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -18,13 +18,11 @@ import akka.stream.Materializer;
 
 import akka.grpc.Codec;
 import akka.grpc.Codecs;
-import akka.grpc.ProtobufSerializer;
-import akka.grpc.javadsl.GoogleProtobufSerializer;
 import akka.grpc.javadsl.GrpcMarshalling;
 import akka.grpc.javadsl.GrpcExceptionHandler;
-import akka.grpc.javadsl.Metadata;
-import akka.grpc.javadsl.MetadataImpl;
 import akka.grpc.javadsl.package$;
+
+@{if (powerApis) "import akka.grpc.javadsl.Metadata;\nimport akka.grpc.javadsl.MetadataImpl;" else ""}
 
 import static @{service.packageName}.@{service.name}.Serializers.*;
 

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -7,7 +7,7 @@
 @akka.grpc.gen.Constants.DoNotEditComment
 package @service.packageName
 
-import scala.concurrent.{ ExecutionContext, Promise }
+import scala.concurrent.ExecutionContext
 
 import io.grpc.ManagedChannel
 import io.grpc.MethodDescriptor
@@ -15,18 +15,28 @@ import io.grpc.MethodDescriptor
 import akka.grpc.GrpcClientSettings
 
 import akka.grpc.scaladsl.AkkaGrpcClient
-import akka.grpc.scaladsl.SingleResponseRequestBuilder
-import akka.grpc.scaladsl.StreamResponseRequestBuilder
 
-import akka.grpc.internal.ScalaUnaryRequestBuilder
-import akka.grpc.internal.ScalaBidirectionalStreamingRequestBuilder
-import akka.grpc.internal.ScalaClientStreamingRequestBuilder
-import akka.grpc.internal.ScalaServerStreamingRequestBuilder
 import akka.grpc.internal.Marshaller
 import akka.grpc.internal.NettyClientUtils
 import akka.grpc.internal.ClientState
 
 import akka.stream.Materializer
+
+@{
+  def withSingleResponse(stmt: String) = Set("import akka.grpc.scaladsl.SingleResponseRequestBuilder", stmt)
+  def withStreamResponse(stmt: String) = Set("import akka.grpc.scaladsl.StreamResponseRequestBuilder", stmt)
+  service.methods.toSet.flatMap { method: akka.grpc.gen.scaladsl.Method =>
+
+    val statements = method.methodType match {
+      case akka.grpc.gen.Unary => withSingleResponse("import akka.grpc.internal.ScalaUnaryRequestBuilder")
+      case akka.grpc.gen.ClientStreaming =>  withSingleResponse("import akka.grpc.internal.ScalaClientStreamingRequestBuilder")
+      case akka.grpc.gen.ServerStreaming => withStreamResponse("import akka.grpc.internal.ScalaServerStreamingRequestBuilder")
+      case akka.grpc.gen.BidiStreaming => withStreamResponse("import akka.grpc.internal.ScalaBidirectionalStreamingRequestBuilder")
+    }
+
+    statements
+  }.mkString("\n")
+}
 
 // Not sealed so users can extend to write their stubs
 trait @{service.name}Client extends @{service.name} with @{service.name}ClientPowerApi with AkkaGrpcClient

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -9,14 +9,16 @@ package @service.packageName
 
 import scala.concurrent.ExecutionContext
 
-import akka.grpc.scaladsl.{ GrpcExceptionHandler, GrpcMarshalling, ScalapbProtobufSerializer, Metadata, MetadataImpl }
-import akka.grpc.{ Codecs, GrpcServiceException }
+import akka.grpc.scaladsl.{ GrpcExceptionHandler, GrpcMarshalling }
+import akka.grpc.Codecs
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.Uri.Path.Segment
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+
+@{if (powerApis) "import akka.grpc.scaladsl.MetadataImpl" else ""}
 
 @defining(if (powerApis) service.name + "PowerApi" else service.name) { serviceName =>
   object @{serviceName}Handler {

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -6,28 +6,11 @@ package example.myapp;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.*;
-import akka.http.scaladsl.settings.ServerSettings;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.FileInputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.KeyFactory;
-import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.SecureRandom;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
 import java.util.concurrent.CompletionStage;
 
 //#import
@@ -61,7 +44,7 @@ class CombinedServer {
 
       Http.get(sys).bindAndHandleAsync(
           serviceHandlers,
-          ConnectHttp.toHost("127.0.0.1", 8080, UseHttp2.always()),
+          ConnectHttp.toHost("127.0.0.1", 8080),
           mat)
       //#concatOrNotFound
       .thenAccept(binding -> {

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
@@ -40,7 +40,7 @@ class GreeterServer {
 
     return Http.get(sys).bindAndHandleAsync(
       GreeterServiceHandlerFactory.create(impl, mat, sys),
-      ConnectHttp.toHost("127.0.0.1", 8080, UseHttp2.always()),
+      ConnectHttp.toHost("127.0.0.1", 8080),
       mat);
   }
 }

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServicePowerApiImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServicePowerApiImpl.java
@@ -10,7 +10,6 @@ import akka.grpc.javadsl.Metadata;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
-import example.myapp.helloworld.grpc.GreeterService;
 import example.myapp.helloworld.grpc.GreeterServicePowerApi;
 import example.myapp.helloworld.grpc.HelloReply;
 import example.myapp.helloworld.grpc.HelloRequest;

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
@@ -9,18 +9,13 @@ import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.UseHttp2;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import example.myapp.helloworld.grpc.GreeterService;
-import example.myapp.helloworld.grpc.GreeterServiceHandlerFactory;
 import example.myapp.helloworld.grpc.GreeterServicePowerApi;
 import example.myapp.helloworld.grpc.GreeterServicePowerApiHandlerFactory;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 class PowerGreeterServer {
@@ -47,7 +42,7 @@ class PowerGreeterServer {
 
       return Http.get(sys).bindAndHandleAsync(
         GreeterServicePowerApiHandlerFactory.create(impl, mat, sys),
-        ConnectHttp.toHost("127.0.0.1", 8081, UseHttp2.always()),
+        ConnectHttp.toHost("127.0.0.1", 8081),
         mat);
   }
 }

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
@@ -12,7 +12,6 @@ import scala.language.postfixOps
 
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.grpc.SSLContextUtils
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures

--- a/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
@@ -4,33 +4,16 @@
 
 package example.myapp
 
-import java.io.{ ByteArrayOutputStream, FileInputStream, InputStream }
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.security.KeyFactory
-import java.security.KeyStore
-import java.security.SecureRandom
-import java.security.cert.CertificateFactory
-import java.security.spec.PKCS8EncodedKeySpec
-import java.util.Base64
-
-import javax.net.ssl.KeyManagerFactory
-import javax.net.ssl.SSLContext
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import akka.actor.ActorSystem
-import akka.grpc.scaladsl.ServiceHandler
-import akka.http.scaladsl.{ Http, HttpConnectionContext, HttpsConnectionContext }
-import akka.http.scaladsl.UseHttp2.Always
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.{ Http, HttpConnectionContext }
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import example.myapp.helloworld._
-import example.myapp.helloworld.grpc._
 import example.myapp.echo._
 import example.myapp.echo.grpc._
 
@@ -64,7 +47,7 @@ object CombinedServer {
         serviceHandlers,
         interface = "127.0.0.1",
         port = 8080,
-        connectionContext = HttpConnectionContext(http2 = Always))
+        connectionContext = HttpConnectionContext())
       //#concatOrNotFound
       .foreach { binding =>
         println(s"gRPC server bound to: ${binding.localAddress}")

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
@@ -6,7 +6,6 @@
 package example.myapp.helloworld
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.UseHttp2.Always
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.{ Directive0, Route, RouteResult }
 import akka.http.scaladsl.server.Directives._
@@ -71,7 +70,7 @@ class AuthenticatedGreeterServer(system: ActorSystem) {
       Route.asyncHandler(route),
       interface = "127.0.0.1",
       port = 8082,
-      connectionContext = HttpConnectionContext(http2 = Always))
+      connectionContext = HttpConnectionContext())
 
     // report successful binding
     binding.foreach { binding =>

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
@@ -6,7 +6,6 @@
 package example.myapp.helloworld
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.UseHttp2.Always
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ Http, HttpConnectionContext }
 import akka.stream.{ ActorMaterializer, Materializer }
@@ -46,7 +45,7 @@ class GreeterServer(system: ActorSystem) {
       service,
       interface = "127.0.0.1",
       port = 8080,
-      connectionContext = HttpConnectionContext(http2 = Always))
+      connectionContext = HttpConnectionContext())
 
     // report successful binding
     binding.foreach { binding =>

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
@@ -4,8 +4,6 @@
 
 package example.myapp.helloworld
 
-import java.util.concurrent.TimeUnit
-
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/PowerGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/PowerGreeterServer.scala
@@ -6,7 +6,6 @@
 package example.myapp.helloworld
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.UseHttp2.Always
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ Http, HttpConnectionContext }
 import akka.stream.{ ActorMaterializer, Materializer }
@@ -31,7 +30,7 @@ class PowerGreeterServer(system: ActorSystem) {
       service,
       interface = "127.0.0.1",
       port = 8081,
-      connectionContext = HttpConnectionContext(http2 = Always))
+      connectionContext = HttpConnectionContext())
 
     // report successful binding
     binding.foreach { binding =>

--- a/plugin-tester-scala/src/main/scala/example/myapp/statefulhelloworld/GreeterServiceImpl.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/statefulhelloworld/GreeterServiceImpl.scala
@@ -6,7 +6,6 @@ package example.myapp.statefulhelloworld
 
 import example.myapp.statefulhelloworld.grpc.GreeterService
 import example.myapp.statefulhelloworld.grpc.{ ChangeRequest, ChangeResponse, HelloReply, HelloRequest }
-import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.pattern.ask
 import akka.util.Timeout

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -5,7 +5,6 @@
 package example.myapp.helloworld
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.UseHttp2.Always
 import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model._

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -8,11 +8,9 @@ import scala.concurrent.Await
 
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.grpc.SSLContextUtils
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures


### PR DESCRIPTION
* Dynamic generate the import statements via twirl dynamic codegen.
* Remove several unused imports and deprecation warnings (mostly in plugin-tester-*) for reproducing changes.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
This PR make the import statements generated by `codegen` module dynamic.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #641 

## Changes

<!-- Bullets for important changes in this PR -->

This is basically a workaround of generating import statements.
From now, the generated scala code would not produce unused warnings.

However, there's still some questions opened:

1. No on demand Java import statements generation: I didn't find a way to produce (automatic) static analysis on **generated Java code**. If such tool doesn't exist, we can omit it for easier maintenance.

2. Should we test against this? For scala, we can add `-Ywarn-unused-import` and `-Xfatal-warnings` to `scalacOptions` for maybe `plugin-tester-scala`, but this would definitely break CI easily. For java, same as question 1.

3. Should we move the dynamic code generation codebase into scala codebase? Currently, there's only two parts for conditionally generating import statements: use `powerApis` and various method signatures (`Unary`, `ClientStreaming`, etc), and they don't follow a general rule. That means, we might need a large refactoring for each `CodeGenerator`, `Service`, etc. to generate those rules polymorphically. 

Any tips on these? Thanks!