### PR TITLE
sbt: improve support for configurations

### DIFF
--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -17,6 +17,9 @@ What language to generate stubs for is also configurable:
 By default, the plugin will run generators against proto sources in the `Compile` directories, as well as the `Test` ones if
 there are some.
 
+The settings documented above can have different values for each configuration, allowing you for example to generate in `Test`
+(and in `Test` only) client stubs for a service defined in `Compile`.
+
 If you have other configurations with proto sources (for example `IntegrationTest`), you can enable the plugin on them:
 
 ```

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -12,6 +12,17 @@ What language to generate stubs for is also configurable:
 
 @@snip[x](/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt) { #languages-scala #languages-java #languages-both }
 
+### Configurations
+
+By default, the plugin will run generators against proto sources in the `Compile` directories, as well as the `Test` ones if
+there are some.
+
+If you have other configurations with proto sources (for example `IntegrationTest`), you can enable the plugin on them:
+
+```
+.settings(AkkaGrpcPlugin.configSettings(IntegrationTest))
+```
+
 ### Generating server "power APIs"
 
 To additionally generate server "power APIs" that have access to request metata, as described

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,8 +67,7 @@ object Dependencies {
   }
 
   object Plugins {
-    // This should follow the version of sbt-protoc ScalaPB is depending on
-    val sbtProtoc = "com.thesamet" % "sbt-protoc" % "0.99.19"
+    val sbtProtoc = "com.thesamet" % "sbt-protoc" % "0.99.26"
   }
 
   private val l = libraryDependencies

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -100,6 +100,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
+      sbtprotoc.ProtocPlugin.protobufConfigSettings ++
       Seq(
         unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,
         watchSources in Defaults.ConfigGlobal ++= (sources in PB.recompile).value,

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -114,10 +114,11 @@ object AkkaGrpcPlugin extends AutoPlugin {
             toGenerator(g, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger))
         },
         // configure the proto gen automatically by adding our codegen:
-        // FIXME: actually specifying separate Compile and Test target stub and languages does not work #194
         PB.targets ++=
           targetsFor(sourceManaged.value, akkaGrpcCodeGeneratorSettings.value, akkaGrpcGenerators.value),
         PB.protoSources += sourceDirectory.value / "proto",
+        // include proto files from parent configurations to be able to run extra generators or generators with different settings
+        PB.protoSources ++= PB.protoSources.all(ancestorConfigsFilter(config)).value.flatten,
         // include proto files extracted from the dependencies with "protobuf" configuration by default
         PB.protoSources += PB.externalIncludePath.value) ++
 
@@ -235,5 +236,12 @@ object AkkaGrpcPlugin extends AutoPlugin {
     }
 
     (outBao.toString("UTF-8"), errBao.toString("UTF-8"), t)
+  }
+
+  private def ancestorConfigsFilter(config: Configuration) = {
+    def ancestors(confs: Vector[Configuration]): Vector[Configuration] =
+      confs ++ confs.flatMap(conf => ancestors(conf.extendsConfigs))
+
+    ScopeFilter(configurations = inConfigurations(ancestors(config.extendsConfigs): _*))
   }
 }

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -1,0 +1,2 @@
+enablePlugins(AkkaGrpcPlugin)
+inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -1,2 +1,1 @@
 enablePlugins(AkkaGrpcPlugin)
-inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -1,1 +1,10 @@
 enablePlugins(AkkaGrpcPlugin)
+
+Compile / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Server)
+
+Test / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client)
+
+configs(IntegrationTest)
+Defaults.itSettings
+AkkaGrpcPlugin.configSettings(IntegrationTest)
+IntegrationTest / akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/main/protobuf/echo_message.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/main/protobuf/echo_message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.echo.grpc";
+
+package echo;
+
+message EchoMessage {
+    string payload = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/main/protobuf/helloworld.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.helloworld.grpc";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/test/protobuf/echo_service.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/test/protobuf/echo_service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.echo.grpc";
+
+package echo;
+
+import "echo_message.proto";
+
+// The greeting service definition.
+service EchoService {
+    rpc Echo (EchoMessage) returns (EchoMessage) {}
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/test/scala/example/myapp/echo/EchoServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/src/test/scala/example/myapp/echo/EchoServiceImpl.scala
@@ -1,0 +1,9 @@
+package example.myapp.echo
+
+import scala.concurrent.Future
+
+import example.myapp.echo.grpc._
+
+class EchoServiceImpl extends EchoService {
+  def echo(in: EchoMessage): Future[EchoMessage] = Future.successful(in)
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
@@ -1,1 +1,15 @@
 > test:compile
+
+# the Scala server was generated in Compile
+$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+
+# only the Scala client was generated in Test
+-$ exists target/scala-2.12/src_managed/test/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+$ exists target/scala-2.12/src_managed/test/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+
+> it:protocGenerate
+
+# only the Java server was generated in IntegrationTest
+-$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+-$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+$ exists target/scala-2.12/src_managed/it/example/myapp/helloworld/grpc/GreeterServiceHandlerFactory.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
@@ -1,0 +1,1 @@
+> test:compile


### PR DESCRIPTION
## Purpose

After integrating sbt-akka-grpc 0.7.2 in my project, I realized #696 introduced a regression for the `Test` configuration (`protoc` hangs every single time, because the same `JvmGenerator` is used multiple times, most likely resulting in a race on the FIFOs used to bridge `protoc` to the JVM generators), so I looked at how `Test` configuration could be better supported/tested.

## References

* Fix regression introduced by #696 
* Make updates so that #194 does not regress, enforce its behavior via scripted & document it

## Changes

See commit messages

## Background Context

* See https://github.com/thesamet/sbt-protoc/issues/108 for how/why this was fixed upstream.
* https://github.com/scalapb/protoc-bridge/pull/52 also "fixes" the problem as `protoc` no longer hangs, but hides the problem that generators are ran twice when they should not.
* The fix for https://github.com/thesamet/sbt-protoc/issues/108 actually broke the [out-of-the-box solution](https://github.com/akka/akka-grpc/issues/194#issuecomment-502995198) for #194, as `protocSources` are not inherited from one configuration (`Compile`) to its child (`Test`), so some extra `ScopeFilter` logic is required to be able to capture proto sources that are not part of the configuration itself to feed them to the local generators.