### PR TITLE
Bumps Akka to 2.6.0-M7

### DIFF
--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadClient.java
@@ -24,7 +24,7 @@ import akka.actor.ActorSystem;
 import akka.grpc.GrpcClientSettings;
 import akka.grpc.benchmarks.Utils;
 import akka.grpc.benchmarks.proto.*;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
 import akka.stream.javadsl.Sink;
@@ -77,7 +77,7 @@ class LoadClient {
     this.config = config;
 
     this.system = ActorSystem.create("AsyncClient");
-    this.mat = ActorMaterializer.create(system);
+    this.mat = Materializer.matFromSystem(system);
 
     // Create the clients
     clients = new BenchmarkServiceClient[config.getClientChannels()];

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadWorker.java
@@ -29,7 +29,7 @@ import akka.grpc.benchmarks.proto.WorkerServiceHandlerFactory;
 import akka.http.javadsl.ConnectWithHttps;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import com.typesafe.config.Config;
@@ -63,7 +63,7 @@ public class LoadWorker {
   }
 
   public CompletionStage<ServerBinding> start() throws Exception {
-    Materializer mat = ActorMaterializer.create(system);
+    Materializer mat = Materializer.matFromSystem(system);
 
     WorkerServiceImpl impl = new WorkerServiceImpl(mat);
 

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncClient.java
@@ -27,7 +27,7 @@ import akka.grpc.benchmarks.proto.BenchmarkServiceClient;
 import akka.grpc.benchmarks.proto.Messages.Payload;
 import akka.grpc.benchmarks.proto.Messages.SimpleRequest;
 import akka.grpc.benchmarks.proto.Messages.SimpleResponse;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import akka.stream.OverflowStrategy;
 import akka.stream.javadsl.Sink;
@@ -62,7 +62,7 @@ public class AsyncClient {
     this.config = config;
 
     this.system = ActorSystem.create("AsyncClient");
-    this.mat = ActorMaterializer.create(system);
+    this.mat = Materializer.matFromSystem(system);
   }
 
   /**

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
@@ -27,7 +27,7 @@ import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.ConnectWithHttps;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.UseHttp2;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.KillSwitches;
 import akka.stream.Materializer;
 import akka.stream.SharedKillSwitch;
@@ -74,7 +74,7 @@ public class AsyncServer {
 
     system = ActorSystem.create("AsyncServer", conf);
 
-    Materializer mat = ActorMaterializer.create(system);
+    Materializer mat = Materializer.matFromSystem(system);
 
     benchmarkService = new BenchmarkServiceImpl(mat);
 

--- a/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -24,7 +24,7 @@ import akka.grpc.benchmarks.Utils;
 import akka.grpc.benchmarks.proto.Control;
 import akka.grpc.benchmarks.proto.Stats;
 import akka.grpc.benchmarks.proto.WorkerServiceClient;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.KillSwitches;
 import akka.stream.Materializer;
 import akka.stream.SharedKillSwitch;
@@ -72,7 +72,7 @@ public class LoadWorkerTest extends JUnitSuite {
     Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
     system = ActorSystem.create("LoadWorkerTest", conf);
-    mat = ActorMaterializer.create(system);
+    mat = Materializer.matFromSystem(system);
 
     int port = Utils.pickUnusedPort();
     worker = new LoadWorker(system, port, 0);

--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -10,7 +10,6 @@ package @service.packageName;
 import akka.grpc.internal.*;
 import akka.grpc.GrpcClientSettings;
 import akka.grpc.javadsl.AkkaGrpcClient;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 import io.grpc.ManagedChannel;
@@ -42,9 +41,7 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
         this.clientState = new ClientState(settings, mat, ec);
         this.options = NettyClientUtils.callOptions(settings);
 
-        if (mat instanceof ActorMaterializer) {
-          ((ActorMaterializer) mat).system().getWhenTerminated().whenComplete((v, e) -> close());
-        }
+        mat.system().getWhenTerminated().whenComplete((v, e) -> close());
       }
 
   @for(method <- service.methods) {

--- a/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcClientJava.java
+++ b/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcClientJava.java
@@ -5,7 +5,7 @@
 package akka.grpc.interop;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import akka.grpc.interop.GrpcClient;
 import io.grpc.internal.testing.TestUtils;
@@ -31,7 +31,7 @@ public class AkkaGrpcClientJava extends GrpcClient {
     final Settings settings = Settings.parseArgs(args);
 
     final ActorSystem sys = ActorSystem.create("AkkaGrpcClientJava");
-    final Materializer mat = ActorMaterializer.create(sys);
+    final Materializer mat = Materializer.matFromSystem(sys);
 
     final TestServiceClient client = new TestServiceClient(clientTesterFactory.apply(settings, mat, sys));
     client.setUp();

--- a/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcServerJava.java
+++ b/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcServerJava.java
@@ -46,7 +46,7 @@ public class AkkaGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBin
     ActorSystem sys = ActorSystem.create(
       "akka-grpc-server-java",
       ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on"));
-    Materializer mat = ActorMaterializer.create(sys);
+    Materializer mat = Materializer.matFromSystem(sys);
 
     Function<HttpRequest, CompletionStage<HttpResponse>> testService = handlerFactory.apply(mat, sys);
 

--- a/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcClientScala.scala
+++ b/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcClientScala.scala
@@ -6,7 +6,7 @@ package akka.grpc.interop
 
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import io.grpc.internal.testing.TestUtils
 import io.grpc.testing.integration2.{ ClientTester, Settings, TestServiceClient }
 
@@ -21,7 +21,7 @@ final case class AkkaGrpcClientScala(clientTesterFactory: Settings => Materializ
     val settings = Settings.parseArgs(args)
 
     implicit val sys = ActorSystem()
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
 
     val client = new TestServiceClient(clientTesterFactory(settings)(mat)(sys))
     client.setUp()

--- a/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcServerScala.scala
+++ b/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcServerScala.scala
@@ -17,7 +17,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ Http2, HttpsConnectionContext }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import io.grpc.internal.testing.TestUtils
 import javax.net.ssl.{ KeyManagerFactory, SSLContext }
 
@@ -31,7 +31,7 @@ case class AkkaGrpcServerScala(serverHandlerFactory: Materializer => ActorSystem
 
   override def start() = {
     implicit val sys = ActorSystem()
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
     implicit val ec = sys.dispatcher
 
     val testService = serverHandlerFactory(mat)(sys)

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcMarshallingSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcMarshallingSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.ActorSystem
 import akka.grpc.scaladsl.headers.`Message-Encoding`
 import akka.grpc.{ Grpc, Gzip }
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import io.grpc.{ Status, StatusException }
 import io.grpc.testing.integration.messages.{ BoolValue, SimpleRequest }
@@ -26,7 +26,7 @@ class GrpcMarshallingSpec extends WordSpec with Matchers {
     val message = SimpleRequest(responseCompressed = Some(BoolValue.of(true)))
     implicit val serializer = TestService.Serializers.SimpleRequestSerializer
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(system)
     val awaitTimeout = 10.seconds
     val zippedBytes = Grpc.encodeFrame(Grpc.compressed, Gzip.compress(serializer.serialize(message)))
 

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -6,7 +6,7 @@ package example.myapp;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.*;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -32,7 +32,7 @@ class CombinedServer {
       Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
       ActorSystem sys = ActorSystem.create("HelloWorld", conf);
-      Materializer mat = ActorMaterializer.create(sys);
+      Materializer mat = Materializer.matFromSystem(sys);
 
       //#concatOrNotFound
       Function<HttpRequest, CompletionStage<HttpResponse>> greeterService =

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
@@ -17,7 +17,7 @@ import io.grpc.StatusRuntimeException;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import akka.grpc.GrpcClientSettings;
@@ -31,7 +31,7 @@ class GreeterClient {
     int serverPort = 8080;
 
     ActorSystem system = ActorSystem.create("HelloWorldClient");
-    Materializer materializer = ActorMaterializer.create(system);
+    Materializer materializer = Materializer.matFromSystem(system);
 
     GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);
     GreeterServiceClient client = null;

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
@@ -7,7 +7,7 @@ package example.myapp.helloworld;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.*;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -33,7 +33,7 @@ class GreeterServer {
   }
 
   public static CompletionStage<ServerBinding> run(ActorSystem sys) throws Exception {
-    Materializer mat = ActorMaterializer.create(sys);
+    Materializer mat = Materializer.matFromSystem(sys);
 
     // Instantiate implementation
     GreeterService impl = new GreeterServiceImpl(mat);

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
@@ -16,7 +16,6 @@ import io.grpc.StatusRuntimeException;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import akka.grpc.GrpcClientSettings;
@@ -30,7 +29,7 @@ class LiftedGreeterClient {
     int serverPort = 8080;
 
     ActorSystem system = ActorSystem.create("HelloWorldClient");
-    Materializer materializer = ActorMaterializer.create(system);
+    Materializer materializer = Materializer.matFromSystem(system);
 
     GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);
     GreeterServiceClient client = null;

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -35,7 +35,7 @@ class PowerGreeterServer {
   }
 
   public static CompletionStage<ServerBinding> run(ActorSystem sys) throws Exception {
-      Materializer mat = ActorMaterializer.create(sys);
+      Materializer mat = Materializer.matFromSystem(sys);
 
       // Instantiate implementation
       GreeterServicePowerApi impl = new GreeterServicePowerApiImpl(mat);

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ HttpMethods, HttpRequest, HttpResponse, StatusCodes }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import example.myapp.helloworld.grpc.{ GreeterService, GreeterServiceHandlerFactory }
 import io.grpc.Status
@@ -25,7 +25,7 @@ class ErrorReportingSpec extends WordSpec with Matchers with ScalaFutures with B
   override implicit val patienceConfig = PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
 
   "A gRPC server" should {
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
 
     val handler = GreeterServiceHandlerFactory.create(new GreeterServiceImpl(mat), mat, sys)
     val binding = {

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
@@ -12,7 +12,7 @@ import scala.language.postfixOps
 
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
@@ -37,7 +37,7 @@ class JGreeterServiceSpec extends Matchers with WordSpecLike with BeforeAndAfter
 
   val clientSystem = ActorSystem("GreeterClient")
 
-  implicit val mat = ActorMaterializer.create(clientSystem)
+  implicit val mat = Materializer.matFromSystem(clientSystem)
   implicit val ec = clientSystem.dispatcher
 
   val clients = Seq(8080, 8081).map { port =>

--- a/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
@@ -10,7 +10,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.{ Http, HttpConnectionContext }
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import example.myapp.helloworld._
@@ -30,7 +30,7 @@ object CombinedServer {
       .parseString("akka.http.server.preview.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     implicit val sys: ActorSystem = ActorSystem("HelloWorld", conf)
-    implicit val mat: Materializer = ActorMaterializer()
+    implicit val mat: Materializer = Materializer.matFromSystem(sys)
     implicit val ec: ExecutionContext = sys.dispatcher
 
     //#concatOrNotFound

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterClient.scala
@@ -6,7 +6,7 @@ package example.myapp.helloworld
 
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import example.myapp.helloworld.grpc._
 
 import scala.concurrent.Await
@@ -17,7 +17,7 @@ object AuthenticatedGreeterClient {
   def main(args: Array[String]): Unit = {
     // Boot akka
     implicit val sys = ActorSystem("HelloWorldClient")
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
     implicit val ec = sys.dispatcher
 
     // Take details how to connect to the service from the config.

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.{ Directive0, Route, RouteResult }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.{ Http, Http2, HttpConnectionContext }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import example.myapp.helloworld.grpc._
 
@@ -35,7 +35,7 @@ class AuthenticatedGreeterServer(system: ActorSystem) {
   def run(): Future[Http.ServerBinding] = {
     // Akka boot up code
     implicit val sys: ActorSystem = system
-    implicit val mat: Materializer = ActorMaterializer()
+    implicit val mat: Materializer = Materializer.matFromSystem(sys)
     implicit val ec: ExecutionContext = sys.dispatcher
 
     // Create service handlers

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
@@ -8,7 +8,7 @@ package example.myapp.helloworld
 import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import example.myapp.helloworld.grpc._
 
@@ -21,7 +21,7 @@ object GreeterClient {
   def main(args: Array[String]): Unit = {
     // Boot akka
     implicit val sys = ActorSystem("HelloWorldClient")
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
     implicit val ec = sys.dispatcher
 
     // Take details how to connect to the service from the config.
@@ -35,7 +35,7 @@ object GreeterClient {
     runStreamingReplyExample()
     runStreamingRequestReplyExample()
 
-    sys.scheduler.schedule(1.second, 1.second) {
+    sys.scheduler.scheduleWithFixedDelay(1.second, 1.second) { () =>
       runSingleRequestReplyExample()
     }
 

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
@@ -8,7 +8,7 @@ package example.myapp.helloworld
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ Http, HttpConnectionContext }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import example.myapp.helloworld.grpc._
 
@@ -33,7 +33,7 @@ class GreeterServer(system: ActorSystem) {
   def run(): Future[Http.ServerBinding] = {
     // Akka boot up code
     implicit val sys: ActorSystem = system
-    implicit val mat: Materializer = ActorMaterializer()
+    implicit val mat: Materializer = Materializer.matFromSystem(sys)
     implicit val ec: ExecutionContext = sys.dispatcher
 
     // Create service handlers

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LiftedGreeterClient.scala
@@ -13,7 +13,7 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 
 import example.myapp.helloworld.grpc._
@@ -23,7 +23,7 @@ object LiftedGreeterClient {
   def main(args: Array[String]): Unit = {
 
     implicit val sys = ActorSystem("HelloWorldClient")
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
     implicit val ec = sys.dispatcher
 
     val clientSettings = GrpcClientSettings.fromConfig(GreeterService.name)
@@ -34,7 +34,7 @@ object LiftedGreeterClient {
     streamingReply()
     streamingRequestReply()
 
-    sys.scheduler.schedule(1.second, 1.second) {
+    sys.scheduler.scheduleWithFixedDelay(1.second, 1.second) { () =>
       Try(singleRequestReply())
     }
 

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/PowerGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/PowerGreeterServer.scala
@@ -8,7 +8,7 @@ package example.myapp.helloworld
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ Http, HttpConnectionContext }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import example.myapp.helloworld.grpc._
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -18,7 +18,7 @@ class PowerGreeterServer(system: ActorSystem) {
   def run(): Future[Http.ServerBinding] = {
     // Akka boot up code
     implicit val sys: ActorSystem = system
-    implicit val mat: Materializer = ActorMaterializer()
+    implicit val mat: Materializer = Materializer.matFromSystem(sys)
     implicit val ec: ExecutionContext = sys.dispatcher
 
     // Create service handlers

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.{ Http, HttpConnectionContext, UseHttp2 }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import example.myapp.helloworld.grpc.{ GreeterService, GreeterServiceHandler }
 import io.grpc.Status
@@ -25,7 +25,7 @@ class ErrorReportingSpec extends WordSpec with Matchers with ScalaFutures with B
   override implicit val patienceConfig = PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
 
   "A gRPC server" should {
-    implicit val mat = ActorMaterializer()
+    implicit val mat = Materializer.matFromSystem(sys)
 
     val binding = Http()
       .bindAndHandleAsync(

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
@@ -36,7 +36,7 @@ class GreeterSpec extends Matchers with WordSpecLike with BeforeAndAfterAll with
 
   val clientSystem = ActorSystem("GreeterClient")
 
-  implicit val mat = ActorMaterializer.create(clientSystem)
+  implicit val mat = Materializer.matFromSystem(clientSystem)
   implicit val ec = clientSystem.dispatcher
 
   val clients = Seq(8080, 8081).map { port =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val scala212 = "2.12.8"
     val scala213 = "2.13.0"
 
-    val akka = "2.5.25"
+    val akka = "2.6.0-M7"
     val akkaHttp = "10.1.10"
 
     val grpc = "1.24.0" // checked synced by GrpcVersionSyncCheckPlugin

--- a/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.Done
 import akka.annotation.InternalApi
 import akka.grpc.GrpcClientSettings
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import io.grpc.ManagedChannel
 
 import scala.annotation.tailrec
@@ -38,11 +38,7 @@ final class ClientState(settings: GrpcClientSettings, channelFactory: GrpcClient
   private val closing = new AtomicReference[Option[Future[Done]]](None)
   private val closeDemand: Promise[Done] = Promise[Done]()
 
-  mat match {
-    case m: ActorMaterializer =>
-      m.system.whenTerminated.foreach(_ => close())(ex)
-    case _ =>
-  }
+  mat.system.whenTerminated.foreach(_ => close())(ex)
 
   def withChannel[A](f: Future[ManagedChannel] => A): A =
     f {

--- a/runtime/src/test/scala/akka/grpc/internal/ClientStateSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/ClientStateSpec.scala
@@ -7,7 +7,7 @@ package akka.grpc.internal
 import akka.Done
 import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import io.grpc.ConnectivityState._
 import io.grpc.ManagedChannel
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
@@ -19,7 +19,7 @@ import scala.concurrent.{ Await, Future, Promise }
 class ClientStateSpec extends AsyncWordSpec with Matchers with ScalaFutures with Eventually with BeforeAndAfterAll {
 
   implicit val sys = ActorSystem()
-  implicit val mat = ActorMaterializer()
+  implicit val mat = Materializer.matFromSystem(sys)
   implicit val ec = sys.dispatcher
   implicit val patience = PatienceConfig(timeout = 5.seconds, interval = 150.milliseconds)
 

--- a/runtime/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
@@ -10,7 +10,7 @@ import akka.grpc.internal.GrpcResponseHelpers
 import akka.grpc.scaladsl.GrpcExceptionHandler.{ default, defaultMapper }
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model.HttpResponse
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ Matchers, WordSpec }
@@ -19,7 +19,7 @@ import scala.concurrent.{ ExecutionException, Future }
 
 class GrpcExceptionHandlerSpec extends WordSpec with Matchers with ScalaFutures {
   implicit val system = ActorSystem("Test")
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer = Materializer.matFromSystem(system)
 
   val expected: Function[Throwable, Status] = {
     case e: ExecutionException =>

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/src/main/scala/example/myapp/Main.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/src/main/scala/example/myapp/Main.scala
@@ -5,7 +5,7 @@ import java.security.{KeyStore, SecureRandom}
 import javax.net.ssl.{KeyManagerFactory, SSLContext}
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.grpc.scaladsl.ServiceHandler
 import akka.http.scaladsl.{Http2, HttpsConnectionContext}
 
@@ -17,7 +17,7 @@ import example.myapp.helloworld.grpc.GreeterServiceHandler
 
 object Main extends App {
   implicit val system = ActorSystem()
-  implicit val mat = ActorMaterializer()
+  implicit val mat = Materializer.matFromSystem(sys)
 
   val echoHandler = EchoServiceHandler.partial(new EchoServiceImpl)
   val greeterHandler = GreeterServiceHandler.partial(new GreeterServiceImpl)


### PR DESCRIPTION
Bumped Akka to M7 while investigating https://github.com/lagom/lagom-samples/pull/99#pullrequestreview-295416315

Didn't use `2.6.0-M8` (currently latest) because Play and Lagom still are on `-M7`.

