### PR TITLE
bump sbt-protoc & fix compatibility with other sbt-protoc plugins

### DIFF
--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -22,11 +22,9 @@ you have to inherit the `.proto` definitions from `Compile` over to `Test`:
 
 @@snip[build.sbt](/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt) { #test }
 
-If you have other configurations with `.proto` sources (for example `IntegrationTest`), you can enable the plugin on them:
+If you have other configurations with `.proto` sources (for example `IntegrationTest`), you must first declare them and enable the plugin on them:
 
-```
-.settings(AkkaGrpcPlugin.configSettings(IntegrationTest))
-```
+@@snip[build.sbt](/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt) { #it }
 
 ### Generating server "power APIs"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 enablePlugins(BuildInfoPlugin)
 
-val sbtProtocV = "0.99.29"
+val sbtProtocV = "0.99.31"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -97,7 +97,8 @@ object AkkaGrpcPlugin extends AutoPlugin {
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
-      sbtprotoc.ProtocPlugin.protobufConfigSettings ++
+      (if (config == Compile) Seq() // already supported by sbt-protoc by default
+       else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
         unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,
         watchSources in Defaults.ConfigGlobal ++= (sources in PB.recompile).value,

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -97,7 +97,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
-      (if (config == Compile) Seq() // already supported by sbt-protoc by default
+      (if (config == Compile || config == Test) Seq() // already supported by sbt-protoc by default
        else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
         unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -7,8 +7,11 @@ Test / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client)
 Test / PB.protoSources ++= (Compile / PB.protoSources).value
 //#test
 
+//#it
 configs(IntegrationTest)
 Defaults.itSettings
 AkkaGrpcPlugin.configSettings(IntegrationTest)
+
 IntegrationTest / akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 IntegrationTest / PB.protoSources ++= (Compile / PB.protoSources).value
+//#it

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
@@ -1,0 +1,6 @@
+enablePlugins(ProtocJSPlugin) // enable it first to test possibility of getting overriden
+
+enablePlugins(JavaAgent)
+enablePlugins(AkkaGrpcPlugin)
+
+javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6" % "runtime"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocJSPlugin.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocJSPlugin.scala
@@ -10,5 +10,5 @@ object ProtocJSPlugin extends AutoPlugin {
   override def requires: Plugins = ProtocPlugin
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    inConfig(Compile)(PB.targets += PB.gens.js -> resourceManaged.value / "js")
+    Seq(Compile, Test).flatMap(inConfig(_)(PB.targets += PB.gens.js -> resourceManaged.value / "js"))
 }

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocJSPlugin.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocJSPlugin.scala
@@ -1,0 +1,14 @@
+import sbt.Keys._
+import sbt._
+import sbtprotoc.ProtocPlugin
+import sbtprotoc.ProtocPlugin.autoImport.PB
+
+object ProtocJSPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = noTrigger
+
+  override def requires: Plugins = ProtocPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    inConfig(Compile)(PB.targets += PB.gens.js -> resourceManaged.value / "js")
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))
+
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/src/main/protobuf/helloworld.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.helloworld.grpc";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/src/test/protobuf/echo.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/src/test/protobuf/echo.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.echo.grpc";
+
+package echo;
+
+// The greeting service definition.
+service EchoService {
+    rpc Echo (EchoMessage) returns (EchoMessage) {}
+}
+
+message EchoMessage {
+    string payload = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
@@ -1,0 +1,4 @@
+> compile
+
+$ exists target/scala-2.12/resource_managed/main/js/hellorequest.js
+$ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
@@ -2,3 +2,7 @@
 
 $ exists target/scala-2.12/resource_managed/main/js/hellorequest.js
 $ exists target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloRequest.scala
+
+> test:compile
+$ exists target/scala-2.12/resource_managed/test/js/echomessage.js
+$ exists target/scala-2.12/src_managed/test/example/myapp/echo/grpc/EchoMessage.scala


### PR DESCRIPTION
This is a second take at https://github.com/akka/akka-grpc/pull/696, which had silently regressed because of https://github.com/akka/akka-grpc/pull/702.

As described in the commit messages:
* cc1c166 fixes and enforce the compatibility with other plugins affecting sbt-protoc keys in `Compile` (what should have been done in https://github.com/akka/akka-grpc/pull/696)
* 415866b bumps sbt-protoc (which does not need any change)
* 66850c0 makes use of https://github.com/thesamet/sbt-protoc/blob/master/CHANGELOG.md#09931 to extend the support of cc1c166 to `Test`
* 2bd5204 is a bit unrelated, but makes more explicit what is needed for `IntegrationTest` to work as expected (as already tested by https://github.com/akka/akka-grpc/blob/v0.8.2/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt#L10-L14)

I chose to group all these commits in the same PR as the sbt-protoc bump is mostly useful for configuration improvements.