### PR TITLE
Whitelist allowed protoc settings

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.gen
 
 object ProtocSettings {

--- a/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
@@ -1,0 +1,16 @@
+package akka.grpc.gen
+
+object ProtocSettings {
+
+  /** Whitelisted options for the built-in Java protoc plugin */
+  val protocJava = Seq("single_line_to_proto_string", "ascii_format_to_string", "retain_source_code_info")
+
+  /** Whitelisted options for the ScalaPB protoc plugin */
+  val scalapb = Seq(
+    "java_conversions",
+    "flat_package",
+    "single_line_to_proto_string",
+    "ascii_format_to_string",
+    "no_lenses",
+    "retain_source_code_info")
+}

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -156,7 +156,7 @@ class GenerateMojo @Inject()(project: MavenProject, buildContext: BuildContext) 
           val settings = parseGeneratorSettings(generatorSettings)
           val javaSettings = settings.intersect(ProtocSettings.protocJava)
 
-          Seq[Target](Target(protocbridge.gens.java, generatedSourcesDir, settings)) ++
+          Seq[Target](Target(protocbridge.gens.java, generatedSourcesDir, javaSettings)) ++
           glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, settings))
         case Scala =>
           // Add flatPackage option as default if it's not set.


### PR DESCRIPTION
This is needed because the built-in java generator and the scalapb scala
generator throw an error when an unrecognized option is passed to them.

Added for sbt and maven, not needed yet for the groovy plugin because
there we don't allow arbitrary settings.

Refs #719 