### PR TITLE
Add sonatype staging for scripted tests

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,6 +16,7 @@ object Common extends AutoPlugin {
       organization := "com.lightbend.akka.grpc",
       organizationName := "Lightbend Inc.",
       organizationHomepage := Some(url("https://www.lightbend.com/")),
+      resolvers += Resolver.sonatypeRepo("staging"),
       homepage := Some(url("https://akka.io/")),
       scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-grpc"), "git@github.com:akka/akka-grpc")),
       developers += Developer(

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -1,3 +1,4 @@
+resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
@@ -1,3 +1,4 @@
+resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
@@ -1,3 +1,4 @@
+resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -1,7 +1,6 @@
-organization := "com.lightbend.akka.grpc"
+resolvers += Resolver.sonatypeRepo("staging")
 
-// For the akka-http snapshot
-resolvers += Resolver.bintrayRepo("akka", "maven")
+organization := "com.lightbend.akka.grpc"
 
 val grpcVersion = "1.28.1" // checked synced by GrpcVersionSyncCheckPlugin
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(AkkaGrpcPlugin)
 
 Compile / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Server)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(ProtocJSPlugin) // enable it first to test possibility of getting overriden
 
 enablePlugins(JavaAgent)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-26/build.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.sonatypeRepo("staging")
+
 enablePlugins(JavaAgent)
 enablePlugins(AkkaGrpcPlugin)
 


### PR DESCRIPTION
Makes it easier to smoke-test other releases by running the
Akka gRPC scripted tests