### PR TITLE
Plug Akka Discovery into the grpc-java NameResolver

### DIFF
--- a/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
+++ b/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
@@ -2,8 +2,6 @@
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package example.myapp.helloworld.grpc;
-
 //#unary
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
+++ b/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
@@ -2,6 +2,8 @@
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
+package example.myapp.helloworld.grpc;
+
 //#unary
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/interop-tests/src/test/resources/application.conf
+++ b/interop-tests/src/test/resources/application.conf
@@ -1,1 +1,4 @@
-akka.http.server.default-host-header = "localhost.com"
+akka.http.server {
+    default-host-header = "localhost.com"
+    preview.enable-http2 = on
+}

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/LoadBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/LoadBalancingIntegrationSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.grpc.scaladsl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.discovery.{ Lookup, ServiceDiscovery }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.Http
+import akka.stream.scaladsl.Source
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+import example.myapp.helloworld.grpc.helloworld._
+import org.scalatest.concurrent.ScalaFutures
+
+class CountingGreeterServiceImpl extends GreeterService {
+  var greetings = new AtomicInteger(0);
+
+  def sayHello(in: HelloRequest): Future[HelloReply] = {
+    greetings.incrementAndGet()
+    Future.successful(HelloReply(s"Hi ${in.name}!"))
+  }
+
+  def itKeepsReplying(in: HelloRequest): Source[HelloReply, NotUsed] = ???
+  def itKeepsTalking(
+      in: akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.helloworld.HelloRequest, akka.NotUsed])
+      : scala.concurrent.Future[example.myapp.helloworld.grpc.helloworld.HelloReply] = ???
+  def streamHellos(in: akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.helloworld.HelloRequest, akka.NotUsed])
+      : akka.stream.scaladsl.Source[example.myapp.helloworld.grpc.helloworld.HelloReply, akka.NotUsed] = ???
+
+}
+
+class LoadBalancingIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+  implicit val system = ActorSystem("LoadBalancingIntegrationSpec")
+  implicit val mat = akka.stream.ActorMaterializer.create(system)
+  implicit val ec = system.dispatcher
+
+  "Client-side loadbalancing" should {
+    "send requests to multiple endpoints" in {
+      val service1 = new CountingGreeterServiceImpl()
+      val service2 = new CountingGreeterServiceImpl()
+
+      val server1 = Http().bindAndHandleAsync(GreeterServiceHandler(service1), "127.0.0.1", 0).futureValue
+      val server2 = Http().bindAndHandleAsync(GreeterServiceHandler(service2), "127.0.0.1", 0).futureValue
+
+      val discovery = new ServiceDiscovery() {
+        override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+          require(query.serviceName == "greeter")
+          return Future.successful(
+            Resolved(
+              "greeter",
+              List(
+                ResolvedTarget(
+                  server1.localAddress.getHostString(),
+                  Some(server1.localAddress.getPort()),
+                  Some(server1.localAddress.getAddress())),
+                ResolvedTarget(
+                  server2.localAddress.getHostString(),
+                  Some(server2.localAddress.getPort()),
+                  Some(server2.localAddress.getAddress())))))
+        }
+      }
+      val client = GreeterServiceClient(
+        GrpcClientSettings
+          .usingServiceDiscovery("greeter", discovery)
+          .withTls(false)
+          .withGrpcLoadBalancingType("round_robin"))
+      for (i <- 1 to 100) {
+        Await.result(client.sayHello(HelloRequest(s"Hello $i")), 10.seconds)
+      }
+
+      service1.greetings.get + service2.greetings.get should be(100)
+      service1.greetings.get should be > (0)
+      service2.greetings.get should be > (0)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+  }
+}

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -79,6 +79,21 @@ object GrpcClientSettings {
   }
 
   /**
+   * Configure the client to lookup a valid hostname:port from a service registry accessed via the provided `ServiceDiscovery`.
+   * When invoking a lookup operation on the service registry, a
+   * name is required and optionally a port name and a protocol. This factory method only requires a `serviceName`.
+   * Use `withServicePortName` and `withServiceProtocol` to refine the lookup on the service registry.
+   *
+   * @param serviceName name of the remote service to lookup.
+   */
+  def usingServiceDiscovery(serviceName: String, discovery: ServiceDiscovery)(
+      implicit actorSystem: ActorSystem): GrpcClientSettings = {
+    val clientConfiguration: Config = actorSystem.settings.config.getConfig("akka.grpc.client").getConfig("\"*\"")
+    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").asScala
+    withConfigDefaults(serviceName, discovery, -1, resolveTimeout, clientConfiguration)
+  }
+
+  /**
    * Configure client via the provided Config. See reference.conf for configuration properties.
    */
   def fromConfig(clientConfiguration: Config)(implicit sys: ActorSystem): GrpcClientSettings = {
@@ -239,6 +254,9 @@ final class GrpcClientSettings private (
     copy(creationAttempts = value)
   def withCreationDelay(delay: FiniteDuration): GrpcClientSettings =
     copy(creationDelay = delay)
+
+  def withGrpcLoadBalancingType(loadBalancingType: String): GrpcClientSettings =
+    copy(grpcLoadBalancingType = Some(loadBalancingType))
 
   /**
    * How many times to retry establishing a connection before failing the client

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -144,7 +144,7 @@ object GrpcClientSettings {
       case _          => Duration.fromNanos(underlying.getDuration(path).toNanos)
     }
 
-  private def staticServiceDiscovery(host: String, port: Int) =
+  private[grpc] def staticServiceDiscovery(host: String, port: Int) =
     new HardcodedServiceDiscovery(Resolved(host, immutable.Seq(ResolvedTarget(host, Some(port), None))))
 
   /**

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
@@ -19,13 +19,12 @@ import scala.util.{ Failure, Success }
 class AkkaDiscoveryNameResolver(
     discovery: ServiceDiscovery,
     defaultPort: Int,
-    authority: String,
+    serviceName: String,
     portName: Option[String],
     protocol: Option[String],
     resolveTimeout: FiniteDuration)(implicit val ec: ExecutionContext)
     extends NameResolver {
-  // TODO
-  override def getServiceAuthority: String = authority
+  override def getServiceAuthority: String = serviceName
 
   val listener: Promise[Listener] = Promise()
 
@@ -41,7 +40,7 @@ class AkkaDiscoveryNameResolver(
     }
 
   def lookup(listener: Listener): Unit = {
-    discovery.lookup(Lookup(authority, portName, protocol), resolveTimeout).onComplete {
+    discovery.lookup(Lookup(serviceName, portName, protocol), resolveTimeout).onComplete {
       case Success(result) =>
         try {
           listener.onAddresses(addresses(result.addresses), Attributes.EMPTY)

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import java.net.{ InetAddress, InetSocketAddress, SocketAddress, URI, UnknownHostException }

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolver.scala
@@ -1,0 +1,79 @@
+package akka.grpc.internal
+
+import java.net.{ InetAddress, InetSocketAddress, SocketAddress, URI, UnknownHostException }
+
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.discovery.{ Lookup, ServiceDiscovery }
+import akka.grpc.GrpcClientSettings
+import io.grpc.{ Attributes, EquivalentAddressGroup, NameResolver, Status }
+import io.grpc.NameResolver.Listener
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ ExecutionContext, Promise }
+import scala.util.{ Failure, Success }
+
+class AkkaDiscoveryNameResolver(
+    discovery: ServiceDiscovery,
+    defaultPort: Int,
+    authority: String,
+    portName: Option[String],
+    protocol: Option[String],
+    resolveTimeout: FiniteDuration)(implicit val ec: ExecutionContext)
+    extends NameResolver {
+  // TODO
+  override def getServiceAuthority: String = authority
+
+  val listener: Promise[Listener] = Promise()
+
+  override def start(l: Listener): Unit = {
+    listener.trySuccess(l)
+    lookup(l)
+  }
+
+  override def refresh(): Unit =
+    listener.future.onComplete {
+      case Success(l) => lookup(l)
+      case Failure(_) => // We never fail this promise
+    }
+
+  def lookup(listener: Listener): Unit = {
+    discovery.lookup(Lookup(authority, portName, protocol), resolveTimeout).onComplete {
+      case Success(result) =>
+        try {
+          listener.onAddresses(addresses(result.addresses), Attributes.EMPTY)
+        } catch {
+          case e: UnknownHostException =>
+            // TODO at least log
+            listener.onError(Status.UNKNOWN.withDescription(e.getMessage))
+        }
+      case Failure(e) =>
+        // TODO at least log
+        listener.onError(Status.UNKNOWN.withDescription(e.getMessage))
+    }
+  }
+
+  @throws[UnknownHostException]
+  private def addresses(addresses: Seq[ResolvedTarget]) = {
+    import scala.collection.JavaConverters._
+    addresses
+      .map(target => {
+        val port = target.port.getOrElse(defaultPort)
+        val address = target.address.getOrElse(InetAddress.getByName(target.host))
+        new EquivalentAddressGroup(new InetSocketAddress(address, port))
+      })
+      .asJava
+  }
+
+  override def shutdown(): Unit = ()
+}
+
+object AkkaDiscoveryNameResolver {
+  def apply(settings: GrpcClientSettings)(implicit ec: ExecutionContext): AkkaDiscoveryNameResolver =
+    new AkkaDiscoveryNameResolver(
+      settings.serviceDiscovery,
+      settings.defaultPort,
+      settings.serviceName,
+      settings.servicePortName,
+      settings.serviceProtocol,
+      settings.resolveTimeout)
+}

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProvider.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProvider.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import java.net.URI

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProvider.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProvider.scala
@@ -1,0 +1,28 @@
+package akka.grpc.internal
+
+import java.net.URI
+
+import akka.discovery.ServiceDiscovery
+import io.grpc.{ NameResolver, NameResolverProvider }
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+class AkkaDiscoveryNameResolverProvider(
+    discovery: ServiceDiscovery,
+    defaultPort: Int,
+    portName: Option[String],
+    protocol: Option[String],
+    resolveTimeout: FiniteDuration)(implicit ec: ExecutionContext)
+    extends NameResolverProvider {
+  override def isAvailable: Boolean = true
+
+  override def priority(): Int = 5
+
+  override def getDefaultScheme: String = "http"
+
+  override def newNameResolver(targetUri: URI, args: NameResolver.Args): AkkaDiscoveryNameResolver = {
+    require(targetUri.getAuthority != null, s"target uri should not have null authority, got [$targetUri]")
+    new AkkaDiscoveryNameResolver(discovery, defaultPort, targetUri.getAuthority, portName, protocol, resolveTimeout)
+  }
+}

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
@@ -1,0 +1,15 @@
+package akka.grpc.internal
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class AkkaDiscoveryNameResolverProviderSpec extends TestKit(ActorSystem()) with AnyWordSpecLike with Matchers {
+  "AkkaDiscoveryNameResolverProviderSpec" should {
+    "provide a NameResolver that uses the supplied serviceName" in {
+//      AkkaDiscoveryNameResolver("")
+    }
+  }
+
+}

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import akka.actor.ActorSystem

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverProviderSpec.scala
@@ -4,15 +4,70 @@
 
 package akka.grpc.internal
 
+import java.net.URI
+import java.net.InetSocketAddress
+import java.util.{ List => JList }
+
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+import io.grpc.Attributes
+import io.grpc.NameResolver.Listener
+import io.grpc.EquivalentAddressGroup
+
 import akka.actor.ActorSystem
+import akka.discovery.Lookup
+import akka.discovery.ServiceDiscovery
+import akka.discovery.ServiceDiscovery.Resolved
+import akka.discovery.ServiceDiscovery.ResolvedTarget
 import akka.testkit.TestKit
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.concurrent.ScalaFutures
 
-class AkkaDiscoveryNameResolverProviderSpec extends TestKit(ActorSystem()) with AnyWordSpecLike with Matchers {
+class AkkaDiscoveryNameResolverProviderSpec
+    extends TestKit(ActorSystem())
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures {
   "AkkaDiscoveryNameResolverProviderSpec" should {
     "provide a NameResolver that uses the supplied serviceName" in {
-//      AkkaDiscoveryNameResolver("")
+      val serviceName = "testServiceName"
+      val discovery = new ServiceDiscovery() {
+        override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+          lookup.serviceName should be(serviceName)
+          Future.successful(Resolved(serviceName, immutable.Seq(ResolvedTarget("10.0.0.3", Some(4312), None))))
+        }
+      }
+      val provider = new AkkaDiscoveryNameResolverProvider(
+        discovery,
+        443,
+        portName = None,
+        protocol = None,
+        resolveTimeout = 3.seconds)
+
+      val resolver = provider.newNameResolver(new URI("//" + serviceName), null)
+
+      val addressGroupsPromise = Promise[List[EquivalentAddressGroup]]
+      val listener = new Listener() {
+        override def onAddresses(addresses: JList[EquivalentAddressGroup], attributes: Attributes): Unit = {
+          import scala.collection.JavaConverters._
+          addressGroupsPromise.success(addresses.asScala.toList)
+        }
+        override def onError(error: io.grpc.Status): Unit = ???
+      }
+      resolver.start(listener)
+      val addressGroups = addressGroupsPromise.future.futureValue
+      addressGroups.size should be(1)
+      val addresses = addressGroups(0).getAddresses()
+      addresses.size should be(1)
+      val address = addresses.get(0).asInstanceOf[InetSocketAddress]
+      address.getHostString() should be("10.0.0.3")
+      address.getPort() should be(4312)
     }
   }
 

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
@@ -43,7 +43,7 @@ class AkkaDiscoveryNameResolverSpec
         case Seq(addressGroup) => addressGroup.getAddresses
         case _                 => fail("Expected a single address group")
       }
-      addresses.asScala match {
+      addresses.asScala.toSeq match {
         case Seq(address: InetSocketAddress) =>
           address.getPort should be(port)
           address.getAddress.getHostName should be(host)

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import java.net.{ InetSocketAddress, URI }

--- a/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaDiscoveryNameResolverSpec.scala
@@ -1,0 +1,55 @@
+package akka.grpc.internal
+
+import java.net.{ InetSocketAddress, URI }
+
+import akka.actor.ActorSystem
+import akka.grpc.{ GrpcClientSettings, GrpcServiceException }
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.collection.JavaConverters._
+
+class AkkaDiscoveryNameResolverSpec
+    extends TestKit(ActorSystem())
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures {
+  implicit val ex = system.dispatcher
+
+  "The AkkaDiscovery-backed NameResolver" should {
+    "correctly report an error for an unknown hostname" in {
+      val host = "example.invalid"
+      val resolver = AkkaDiscoveryNameResolver(GrpcClientSettings.connectToServiceAt(host, 80))
+      val probe = new NameResolverListenerProbe()
+
+      resolver.start(probe)
+
+      val exception = probe.future.failed.futureValue.asInstanceOf[GrpcServiceException]
+      exception.status.getDescription should equal(host + ": Name or service not known")
+    }
+
+    "support serving a static host/port" in {
+      // Unfortunately it needs to be an actually resolvable address...
+      val host = "akka.io"
+      val port = 4040
+      val resolver = AkkaDiscoveryNameResolver(GrpcClientSettings.connectToServiceAt(host, port))
+      val probe = new NameResolverListenerProbe()
+
+      resolver.start(probe)
+
+      val addresses = probe.future.futureValue match {
+        case Seq(addressGroup) => addressGroup.getAddresses
+        case _                 => fail("Expected a single address group")
+      }
+      addresses.asScala match {
+        case Seq(address: InetSocketAddress) =>
+          address.getPort should be(port)
+          address.getAddress.getHostName should be(host)
+        case other =>
+          fail(s"Expected a single InetSocketAddress, got $other")
+      }
+    }
+  }
+}

--- a/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
@@ -12,7 +12,7 @@ class NameResolverListenerProbe extends NameResolver.Listener {
 
   override def onAddresses(servers: util.List[EquivalentAddressGroup], attributes: Attributes): Unit = {
     import scala.collection.JavaConverters._
-    promise.trySuccess(servers.asScala)
+    promise.trySuccess(servers.asScala.toSeq)
   }
 
   override def onError(error: Status): Unit =

--- a/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import java.util

--- a/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/NameResolverListenerProbe.scala
@@ -1,0 +1,22 @@
+package akka.grpc.internal
+
+import java.util
+
+import akka.grpc.GrpcServiceException
+import io.grpc.{ Attributes, EquivalentAddressGroup, NameResolver, Status }
+
+import scala.concurrent.Promise
+
+class NameResolverListenerProbe extends NameResolver.Listener {
+  private val promise = Promise[Seq[EquivalentAddressGroup]]
+
+  override def onAddresses(servers: util.List[EquivalentAddressGroup], attributes: Attributes): Unit = {
+    import scala.collection.JavaConverters._
+    promise.trySuccess(servers.asScala)
+  }
+
+  override def onError(error: Status): Unit =
+    promise.tryFailure(new GrpcServiceException(error))
+
+  val future = promise.future
+}

--- a/runtime/src/test/scala/akka/grpc/internal/NettyClientUtilsSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/NettyClientUtilsSpec.scala
@@ -26,12 +26,13 @@ class NettyClientUtilsSpec extends AnyWordSpec with Matchers with ScalaFutures w
   "The Netty client-utilities" should {
     implicit val ec = system.dispatcher
 
-    "fail to create a channel when service discovery times out" in {
-      val settings = GrpcClientSettings.usingServiceDiscovery("testService")
-
-      val channel = NettyClientUtils.createChannel(settings, Logging(system, this.getClass))
-      channel.failed.futureValue shouldBe a[AskTimeoutException]
-    }
+//    The channel can now retry service discovery as needed itself,
+//    I guess we should test that instead?
+//    "fail to create a channel when service discovery times out" in {
+//      val settings = GrpcClientSettings.usingServiceDiscovery("testService")
+//
+//      val channel = NettyClientUtils.createChannel(settings)
+//    }
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
Instead of performing discovery 'outside' of the Channel.

This would allow configuring client-side loadbalancing, #809, but I have
not yet tested that that goal is actually achieved.

Before un-drafting this generally needs some more testing whether it
does the right thing, especially re-resolving names in case of updates
etc. It may also mean we can simplify/remove the recreation code in
ClientState.scala, but that also still needs to be verified.
