### PR TITLE
Remove unnecessary print out of gradle tasks on plugin apply

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -114,7 +114,6 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
                 }
             }
 
-            println project.getTasks()
             project.task("printProtocLogs") {
                 doLast {
                     Files.lines(logFile).forEach { line ->


### PR DESCRIPTION
## Purpose

Gradle plugin unnecessary prints out a list o tasks.

## References

See #735

## Changes

- Removed printing tasks

