### PR TITLE
Make "default" private

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import akka.grpc.Dependencies
 import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
 import akka.grpc.ProjectExtensions._
 import akka.grpc.build.ReflectiveCodeGen
+import com.typesafe.tools.mima.core._
 
 scalaVersion := scala212
 
@@ -42,6 +43,9 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
     // We don't actually promise binary compatibility before 1.0.0, but want to
     // introduce the tooling
     mimaPreviousArtifacts := Set(organization.value %% "akka-grpc-runtime" % previousStableVersion.value.get),
+    mimaBinaryIssueFilters ++= Seq(
+        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.javadsl.GrpcExceptionHandler.default")))
+  .settings(
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"))

--- a/build.sbt
+++ b/build.sbt
@@ -43,9 +43,6 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
     // We don't actually promise binary compatibility before 1.0.0, but want to
     // introduce the tooling
     mimaPreviousArtifacts := Set(organization.value %% "akka-grpc-runtime" % previousStableVersion.value.get),
-    mimaBinaryIssueFilters ++= Seq(
-        ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.javadsl.GrpcExceptionHandler.default")))
-  .settings(
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"))

--- a/runtime/src/main/mima-filters/0.8.4.backwards.excludes/allow-either-classic-or-typed-actorsystem.backwards.excludes
+++ b/runtime/src/main/mima-filters/0.8.4.backwards.excludes/allow-either-classic-or-typed-actorsystem.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.javadsl.GrpcExceptionHandler.default")

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
@@ -33,7 +33,7 @@ object GrpcExceptionHandler {
 
   /** INTERNAL API */
   @InternalApi
-  def default(system: ActorSystem): jFunction[Throwable, Trailers] =
+  private def default(system: ActorSystem): jFunction[Throwable, Trailers] =
     new jFunction[Throwable, Trailers] {
       override def apply(param: Throwable): Trailers = param match {
         case e: ExecutionException =>


### PR DESCRIPTION
References #761

I think exposing `GrpcExceptionHandler.default` is because:

- `default` is a reserved work in Java8+
- users will probably use `GrpcExceptionHandler.defaultMapper` instead (invoking `MySvcHandlerFactory.create(new MySvcImpl(mat), GrpcExceptionHandler.defaultMapper(), system);`)

If we want to keep it public, we probably need to change the argument type to `ClassicActorSystem.Provider` anyway.