### PR TITLE
Use a dedicated managed sources directory

### DIFF
--- a/runtime/src/main/scala/akka/grpc/GrpcServiceException.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcServiceException.scala
@@ -14,14 +14,14 @@ class GrpcServiceException(val status: Status, val metadata: Metadata) extends R
 
   require(!status.isOk, "Use GrpcServiceException in case of failure, not as a flow control mechanism.")
 
-  def this(status: Status) {
+  def this(status: Status) = {
     this(status, MetadataBuilder.empty)
   }
 
   /**
    * Java API: Constructs a service exception which includes response metadata.
    */
-  def this(status: Status, metadata: javadsl.Metadata) {
+  def this(status: Status, metadata: javadsl.Metadata) = {
     this(status, metadata.asScala)
   }
 

--- a/runtime/src/main/scala/akka/grpc/Trailers.scala
+++ b/runtime/src/main/scala/akka/grpc/Trailers.scala
@@ -12,11 +12,11 @@ import akka.grpc.javadsl.{ Metadata => jMetadata }
 
 @ApiMayChange
 class Trailers(val status: Status, val metadata: Metadata) {
-  def this(status: Status) {
+  def this(status: Status) = {
     this(status, MetadataBuilder.empty)
   }
 
-  def this(status: Status, metadata: jMetadata) {
+  def this(status: Status, metadata: jMetadata) = {
     this(status, metadata.asScala)
   }
 

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -93,16 +93,15 @@ object AkkaGrpcPlugin extends AutoPlugin {
         // hack to get our (dirty) hands on a proper sbt logger before running the generators
         generatorLogger.logger = streams.value.log
         (PB.recompile in Test).value
-      },
-      target in akkaGrpcCodeGeneratorSettings := crossTarget.value / "akka-grpc")
+      })
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
       (if (config == Compile || config == Test) Seq() // already supported by sbt-protoc by default
        else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
-        target in akkaGrpcCodeGeneratorSettings := (target in akkaGrpcCodeGeneratorSettings).value / Defaults
-            .nameForSrc(configuration.value.name),
+        target in akkaGrpcCodeGeneratorSettings := crossTarget.value / "akka-grpc" / Defaults.nameForSrc(
+            configuration.value.name),
         managedSourceDirectories += (target in akkaGrpcCodeGeneratorSettings).value,
         unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,
         watchSources in Defaults.ConfigGlobal ++= (sources in PB.recompile).value,

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -93,13 +93,17 @@ object AkkaGrpcPlugin extends AutoPlugin {
         // hack to get our (dirty) hands on a proper sbt logger before running the generators
         generatorLogger.logger = streams.value.log
         (PB.recompile in Test).value
-      })
+      },
+      target in akkaGrpcCodeGeneratorSettings := crossTarget.value / "akka-grpc")
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
       (if (config == Compile || config == Test) Seq() // already supported by sbt-protoc by default
        else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
+        target in akkaGrpcCodeGeneratorSettings := (target in akkaGrpcCodeGeneratorSettings).value / Defaults
+            .nameForSrc(configuration.value.name),
+        managedSourceDirectories += (target in akkaGrpcCodeGeneratorSettings).value,
         unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,
         watchSources in Defaults.ConfigGlobal ++= (sources in PB.recompile).value,
         akkaGrpcGenerators := {
@@ -112,9 +116,11 @@ object AkkaGrpcPlugin extends AutoPlugin {
         },
         // configure the proto gen automatically by adding our codegen:
         PB.targets ++=
-          targetsFor(sourceManaged.value, akkaGrpcCodeGeneratorSettings.value, akkaGrpcGenerators.value),
+          targetsFor(
+            (target in akkaGrpcCodeGeneratorSettings).value,
+            akkaGrpcCodeGeneratorSettings.value,
+            akkaGrpcGenerators.value),
         PB.protoSources += sourceDirectory.value / "proto") ++
-
       inTask(PB.recompile)(Seq(
         includeFilter := GlobFilter("*.proto"),
         managedSourceDirectories := Nil,

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/test
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/test
@@ -1,7 +1,7 @@
 > compile
 
-$ exists target/scala-2.12/src_managed
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloReply.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java
+$ exists target/scala-2.12/akka-grpc
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/test
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/test
@@ -1,7 +1,7 @@
 > compile
 
-$ exists target/scala-2.12/src_managed
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloReply.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java
+$ exists target/scala-2.12/akka-grpc
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
@@ -1,3 +1,3 @@
 > compile
 
-$ exists target/scala-2.12/src_managed/main/helloworld/Helloworld.java
+$ exists target/scala-2.12/akka-grpc/main/helloworld/Helloworld.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/test
@@ -1,9 +1,9 @@
 > compile
 
-$ exists target/scala-2.12/src_managed
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.scala
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloworldProto.scala
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala
+$ exists target/scala-2.12/akka-grpc
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
 
 # This will for example detect when we publish generated code that is
 # already in scalapb-runtime

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
@@ -1,15 +1,15 @@
 > test:compile
 
 # the Scala server was generated in Compile
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
 
 # only the Scala client was generated in Test
--$ exists target/scala-2.12/src_managed/test/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
-$ exists target/scala-2.12/src_managed/test/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+-$ exists target/scala-2.12/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+$ exists target/scala-2.12/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceClient.scala
 
 > it:protocGenerate
 
 # only the Java server was generated in IntegrationTest
--$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
--$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceClient.scala
-$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceHandlerFactory.java
+-$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+-$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandlerFactory.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/test
@@ -1,6 +1,6 @@
 > compile
 
-$ exists target/scala-2.12/src_managed
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.scala
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloworldProto.scala
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala
+$ exists target/scala-2.12/akka-grpc/main
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
@@ -1,6 +1,6 @@
 > compile
 
-$ exists target/scala-2.12/src_managed
-$ exists target/scala-2.12/src_managed/main/helloworld/HelloRequest.scala
-$ exists target/scala-2.12/src_managed/main/helloworld/HelloworldProto.scala
-$ exists target/scala-2.12/src_managed/main/helloworld/GreeterService.scala
+$ exists target/scala-2.12/akka-grpc
+$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloworldProto.scala
+$ exists target/scala-2.12/akka-grpc/main/helloworld/GreeterService.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
@@ -1,8 +1,8 @@
 > compile
 
 $ exists target/scala-2.12/resource_managed/main/js/hellorequest.js
-$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
 
 > test:compile
 $ exists target/scala-2.12/resource_managed/test/js/echomessage.js
-$ exists target/scala-2.12/src_managed/test/example/myapp/echo/grpc/EchoMessage.scala
+$ exists target/scala-2.12/akka-grpc/test/example/myapp/echo/grpc/EchoMessage.scala


### PR DESCRIPTION
Fixes #672

Since sbt-protoc deletes all files in its target directories, it's inappropriate to use the shared sourceManaged directory, because it will potentially clobber the files of other source generators immediately after they've generated them.

This gives akka-grpc its own target directory, which is managed heirarchically using `target in akkaGrpcCodeGeneratorSettings`.  Convention would say that it should be `target in PB.recompile`, since usually you scope the target setting to the task that generates to it, but since Akka doesn't provide `PB.recompile` itself, and sbt-protoc may some day decide to define `target in PB.recompile` for its own purposes, it's safer to use something that akka-grpc provides itself.  

So, the target directory is set to `target/scala_2.12/akka-grpc` at the no configuration scope, and then redefined in each configuration (test, compile) to be that plus `/main` or `/test`.