### PR TITLE
Adds a scripted tests which uses Akka 2.6.x

### DIFF
--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/build.sbt
@@ -1,0 +1,6 @@
+enablePlugins(JavaAgent)
+enablePlugins(AkkaGrpcPlugin)
+
+javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6" % "runtime"
+
+dependencyOverrides += "com.typesafe.akka" %% "akka-stream" % "2.6.4"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))
+
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/src/main/protobuf/helloworld.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "example.myapp.helloworld.grpc";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/src/main/scala/example/myapp/helloworld/GreeterServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/src/main/scala/example/myapp/helloworld/GreeterServiceImpl.scala
@@ -1,0 +1,19 @@
+package example.myapp.helloworld
+
+import scala.concurrent.Future
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+import example.myapp.helloworld.grpc._
+
+class GreeterServiceImpl extends GreeterService {
+  override def sayHello(in: HelloRequest): Future[HelloReply] = ???
+
+  override def streamHellos(in: Source[HelloRequest, NotUsed]): Source[HelloReply, NotUsed] = ???
+
+  override def itKeepsTalking(in: Source[HelloRequest, NotUsed]): Future[HelloReply] = ???
+
+  override def itKeepsReplying(in: HelloRequest): Source[HelloReply, NotUsed] = ???
+
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
References #904

Adds a scripted test where the project explicitly overrides Akka to `2.6.x`. We can get rid of it after akka-grpc 1.1.

The new test is a copy/paste of the existing `01-gen-basic-server`. I made the improvement on a branch from `0.8.3` to see the tests fail and then rebased to `HEAD` and the test passed (as expected).
