### PR TITLE
Makes concat public

### DIFF
--- a/runtime/src/main/scala/akka/grpc/scaladsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ServiceHandler.scala
@@ -31,7 +31,7 @@ object ServiceHandler {
       handlers: PartialFunction[HttpRequest, Future[HttpResponse]]*): HttpRequest => Future[HttpResponse] =
     concat(handlers: _*).orElse { case _ => notFound }
 
-  private[scaladsl] def concat(handlers: PartialFunction[HttpRequest, Future[HttpResponse]]*)
+  def concat(handlers: PartialFunction[HttpRequest, Future[HttpResponse]]*)
       : PartialFunction[HttpRequest, Future[HttpResponse]] =
     handlers.foldLeft(PartialFunction.empty[HttpRequest, Future[HttpResponse]]) {
       case (acc, pf) => acc.orElse(pf)


### PR DESCRIPTION
I want to be able to concatenate the Service and the Service Reflection for reuse.

For instance, it's handy to have a class like:
```scala

class GrpcServer(
  grpcPort: Int,
  grpcServices: PartialFunction[HttpRequest, Future[HttpResponse]]*
)(
  override implicit val ec: ExecutionContext,
  override implicit val system: ActorSystem,
  override implicit val materializer: ActorMaterializer
) extends Server {

  override val port: Int = grpcPort

  override val services: Service =
    ServiceHandler.concatOrNotFound(grpcServices: _*).asInstanceOf[Service]

}
```

And then a separate one that does authentication
```Scala
class AuthenticatedGrpcServer(
  grpcPort: Int,
  authenticator: Authenticator,
  authedServices: PartialFunction[HttpRequest, Future[HttpResponse]]*
)(
  override implicit val ec: ExecutionContext,
  override implicit val system: ActorSystem,
  override implicit val materializer: ActorMaterializer
) extends Server {
  override val port: Int = grpcPort

  override val services: Service = Route
    .asyncHandler(
      authenticator
        .authenticationDirective { ctx =>
          ServiceHandler
            .concatOrNotFound(authedServices: _*)(ctx.request)
            .map(RouteResult.Complete)
        }
    )

}
```

So then we can host it like this
```Scala

  val unauthedServer: Server = new GrpcServer(
    grpcPort,
    service1,
    service2,
    service3,
  )

  val authedServer: Server = new AuthenticatedGrpcServer(
    authGrpcPort,
    authenticator,
    service1,
    service3,
  )
```

But that now means I have to pass in reflection separate into each of those services. 
I believe it's easiest to concat them at the top then
```Scala
  val service1 = ServiceHandler.concat(
    Service1.partial(new Service1Impl)),
    ServerReflection.partial(List(Service1))
)
```