### PR TITLE
play nice on projects with other sbt-protoc-based plugins

### DIFF
--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -111,7 +111,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
         },
         // configure the proto gen automatically by adding our codegen:
         // FIXME: actually specifying separate Compile and Test target stub and languages does not work #194
-        PB.targets :=
+        PB.targets ++=
           targetsFor(sourceManaged.value, akkaGrpcCodeGeneratorSettings.value, akkaGrpcGenerators.value),
         PB.protoSources += sourceDirectory.value / "proto",
         // include proto files extracted from the dependencies with "protobuf" configuration by default


### PR DESCRIPTION
## Purpose

Updates the way generators are injected in the sbt plugin to coexist better with other plugins.

## References

Slightly related to https://github.com/akka/akka-grpc/issues/456 (although this one is about sbt settings of the project itself)

## Changes

I could not find in the original commit 7f2f96c or original issue https://github.com/akka/akka-grpc/issues/3 a reason for overriding `PB.targets`, so akka-grpc generators are now appended. Writing a scripted test to guard this behavior is hard as the order in which plugins are flattened is not guaranteed/deterministic.

## Background Context

When `AkkaGrpcPlugin` is added to a project with other plugins appending generators to `PB.targets`, these extra generators could be ignored, when `AkkaGrpcPlugin` was injected last (something which cannot be controlled, unless there is an explicit dependency from that plugin to `AkkaGrpcPlugin` via `AutoPlugin#requires`).