### PR TITLE
prevent closing comment early by ensure heading whitespace

### DIFF
--- a/codegen/src/main/twirl/templates/JavaCommon/ApiInterface.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaCommon/ApiInterface.scala.txt
@@ -11,13 +11,11 @@ import akka.grpc.ProtobufSerializer;
 import akka.grpc.javadsl.GoogleProtobufSerializer;
 
 @for(comment <- service.comment) {/**
- *@{comment.replaceAll("\n", "\n *")}
- */}
+@{java.util.regex.Pattern.compile("^\\s?(.*)$", java.util.regex.Pattern.MULTILINE).matcher(comment).replaceAll(" * $1")} */}
 public interface @{service.name} {
   @for(method <- service.methods) {
   @for(comment <- method.comment) {/**
-   *@{comment.replaceAll("\n", "\n   *")}
-   */}
+@{java.util.regex.Pattern.compile("^\\s?(.*)$", java.util.regex.Pattern.MULTILINE).matcher(comment).replaceAll("   * $1")}   */}
   @{method.getReturnType} @{method.name}(@{method.getParameterType} in);
   }
 

--- a/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
@@ -8,13 +8,11 @@
 package @service.packageName
 
 @for(comment <- service.comment) {/**
- *@{comment.replaceAll("\n", "\n *")}
- */}
+@{java.util.regex.Pattern.compile("^\\s?(.*)$", java.util.regex.Pattern.MULTILINE).matcher(comment).replaceAll(" * $1")} */}
 trait @{service.name} {
   @for(method <- service.methods) {
   @for(comment <- method.comment) {/**
-   *@{comment.replaceAll("\n", "\n   *")}
-   */}
+@{java.util.regex.Pattern.compile("^\\s?(.*)$", java.util.regex.Pattern.MULTILINE).matcher(comment).replaceAll("   * $1")}   */}
   def @{method.name}(in: @method.parameterType): @method.returnType
   }
 }

--- a/plugin-tester-java/src/main/protobuf/helloworld.proto
+++ b/plugin-tester-java/src/main/protobuf/helloworld.proto
@@ -6,9 +6,13 @@ option java_outer_classname = "HelloWorldProto";
 
 package helloworld;
 
-// The greeting service definition.
+////////////////////////////////////// The greeting service definition.
 service GreeterService {
-    // Sends a greeting
+    //////////////////////
+    // Sends a greeting //
+    ////////*****/////////
+    //      HELLO       //
+    ////////*****/////////
     rpc SayHello (HelloRequest) returns (HelloReply) {}
 
     // Comment spanning

--- a/plugin-tester-scala/src/main/protobuf/helloworld.proto
+++ b/plugin-tester-scala/src/main/protobuf/helloworld.proto
@@ -9,9 +9,13 @@ package helloworld;
 //#options
 
 //#services
-// The greeting service definition.
+////////////////////////////////////// The greeting service definition.
 service GreeterService {
-    // Sends a greeting
+    //////////////////////
+    // Sends a greeting //
+    ////////*****/////////
+    //      HELLO       //
+    ////////*****/////////
     rpc SayHello (HelloRequest) returns (HelloReply) {}
 
     // Comment spanning


### PR DESCRIPTION
Fixes #652 by replicating the logic of https://github.com/bjaglin/ScalaPB/blob/ceebc91a36929f4a595bc4c5ed7be65cd4fba59d/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala#L1892.

`GreeterService.java` before/after the fix:
```diff
 // Generated by Akka gRPC. DO NOT EDIT.
 package example.myapp.helloworld.grpc;
 
 import akka.grpc.ProtobufSerializer;
 import akka.grpc.javadsl.GoogleProtobufSerializer;
 
 /**
- *//////////////////////////////////// The greeting service definition.
- *
+ * //////////////////////////////////// The greeting service definition.
  */
 public interface GreeterService {
   
   /**
-   *////////////////////
+   * ////////////////////
    * Sends a greeting //
-   *//////&#42;****&#47;////////
+   * //////&#42;****&#47;////////
    *      HELLO       //
-   *//////&#42;****&#47;////////
-   *
+   * //////&#42;****&#47;////////
    */
   java.util.concurrent.CompletionStage<example.myapp.helloworld.grpc.HelloReply> sayHello(example.myapp.helloworld.grpc.HelloRequest in);
   
   /**
    * Comment spanning
    * on several lines
-   *
    */
   java.util.concurrent.CompletionStage<example.myapp.helloworld.grpc.HelloReply> itKeepsTalking(akka.stream.javadsl.Source<example.myapp.helloworld.grpc.HelloRequest, akka.NotUsed> in);
   
   /**
-   *
-   * C style comments
-   *
+   *  C style comments
    */
   akka.stream.javadsl.Source<example.myapp.helloworld.grpc.HelloReply, akka.NotUsed> itKeepsReplying(example.myapp.helloworld.grpc.HelloRequest in);
   
   /**
    * C style comments
    * on several lines
-   * with non-empty heading/trailing line 
-   */
+   * with non-empty heading/trailing line    */
   akka.stream.javadsl.Source<example.myapp.helloworld.grpc.HelloReply, akka.NotUsed> streamHellos(akka.stream.javadsl.Source<example.myapp.helloworld.grpc.HelloRequest, akka.NotUsed> in);
```

`GreeterService.scala` before/after the fix:
```diff
 package example.myapp.helloworld.grpc
 
 /**
- *#services
- *//////////////////////////////////// The greeting service definition.
- *
+ * #services
+ * //////////////////////////////////// The greeting service definition.
  */
 trait GreeterService {
   
   /**
-   *////////////////////
+   * ////////////////////
    * Sends a greeting //
-   *//////&#42;****&#47;////////
+   * //////&#42;****&#47;////////
    *      HELLO       //
-   *//////&#42;****&#47;////////
-   *
+   * //////&#42;****&#47;////////
    */
   def sayHello(in: example.myapp.helloworld.grpc.HelloRequest): scala.concurrent.Future[example.myapp.helloworld.grpc.HelloReply]
   
   /**
    * Comment spanning
    * on several lines
-   *
    */
   def itKeepsTalking(in: akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.HelloRequest, akka.NotUsed]): scala.concurrent.Future[example.myapp.helloworld.grpc.HelloReply]
   
   /**
-   *
-   * C style comments
-   *
+   *  C style comments
    */
   def itKeepsReplying(in: example.myapp.helloworld.grpc.HelloRequest): akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.HelloReply, akka.NotUsed]
   
   /**
    * C style comments
    * on several lines
-   * with non-empty heading/trailing line 
-   */
+   * with non-empty heading/trailing line    */
   def streamHellos(in: akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.HelloRequest, akka.NotUsed]): akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.HelloReply, akka.NotUsed]
   
 }
```