### PR TITLE
codegen: fallback to protobuf package when no java_package is defined

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
@@ -80,8 +80,12 @@ object Method {
     "_root_." + t.getFile.getOptions.getJavaPackage + "." + protoName(t) + "." + t.getName
 
   /** Java API */
-  def getMessageType(t: Descriptor) =
-    t.getFile.getOptions.getJavaPackage + "." + outerClass(t) + t.getName
+  def getMessageType(t: Descriptor) = {
+    val packageName =
+      if (t.getFile.getOptions.hasJavaPackage) t.getFile.getOptions.getJavaPackage
+      else t.getFile.getPackage
+    (if (packageName.isEmpty) "" else packageName + ".") + outerClass(t) + t.getName
+  }
 
   private def outerClass(t: Descriptor) =
     if (t.getFile.toProto.getOptions.getJavaMultipleFiles) ""

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
@@ -37,13 +37,16 @@ object Service {
       import ops._
       serviceDescriptor.comment
     }
+    val packageName =
+      if (fileDesc.getOptions.hasJavaPackage) fileDesc.getOptions.getJavaPackage
+      else fileDesc.getPackage
     val outerClassName =
       if (fileDesc.getOptions.getJavaOuterClassname.isEmpty)
-        fileDesc.getOptions.getJavaPackage + "." + toCamelCase(basename(fileDesc.getName))
+        (if (packageName.isEmpty) "" else packageName + ".") + toCamelCase(basename(fileDesc.getName))
       else fileDesc.getOptions.getJavaOuterClassname
     Service(
       outerClassName + ".getDescriptor()",
-      fileDesc.getOptions.getJavaPackage,
+      packageName,
       serviceDescriptor.getName,
       (if (fileDesc.getPackage.isEmpty) "" else fileDesc.getPackage + ".") + serviceDescriptor.getName,
       serviceDescriptor.getMethods.asScala.map(method => Method(method)).to[immutable.Seq],

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
@@ -1,0 +1,7 @@
+
+enablePlugins(JavaAgent)
+enablePlugins(AkkaGrpcPlugin)
+
+javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6" % "runtime"
+
+akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))
+
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/src/main/java/helloworld/GreeterServiceImpl.java
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/src/main/java/helloworld/GreeterServiceImpl.java
@@ -1,0 +1,24 @@
+package helloworld;
+
+import java.util.concurrent.CompletionStage;
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
+import helloworld.Helloworld.*;
+
+class GreeterServiceImpl implements GreeterService {
+  public CompletionStage<HelloReply> sayHello(HelloRequest request) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Source<HelloReply, NotUsed> streamHellos(Source<HelloRequest, NotUsed> in) {
+    throw new UnsupportedOperationException();
+  }
+
+  public CompletionStage<HelloReply> itKeepsTalking(Source<HelloRequest, NotUsed> in) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Source<HelloReply, NotUsed> itKeepsReplying(HelloRequest request) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/src/main/protobuf/helloworld.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
@@ -1,0 +1,3 @@
+> compile
+
+$ exists target/scala-2.12/src_managed/main/helloworld/Helloworld.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
@@ -1,0 +1,4 @@
+enablePlugins(JavaAgent)
+enablePlugins(AkkaGrpcPlugin)
+
+javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6" % "runtime"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))
+
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/src/main/protobuf/helloworld.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/src/main/scala/helloworld/GreeterServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/src/main/scala/helloworld/GreeterServiceImpl.scala
@@ -1,0 +1,17 @@
+package helloworld
+
+import scala.concurrent.Future
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+class GreeterServiceImpl extends GreeterService {
+  override def sayHello(in: HelloRequest): Future[HelloReply] = ???
+
+  override def streamHellos(in: Source[HelloRequest, NotUsed]): Source[HelloReply, NotUsed] = ???
+
+  override def itKeepsTalking(in: Source[HelloRequest, NotUsed]): Future[HelloReply] = ???
+
+  override def itKeepsReplying(in: HelloRequest): Source[HelloReply, NotUsed] = ???
+
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
@@ -1,0 +1,6 @@
+> compile
+
+$ exists target/scala-2.12/src_managed
+$ exists target/scala-2.12/src_managed/main/helloworld/HelloRequest.scala
+$ exists target/scala-2.12/src_managed/main/helloworld/HelloworldProto.scala
+$ exists target/scala-2.12/src_managed/main/helloworld/GreeterService.scala


### PR DESCRIPTION
Follow the behavior of:
- protobuf-java: https://github.com/protocolbuffers/protobuf/blob/2228af6/src/google/protobuf/compiler/java/java_helpers.cc#L243-L257
- scalapb: https://github.com/scalapb/ScalaPB/blob/d5e3c33/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala#L831-L835

The Scala codegen was already working without a `java_package` (since it uses the scalapb descriptor implicits), but I added a scripted test anyway.