### PR TITLE
Don't include .proto source into artifacts

### DIFF
--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -100,7 +100,6 @@ object AkkaGrpcPlugin extends AutoPlugin {
       (if (config == Compile || config == Test) Seq() // already supported by sbt-protoc by default
        else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
-        unmanagedResourceDirectories ++= (resourceDirectories in PB.recompile).value,
         watchSources in Defaults.ConfigGlobal ++= (sources in PB.recompile).value,
         akkaGrpcGenerators := {
           generatorsFor(


### PR DESCRIPTION
This was originally added in https://github.com/akka/akka-grpc/pull/149
for dev-mode in play/lagom. Since we don't want .proto definitions to
appear in our output artifacts we have to remove this connection here,
though we might possibly add it back in play-grpc.