### PR TITLE
Don't use github milestones

### DIFF
--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -14,16 +14,12 @@ Variables to be expanded in this template:
 
 ### before the release
 
-- [ ] Create a new milestone for the [next version](https://github.com/akka/akka-grpc/milestones)
-- [ ] Check [closed issues without a milestone](https://github.com/akka/akka-grpc/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20no%3Amilestone) and either assign them the 'upcoming' release milestone or `invalid/not release-bound`
 - [ ] Make sure all important / big PRs have been merged by now
 
 ### Preparing release notes in the documentation / announcement
 
 - [ ] For non-patch releases: rename the 'akka-grpc-x.x-stable' and 'akka-grpc-supported-x.x-stable' reporting projects in [WhiteSource](https://saas.whitesourcesoftware.com/Wss/WSS.html) accordingly (unfortunately this requires permissions that cannot be shared outside of Lightbend)
 - [ ] For non-patch releases: Create a news item draft PR on [akka.github.com](https://github.com/akka/akka.github.com), using the milestone
-- [ ] Move all [unclosed issues](https://github.com/akka/akka-grpc/issues?q=is%3Aopen+is%3Aissue+milestone%3A$VERSION$) for this milestone to the next milestone
-- [ ] Close the [milestone](https://github.com/akka/akka-grpc/milestones?direction=asc&sort=due_date)
 
 ### Cutting the release
 


### PR DESCRIPTION
The last few releases using release-drafter to have an overview of the changes
in a release worked pretty well, and avoided the overhead of using a milestone.
Maybe let's not require using milestones anymore?