### PR TITLE
update akkaGrpcCodeGeneratorSettings possible values

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -41,6 +41,7 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
     // Currently per-invocation options, intended to become per-service options eventually
     // https://github.com/akka/akka-grpc/issues/451
     val params = request.getParameter.toLowerCase
+    // flags listed in akkaGrpcCodeGeneratorSettings's description
     val serverPowerApi = params.contains("server_power_apis") && !params.contains("server_power_apis=false")
     val usePlayActions = params.contains("use_play_actions") && !params.contains("use_play_actions=false")
 
@@ -65,12 +66,16 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
     b.build()
   }
 
+  // flags listed in akkaGrpcCodeGeneratorSettings's description
   private def parseParameters(params: String): GeneratorParams =
     params.split(",").map(_.trim).filter(_.nonEmpty).foldLeft[GeneratorParams](GeneratorParams()) {
-      case (p, "java_conversions")      => p.copy(javaConversions = true)
-      case (p, "flat_package")          => p.copy(flatPackage = true)
-      case (p, "grpc")                  => p.copy(grpc = true)
-      case (p, "single_line_to_string") => p.copy(singleLineToProtoString = true)
-      case (x, _)                       => x
+      case (p, "java_conversions")            => p.copy(javaConversions = true)
+      case (p, "flat_package")                => p.copy(flatPackage = true)
+      case (p, "single_line_to_string")       => p.copy(singleLineToProtoString = true) // for backward-compatibility
+      case (p, "single_line_to_proto_string") => p.copy(singleLineToProtoString = true)
+      case (p, "ascii_format_to_string")      => p.copy(asciiFormatToString = true)
+      case (p, "no_lenses")                   => p.copy(lenses = false)
+      case (p, "retain_source_code_info")     => p.copy(retainSourceCodeInfo = true)
+      case (x, _)                             => x
     }
 }

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -70,7 +70,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
     val akkaGrpcGenerators = settingKey[Seq[protocbridge.Generator]](
       "Generators to evaluate. Populated based on akkaGrpcGeneratedLanguages, akkaGrpcGeneratedSources and akkaGrpcExtraGenerators, but can be extended if needed")
     val akkaGrpcCodeGeneratorSettings = settingKey[Seq[String]](
-      "Boolean settings to pass to the code generators, empty (all false) by default. ScalaPB settings: java_conversions, flat_package, single_line_to_proto_string, ascii_format_to_string. Akka gRPC settings: server_power_apis")
+      "Boolean settings to pass to the code generators, empty (all false) by default. ScalaPB settings: java_conversions, flat_package, single_line_to_proto_string, ascii_format_to_string, no_lenses, retain_source_code_info. Akka gRPC settings: server_power_apis, use_play_actions.")
   }
 
   object autoImport extends Keys


### PR DESCRIPTION
* remove `grpc`, confusing within Akka gRPC as it's ScalaPB's
* align `single_line_to_proto_string` with ScalaPB, keeping the previous flag name for backward compatibility
* support ScalaPB's latest flags: `ascii_format_to_string`, `no_lenses` & `retain_source_code_info`
* reflect the possible values in the settings description