### PR TITLE
Missing private modifiers

### DIFF
--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -6,6 +6,7 @@ package akka.grpc
 
 import akka.NotUsed
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
 import akka.grpc.internal.{ Codec, Codecs, GrpcProtocolNative, GrpcProtocolWeb, GrpcProtocolWebText }
 import akka.http.javadsl.{ model => jmodel }
@@ -33,8 +34,8 @@ trait GrpcProtocol {
    * Constructs a protocol writer for writing gRPC protocol frames for this variant
    * @param codec the compression codec to encode data frame bodies with.
    */
-  @InternalApi
-  private[grpc] def newWriter(codec: Codec): GrpcProtocolWriter
+  @InternalStableApi
+  def newWriter(codec: Codec): GrpcProtocolWriter
 
   /**
    * INTERNAL API
@@ -42,8 +43,8 @@ trait GrpcProtocol {
    * Constructs a protocol reader for reading gRPC protocol frames for this variant.
    * @param codec the compression codec to decode data frame bodies with.
    */
-  @InternalApi
-  private[grpc] def newReader(codec: Codec): GrpcProtocolReader
+  @InternalStableApi
+  def newReader(codec: Codec): GrpcProtocolReader
 }
 
 /**

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -34,7 +34,7 @@ trait GrpcProtocol {
    * @param codec the compression codec to encode data frame bodies with.
    */
   @InternalApi
-  def newWriter(codec: Codec): GrpcProtocolWriter
+  private[grpc] def newWriter(codec: Codec): GrpcProtocolWriter
 
   /**
    * INTERNAL API
@@ -43,7 +43,7 @@ trait GrpcProtocol {
    * @param codec the compression codec to decode data frame bodies with.
    */
   @InternalApi
-  def newReader(codec: Codec): GrpcProtocolReader
+  private[grpc] def newReader(codec: Codec): GrpcProtocolReader
 }
 
 /**


### PR DESCRIPTION
References #761

A couple of methods annotated as internal and documented as such (but still not `private`). I'm not 100% sure this is the correct fix (or the annotation and docs should be removed instead).
