### PR TITLE
Store the gradle plugin logfile inside the build directory

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -7,8 +7,7 @@ import org.gradle.api.artifacts.DependencyResolutionListener
 import org.gradle.api.artifacts.ResolvableDependencies
 
 import java.nio.file.Files
-import java.util.regex.Matcher
-import java.util.regex.Pattern
+import java.nio.file.Path
 
 class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
 
@@ -27,6 +26,8 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
         def extension = project.extensions.create('akkaGrpc', AkkaGrpcPluginExtension, project)
         String assemblySuffix = SystemUtils.IS_OS_WINDOWS ? "bat" : "jar"
         String assemblyClassifier = SystemUtils.IS_OS_WINDOWS ? "bat" : "assembly"
+
+        Path logFile = project.buildDir.toPath().resolve("akka-grpc-gradle-plugin.log")
 
         project.configure(project) {
             boolean isScala = "${extension.language}".toLowerCase() == "scala"
@@ -95,7 +96,7 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
                                 option "server_power_apis=${extension.serverPowerApis}"
                                 option "use_play_actions=${extension.usePlayActions}"
                                 option "extra_generators=${extension.extraGenerators.join(';')}"
-                                option "logfile=build/akka-grpc-gradle-plugin.log"
+                                option "logfile=${project.projectDir.toPath().relativize(logFile).toString()}"
                                 if (extension.generatePlay) {
                                     option "generate_play=true"
                                 }
@@ -116,7 +117,7 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
             println project.getTasks()
             project.task("printProtocLogs") {
                 doLast {
-                    Files.lines(logFile.toPath()).forEach { line ->
+                    Files.lines(logFile).forEach { line ->
                         if (line.startsWith("[info]")) logger.info(line.substring(7))
                         else if (line.startsWith("[debug]")) logger.debug(line.substring(7))
                         else if (line.startsWith("[warn]")) logger.warn(line.substring(6))

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -3,7 +3,6 @@ package akka.grpc.gradle
 import org.apache.commons.lang.SystemUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolutionListener
 import org.gradle.api.artifacts.ResolvableDependencies
 
@@ -20,21 +19,6 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
 
     Project project
 
-    private String renderLogPath(File logFile) {
-        String candidate = logFile.toPath().toAbsolutePath().toRealPath().toString()
-        if (!SystemUtils.IS_OS_WINDOWS) {
-            return candidate
-        } else {
-            Pattern ptnWinPath = Pattern.compile("(?i)^[a-z]:(\\\\.+)")
-            Matcher matcher = ptnWinPath.matcher(candidate)
-            if (matcher.matches()) {
-                return matcher.group(1).replace("\\", "/")
-            } else {
-                return candidate.replace("\\", "/")
-            }
-        }
-    }
-
     @Override
     void apply(Project project) {
         this.project = project
@@ -47,8 +31,6 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
         project.configure(project) {
             boolean isScala = "${extension.language}".toLowerCase() == "scala"
             boolean isJava = "${extension.language}".toLowerCase() == "java"
-            File logFile = File.createTempFile("akka-grpc-gradle", ".log")
-            logFile.deleteOnExit()
 
             apply plugin: 'com.google.protobuf'
             protobuf {
@@ -113,7 +95,7 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
                                 option "server_power_apis=${extension.serverPowerApis}"
                                 option "use_play_actions=${extension.usePlayActions}"
                                 option "extra_generators=${extension.extraGenerators.join(';')}"
-                                option "logfile=${renderLogPath(logFile)}"
+                                option "logfile=build/akka-grpc-gradle-plugin.log"
                                 if (extension.generatePlay) {
                                     option "generate_play=true"
                                 }


### PR DESCRIPTION
## Purpose

The location of the logfile is changed from the users temp directory to the gradle build directory.
This in order to prevent an issues when using the plugin on Windows while the project folder is not on `C:\`

## References

References #669

## Changes

- Change the logfile location from the users temp directory to the gradle build directory
- Log file is no longer created when the plugin is configured

## Background Context

As discussed in #669, there is a split on `:` when passing the logfile location, which complicates the approach of passing a Windows path with a drive letter. Writing the logfile to the gradle build directory seems the next best thing when trying to get it all to work.