### PR TITLE
Don't generate unidoc for the sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,6 @@ lazy val root = Project(id = "akka-grpc", base = file("."))
   .settings(
     skip in publish := true,
     unmanagedSources in (Compile, headerCreate) := (baseDirectory.value / "project").**("*.scala").get,
-    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(codegen, runtime, scalapbProtocPlugin, sbtPlugin),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(codegen, runtime, scalapbProtocPlugin),
     // https://github.com/sbt/sbt/issues/3465
     crossScalaVersions := List())


### PR DESCRIPTION
Refs #831

For some reason this pulls in scalapb-runtime 0.6.0, though I don't
see how.