### PR TITLE
Use same sbt-protoc version everywhere

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,7 @@ package akka.grpc
 
 import sbt._
 import sbt.Keys._
+import buildinfo.BuildInfo
 
 object Dependencies {
   object Versions {
@@ -59,7 +60,7 @@ object Dependencies {
   }
 
   object Plugins {
-    val sbtProtoc = "com.thesamet" % "sbt-protoc" % "0.99.26"
+    val sbtProtoc = "com.thesamet" % "sbt-protoc" % BuildInfo.sbtProtocVersion
   }
 
   private val l = libraryDependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,16 @@
+
+
+enablePlugins(BuildInfoPlugin)
+
+val sbtProtocV = "0.99.25"
+
+buildInfoKeys := Seq[BuildInfoKey](
+  "sbtProtocVersion"      -> sbtProtocV
+)
+
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % sbtProtocV)
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,8 @@
-
-
 enablePlugins(BuildInfoPlugin)
 
 val sbtProtocV = "0.99.25"
 
-buildInfoKeys := Seq[BuildInfoKey](
-  "sbtProtocVersion"      -> sbtProtocV
-)
+buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,2 +1,1 @@
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
akka-grpc plugin is depending on sbt-protoc v0.99.26, but the project itself is using v0.99.19.  

play-grpc is pulling v0.99.26 and failing to build because v0.99.26 sets `PB.targets := Nil` after we set it to ListBuffer (in ReflectiveCodeGen). Later, when we try to cast it back to ListBuffer, we get an error because we can't cast `immutable.Nil` to `ListBuffer`. 

This is not yet a fix for that issue, but it makes sure that the version we use in akka-grpc is the same that we add as a dependency in the sbt plugin we produce. 

Because the issue is not yet solved in `ReflectiveCodeGen`, I'm reverting the version to 0.99.25 as it doesn't set `PB.targets` to `Nil`. 

We do have a fix in play-grpc's ReflectiveCodeGen that allows us to use 0.99.26, but that same fix doesn't work on akka-grpc. I'm still looking for a solution.