### PR TITLE
Simplify ClientState

### DIFF
--- a/runtime/src/main/mima-filters/0.7.3.backwards.excludes/843-simplify-clientstate.backwards.excludes
+++ b/runtime/src/main/mima-filters/0.7.3.backwards.excludes/843-simplify-clientstate.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.grpc.internal.ClientState.this")

--- a/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.Done
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
 import akka.pattern.Patterns
@@ -22,24 +23,17 @@ import scala.util.Failure
 
 /**
  * INTERNAL API
- * Used from generated code so can't be private.
  *
  * Client utilities taking care of Channel reconnection and Channel lifecycle in general.
  */
 @InternalApi
-final class ClientState(
-    settings: GrpcClientSettings,
-    log: LoggingAdapter,
-    channelFactory: GrpcClientSettings => Future[InternalChannel])(implicit mat: Materializer, ex: ExecutionContext) {
+final class ClientState(settings: GrpcClientSettings, log: LoggingAdapter, channel: InternalChannel)(
+    implicit mat: Materializer,
+    ex: ExecutionContext) {
+
+  @InternalStableApi
   def this(settings: GrpcClientSettings, log: LoggingAdapter)(implicit mat: Materializer, ex: ExecutionContext) =
-    this(settings, log, s => NettyClientUtils.createChannel(s, log))
-
-  // usually None, it'll have a value when the underlying InternalChannel is closing or closed.
-  private val closing = new AtomicReference[Option[Future[Done]]](None)
-  private val closeDemand: Promise[Done] = Promise[Done]()
-
-  private val internalChannelRef = new AtomicReference[Option[Future[InternalChannel]]](Some(create()))
-  internalChannelRef.get().foreach(c => recreateOnFailure(c.flatMap(_.done), settings.creationAttempts))
+    this(settings, log, NettyClientUtils.createChannel(settings, log))
 
   mat match {
     case m: ActorMaterializer =>
@@ -47,113 +41,17 @@ final class ClientState(
     case _ =>
   }
 
-  // used from generated client
+  // TODO #761 consider not leaking ManagedChannel to the generated code?
+  @InternalStableApi
   def withChannel[A](f: Future[ManagedChannel] => A): A =
-    f {
-      internalChannelRef.get().getOrElse(Future.failed(new ClientClosedException)).map(_.managedChannel)
-    }
+    f { Future.successful(channel.managedChannel) }
 
   def closedCS(): CompletionStage[Done] = closed().toJava
   def closeCS(): CompletionStage[Done] = close().toJava
 
-  def closed(): Future[Done] =
-    // while there's no request to close this RestartingClient, it will continue to restart.
-    // Once there's demand, the `closeDemand` future will redeem flatMapping with the `closing`
-    // future which is a reference to promise of the internalChannel close status.
-    closeDemand.future.flatMap { _ =>
-      // `closeDemand` guards the read access to `closing`
-      closing.get().get
-    }
+  def closed(): Future[Done] = channel.done
 
-  @tailrec
-  def close(): Future[Done] = {
-    val maybeChannel = internalChannelRef.get()
-    maybeChannel match {
-      case Some(channel) =>
-        // invoke `close` on the channel and capture the `channel.done` returned
-        val done = channel.flatMap(ChannelUtils.close(_))
-        // set the `closing` to the current `channel.done`
-        closing.compareAndSet(None, Some(done))
-        // notify there's been close demand (see `def closed()` above)
-        closeDemand.trySuccess(Done)
-
-        if (internalChannelRef.compareAndSet(maybeChannel, None)) {
-          done
-        } else {
-          // when internalChannelRef was not maybeChannel
-          if (internalChannelRef.get != null) {
-            // client has had an exception and been re-created, need to shutdown the new one
-            close()
-          } else {
-            // or a competing thread already set `internalChannelRef` to None and CAS failed.
-            done
-          }
-        }
-      case _ =>
-        // set the `closing` to immediate success
-        val done = Future.successful(Done)
-        closing.compareAndSet(None, Some(done))
-        // notify there's been close demand (see `def closed()` above)
-        closeDemand.trySuccess(Done)
-        done
-    }
-  }
-
-  private def create(): Future[InternalChannel] =
-    Patterns.retry(
-      () => channelFactory(settings),
-      settings.creationAttempts,
-      settings.creationDelay,
-      // TODO #733 remove cast once we update Akka
-      mat.asInstanceOf[ActorMaterializer].system.scheduler,
-      mat.asInstanceOf[ActorMaterializer].system.dispatcher)
-
-  private def recreateOnFailure(done: Future[Done], creationsLeft: Int): Unit =
-    done.onComplete {
-      case Failure(e) =>
-        if (creationsLeft <= 0) {
-          // Error does not need to be explicitly propagated here
-          // since it's in the internalChannelRef already
-          log.warning(s"Client error [${e.getMessage}], not recreating client")
-          close()
-        } else if (settings.creationDelay.length < 1) {
-          if (!closeDemand.isCompleted) {
-            log.warning(s"Client error [${e.getMessage}], recreating client")
-            recreate(creationsLeft - 1)
-          }
-        } else {
-          log.warning(s"Client error [${e.getMessage}], recreating client after ${settings.creationDelay}")
-
-          Patterns.after(
-            settings.creationDelay,
-            // TODO #733 remove cast once we update Akka
-            mat.asInstanceOf[ActorMaterializer].system.scheduler,
-            mat.asInstanceOf[ActorMaterializer].system.dispatcher,
-            () =>
-              Future {
-                log.info("Recreating channel now")
-                if (!closeDemand.isCompleted) {
-                  recreate(creationsLeft - 1)
-                }
-              })
-        }
-      case _ =>
-        log.info("Client closed")
-      // completed successfully, nothing else to do (except perhaps log?)
-    }
-
-  private def recreate(creationsLeft: Int): Unit = {
-    val old = internalChannelRef.get()
-    if (old.isDefined) {
-      val newInternalChannel = create()
-      recreateOnFailure(newInternalChannel.flatMap(_.done), creationsLeft)
-      // Only one client is alive at a time. However a close() could have happened between the get() and this set
-      if (!internalChannelRef.compareAndSet(old, Some(newInternalChannel))) {
-        // close the newly created client we've been shutdown
-        newInternalChannel.map(ChannelUtils.close(_))
-      }
-    }
-  }
+  def close(): Future[Done] = ChannelUtils.close(channel)
 }
 
 /**

--- a/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
@@ -5,21 +5,17 @@
 package akka.grpc.internal
 
 import java.util.concurrent.CompletionStage
-import java.util.concurrent.atomic.AtomicReference
 
 import akka.Done
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
-import akka.pattern.Patterns
 import akka.stream.{ ActorMaterializer, Materializer }
 import io.grpc.ManagedChannel
 
-import scala.annotation.tailrec
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.{ ExecutionContext, Future, Promise }
-import scala.util.Failure
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * INTERNAL API

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -40,7 +40,7 @@ object NettyClientUtils {
    */
   @InternalApi
   def createChannel(settings: GrpcClientSettings, log: LoggingAdapter)(
-      implicit ec: ExecutionContext): Future[InternalChannel] = {
+      implicit ec: ExecutionContext): InternalChannel = {
     var builder =
       NettyChannelBuilder
       // Not sure why netty wants to be able to shoe-horn the target into a URI... but ok,
@@ -73,7 +73,7 @@ object NettyClientUtils {
     val promise = Promise[Done]()
     ChannelUtils.monitorChannel(promise, channel, settings.connectionAttempts, log)
 
-    Future.successful(InternalChannel(channel, promise.future))
+    InternalChannel(channel, promise.future)
   }
 
   /**

--- a/runtime/src/main/scala/akka/grpc/scaladsl/AkkaGrpcClient.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/AkkaGrpcClient.scala
@@ -19,9 +19,9 @@ trait AkkaGrpcClient {
   def close(): Future[Done]
 
   /**
-   * Returns a Future that completes successfully when shutdown via close()
+   * A Future that completes successfully when shutdown via close()
    * or exceptionally if a connection can not be established or reestablished
    * after maxConnectionAttempts.
    */
-  def closed(): Future[Done]
+  def closed: Future[Done]
 }


### PR DESCRIPTION
As rediscovering/retrying is now the responsibility of the netty client

/cc @tayvs since you worked on retry logic, that should be intact and not rely on the retry logic in CiientState AFAICS