### PR TITLE
Docs: add project info

### DIFF
--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -23,11 +23,7 @@ It features:
 
 ## Project Information
 
-* Akka gRPC $project.version$ ([Github](https://github.com/akka/akka-grpc))
-* Scala $scala.binary.version$
-* Akka Http $akka-http.version$ (@extref[Docs](akka-http:index.html), [Github](https://github.com/akka/akka-http))
-
-Release notes are found at [Github releases](https://github.com/akka/akka-grpc/releases).
+@@project-info{ projectId="akka-grpc-runtime" }
 
 ## Project Status
 

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,2 +1,42 @@
 project-info {
+  version: "current"
+  shared-info {
+    jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
+    // snapshots: { }
+    issues: {
+      url: "https://github.com/akka/akka-grpc/issues"
+      text: "GitHub issues"
+    }
+    release-notes: {
+      url: "https://github.com/akka/akka-grpc/releases"
+      text: "GitHub releases"
+    }
+    forums: [
+      {
+        text: "Lightbend Discuss"
+        url: "https://discuss.lightbend.com/c/akka/akka-grpc"
+      }
+      {
+        text: "akka/akka Gitter channel"
+        url: "https://gitter.im/akka/akka"
+      }
+    ]
+  }
+  akka-grpc-runtime: ${project-info.shared-info} {
+    title: "Akka gRPC"
+    # jpms-name: "akka.grpc" See https://github.com/akka/akka-grpc/issues/814
+    levels: [
+      {
+        readiness: Incubating
+        since: "2019-04-18"
+        since-version: "0.6.1"
+      }
+      {
+        readiness: CommunityDriven
+        since: "2018-05-08"
+        since-version: "0.1"
+      }
+    ]
+    api-docs: [] // https://github.com/akka/akka-grpc/issues/784
+  }
 }

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -2,7 +2,10 @@ project-info {
   version: "current"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
-    // snapshots: { }
+    snapshots: {
+      url: "https://bintray.com/akka/maven/akka-grpc"
+      text: "Snapshots are available from Bintray"
+    }
     issues: {
       url: "https://github.com/akka/akka-grpc/issues"
       text: "GitHub issues"


### PR DESCRIPTION
Use the Paradox project-info plugin to render standardised information.

![bild](https://user-images.githubusercontent.com/458526/74222406-b56f0e80-4cb4-11ea-9d84-c3f4994cb1e8.png)

