### PR TITLE
Enable the client-side load balancing provided by grpc-java

### DIFF
--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -20,6 +20,10 @@ akka.grpc.client."*" {
   # port to use if service-discovery-mechism is static or service discovery does not return a port
   port = 0
 
+  # pick_first or round_robin
+  # TODO: test more policies, add support by using io.grpc.internal.AbstractManagedChannelImplBuilder.defaultServiceConfig
+  grpc-load-balancing = ""
+
   deadline = infinite
   override-authority = ""
   user-agent = ""

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -88,16 +88,9 @@ object GrpcClientSettings {
     val port = clientConfiguration.getInt("port")
     val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").asScala
     val sd = serviceDiscoveryMechanism match {
-      case "static" =>
+      case "static" | "grpc-dns" =>
         val host = clientConfiguration.getString("host")
-        require(host.nonEmpty, "host can't be empty when service-discovery-mechanism is set to static")
-        // Required by the Discovery infrastructure, even when we use static discovery.
-        if (serviceName.isEmpty)
-          serviceName = "static"
-        staticServiceDiscovery(host, port)
-      case "grpc-dns" =>
-        val host = clientConfiguration.getString("host")
-        require(host.nonEmpty, "host can't be empty when service-discovery-mechanism is set to grpc-dns")
+        require(host.nonEmpty, "host can't be empty when service-discovery-mechanism is set to static or grpc-dns")
         // Required by the Discovery infrastructure, even when we use static discovery.
         if (serviceName.isEmpty)
           serviceName = "static"

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -60,7 +60,7 @@ object NettyClientUtils {
 
           builder = settings.grpcLoadBalancingType
             .map(builder.defaultLoadBalancingPolicy(_))
-            .map(_ => builder.nameResolverFactory(new DnsNameResolverProvider()))
+            .map(_.nameResolverFactory(new DnsNameResolverProvider()))
             .getOrElse(builder)
           builder = settings.overrideAuthority.map(builder.overrideAuthority(_)).getOrElse(builder)
           builder = settings.userAgent.map(builder.userAgent(_)).getOrElse(builder)


### PR DESCRIPTION
## Purpose

Allows to use client-side load balancing by providing akka-grpc configuration options

## Changes

- configuration options for client-side LB
- setting up NettyChannelBuilder with client-side LB

## Background Context

I just need client-side LB ;)
