### PR TITLE
Fix server walkthrough vars

### DIFF
--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -21,11 +21,10 @@ sbt
     enablePlugins(JavaAgent)
     javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9" % "runtime;test"
     ```
-​    @@@
+    @@@
 
 Gradle
 :   @@@vars
-
     ```gradle
     buildscript {
       repositories {
@@ -48,7 +47,7 @@ Gradle
       mavenCentral()
     }
     ```
-​    @@@
+    @@@
 
 Maven
 :   @@@vars


### PR DESCRIPTION
The cause of the issue was a zero-width unicode character...

Checked with "grep -ra $'\u200b' docs/" that there are no more.

refs #980