### PR TITLE
Docs: configure creating Scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,6 @@ lazy val root = Project(id = "akka-grpc", base = file("."))
   .settings(
     skip in publish := true,
     unmanagedSources in (Compile, headerCreate) := (baseDirectory.value / "project").**("*.scala").get,
-    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(codegen, runtime, scalapbProtocPlugin),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(codegen, runtime, scalapbProtocPlugin, sbtPlugin),
     // https://github.com/sbt/sbt/issues/3465
     crossScalaVersions := List())

--- a/build.sbt
+++ b/build.sbt
@@ -135,17 +135,17 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
 // Make sure code generation is ran:
   .dependsOn(pluginTesterScala)
   .dependsOn(pluginTesterJava)
-  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PublishRsyncPlugin)
+  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .settings(
     mimaFailOnNoPrevious := false,
     name := "Akka gRPC",
     publish / skip := true,
     whitesourceIgnore := true,
-    // We don't yet publish java/scaladoc, so this is not yet relevant
-    // https://github.com/akka/akka-grpc/issues/784
-    // apidocRootPackage := "akka.grpc",
+    makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     previewPath := (Paradox / siteSubdirName).value,
-    Paradox / siteSubdirName := s"docs/akka-grpc/${if (isSnapshot.value) "snapshot" else version.value}",
+    Preprocess / siteSubdirName := s"api/akka-grpc/${projectInfoVersion.value}",
+    Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
+    Paradox / siteSubdirName := s"docs/akka-grpc/${projectInfoVersion.value}",
     // Make sure code generation is ran before paradox:
     (Compile / paradox) := (Compile / paradox).dependsOn(Compile / compile).value,
     paradoxGroups := Map("Language" -> Seq("Java", "Scala"), "Buildtool" -> Seq("sbt", "Gradle", "Maven")),
@@ -156,10 +156,19 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
         "project.url" -> "https://doc.akka.io/docs/akka-grpc/current/",
         "canonical.base_url" -> "https://doc.akka.io/docs/akka-grpc/current",
         "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
-        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.Versions.akka}/%s",
-        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.Versions.akka}",
-        "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.Versions.akkaHttp}/%s",
-        "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.Versions.akkaHttp}/"),
+        // Akka
+        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.Versions.akkaBinary}/%s",
+        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.Versions.akkaBinary}",
+        "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.Versions.akkaBinary}/",
+        // Akka HTTP
+        "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.Versions.akkaHttpBinary}/%s",
+        "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.Versions.akkaHttpBinary}/",
+        "javadoc.akka.http.base_url" -> s"https://doc.akka.io/japi/akka-http/${Dependencies.Versions.akkaHttpBinary}/",
+        // Akka gRPC
+        "scaladoc.akka.grpc.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
+        "javadoc.akka.grpc.base_url" -> "" // @apidoc links to Scaladoc
+      ),
+    apidocRootPackage := "akka",
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io",
@@ -183,7 +192,8 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
   .pluginTestingSettings
 
 lazy val root = Project(id = "akka-grpc", base = file("."))
-  .disablePlugins(MimaPlugin)
+  .enablePlugins(ScalaUnidocPlugin)
+  .disablePlugins(SitePlugin, MimaPlugin)
   .aggregate(
     runtime,
     codegen,
@@ -197,5 +207,6 @@ lazy val root = Project(id = "akka-grpc", base = file("."))
   .settings(
     skip in publish := true,
     unmanagedSources in (Compile, headerCreate) := (baseDirectory.value / "project").**("*.scala").get,
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(codegen, runtime, scalapbProtocPlugin),
     // https://github.com/sbt/sbt/issues/3465
     crossScalaVersions := List())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,9 @@ object Dependencies {
     val scala213 = "2.13.1"
 
     val akka = "2.5.29"
+    val akkaBinary = "2.5"
     val akkaHttp = "10.1.11"
+    val akkaHttpBinary = "10.1"
 
     val grpc = "1.27.1" // checked synced by GrpcVersionSyncCheckPlugin
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,13 +11,16 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.29")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
-addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.4")
+
+// docs
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.31")
+addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 
 // For RawText
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.6.1.202002131546-r"

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -14,6 +14,12 @@ project-info {
       url: "https://github.com/akka/akka-grpc/releases"
       text: "GitHub releases"
     }
+    api-docs: [
+      {
+        url: "https://doc.akka.io/api/akka-grpc/"${project-info.version}"/akka/grpc/"
+        text: "API (Scaladoc)"
+      }
+    ]
     forums: [
       {
         text: "Lightbend Discuss"
@@ -40,6 +46,5 @@ project-info {
         since-version: "0.1"
       }
     ]
-    api-docs: [] // https://github.com/akka/akka-grpc/issues/784
   }
 }


### PR DESCRIPTION
Set up Scaladoc creation via sbt-unidoc for codegen, runtime, and scalapbProtocPlugin.

Configure URLs to point to Scaladoc, sources and such.

References #784
