### PR TITLE
Adjusted Gradle plugin logfile to be generated as an absolute path.

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -96,7 +96,7 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
                                 option "server_power_apis=${extension.serverPowerApis}"
                                 option "use_play_actions=${extension.usePlayActions}"
                                 option "extra_generators=${extension.extraGenerators.join(';')}"
-                                option "logfile=${project.projectDir.toPath().relativize(logFile).toString()}"
+                                option "logfile=${logFile.toAbsolutePath().toString()}"
                                 if (extension.generatePlay) {
                                     option "generate_play=true"
                                 }


### PR DESCRIPTION
## Purpose

To attempt to correct the log file path that is generated so it works no matter if a build is triggered from the root project or the subproject.

## References

References #786.

## Changes

- Adjust the generated log file path so that it is absolute, rather than relative, which causes issues when the build is not triggered from the specific subproject the plugin is used in.

## Background Context

Please see issue #786 for an explanation of the project.  This is caused by the following:

The path to a `logFile` is correctly generated by:
https://github.com/akka/akka-grpc/blob/c1eb6fa184d45c289ade3befde9c0551597b6542/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy#L30

However, the offending line is the following, which generates a relative path _from the active project directory (e.g., the root project directory)_ .
https://github.com/akka/akka-grpc/blob/c1eb6fa184d45c289ade3befde9c0551597b6542/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy#L99

Consider that in a multi-build Gradle project, the `build` folder is located at `rootProject/subProject/build`.  The log file then has the path of `rootProject/subProject/build/file.log`  By relativizing the log file path with the _subproject path_, the log file is reduced to have the path `build/file.log`.

Thus, when the build is executed from the root project, the file is written to `rootProject/file.log` which does not exist.

The suggested fix is to generate an absolute path so that it works no matter where the build is triggered from.

## Testing

Please note that I **did not** test this on a Windows machine, which was the reason that this file was originally changed and this regression popped up.

This fix was tested on both Linux and Mac (and on a number of *nix Jenkins machines).

However, I would humbly request that someone try this on their Windows machine to make sure that Java's [Path.AbsolutePath](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#toAbsolutePath) does not require any special escaping for Windows.  If someone is 100% sure that the above method works out of the box, then I presume that there shouldn't be any issues, but I personally am not sure how Java renders Windows paths.

## Credit

Credit to @hithran for the original fix to this file which I'm patching (hopefully this patch does not conflict with the Windows compatibility he built-in).