### PR TITLE
Don't use unicode arrows in templates

### DIFF
--- a/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
@@ -26,14 +26,14 @@ object @{service.name}Marshallers {
   }
 
   implicit def unmarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer): FromRequestUnmarshaller[T] =
-    Unmarshaller((ec: ExecutionContext) ⇒ (req: HttpRequest) ⇒ GrpcMarshalling.unmarshal(req)(serializer, mat))
+    Unmarshaller((ec: ExecutionContext) => (req: HttpRequest) => GrpcMarshalling.unmarshal(req)(serializer, mat))
 
   implicit def toSourceUnmarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer): FromRequestUnmarshaller[akka.stream.scaladsl.Source[T, akka.NotUsed]] =
-    Unmarshaller((ec: ExecutionContext) ⇒ (req: HttpRequest) ⇒ GrpcMarshalling.unmarshalStream(req)(serializer, mat))
+    Unmarshaller((ec: ExecutionContext) => (req: HttpRequest) => GrpcMarshalling.unmarshalStream(req)(serializer, mat))
 
   implicit def marshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[T] =
-    Marshaller.opaque((response: T) ⇒ GrpcMarshalling.marshal(response)(serializer, mat, codec, system))
+    Marshaller.opaque((response: T) => GrpcMarshalling.marshal(response)(serializer, mat, codec, system))
 
   implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], mat: Materializer, codec: Codec, system: ActorSystem): ToResponseMarshaller[akka.stream.scaladsl.Source[T, akka.NotUsed]] =
-    Marshaller.opaque((response: akka.stream.scaladsl.Source[T, akka.NotUsed]) ⇒ GrpcMarshalling.marshalStream(response)(serializer, mat, codec, system))
+    Marshaller.opaque((response: akka.stream.scaladsl.Source[T, akka.NotUsed]) => GrpcMarshalling.marshalStream(response)(serializer, mat, codec, system))
 }

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -94,7 +94,7 @@ import akka.stream.Materializer
       }
 
       Function.unlift((req: HttpRequest) => req.uri.path match {
-        case Path.Slash(Segment(`prefix`, Path.Slash(Segment(method, Path.Empty)))) ⇒
+        case Path.Slash(Segment(`prefix`, Path.Slash(Segment(method, Path.Empty)))) =>
           Some(handle(req, method).recoverWith(GrpcExceptionHandler.default(eHandler(system))))
         case _ =>
           None


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Remove unicode arrows in templates

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

* codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
* codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt

## Background Context

<!-- Why did you take this approach? -->
