### PR TITLE
Update protobuf gradle plugin to 0.8.11, require gradle 5.6.4

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -50,7 +50,7 @@ pluginBundle {
 
 jar {
     manifest {
-        attributes 'Implementation-Version': version
+        attributes 'Implementation-Version': project.version
     }
 }
 
@@ -58,7 +58,7 @@ dependencies {
     compile localGroovy()
     compile gradleApi()
 
-    implementation 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+    implementation 'com.google.protobuf:protobuf-gradle-plugin:0.8.11'
 }
 
 repositories {

--- a/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -1,6 +1,9 @@
 package akka.grpc.gradle
 
+
+import com.google.protobuf.gradle.Utils
 import org.apache.commons.lang.SystemUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencyResolutionListener
@@ -20,6 +23,11 @@ class AkkaGrpcPlugin implements Plugin<Project>, DependencyResolutionListener {
 
     @Override
     void apply(Project project) {
+        if (Utils.compareGradleVersion(project, "5.6") < 0) {
+            throw new GradleException(
+                    "Gradle version is ${project.gradle.gradleVersion}. Minimum supported version is 5.6")
+        }
+
         this.project = project
         project.gradle.addListener(this)
 

--- a/plugin-tester-java/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-tester-java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/plugin-tester-scala/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-tester-scala/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

- support for gradle 6.x

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

- increased gradle wrapper version to 5.6.4
- upgraded protobuf gradle plugin to 0.8.11
- added compatibility check when applying the plugin

## Background Context

<!-- Why did you take this approach? -->
