### PR TITLE
bump sbt-protoc

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 enablePlugins(BuildInfoPlugin)
 
-val sbtProtocV = "0.99.26"
+val sbtProtocV = "0.99.28"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 


### PR DESCRIPTION
A requirement according to https://github.com/scalapb/ScalaPB/compare/v0.10.0-M6...v0.10.0-M7#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR4, that I am challenging in https://gitter.im/ScalaPB/community?at=5e6b4866467c854233011227 as I don't see any problem with 0.99.26.

There is no reason not to bump anyway.