### PR TITLE
Docs: show dependencies

### DIFF
--- a/docs/src/main/paradox/client/walkthrough.md
+++ b/docs/src/main/paradox/client/walkthrough.md
@@ -92,6 +92,14 @@ Maven
 
 For a complete overview of the configuration options see the chapter for your build tool, @ref[sbt](../buildtools/sbt.md), @ref[Gradle](../buildtools/gradle.md) or @ref[Maven](../buildtools/maven.md).
 
+### Dependencies
+
+The Akka gRPC plugin makes your code depend on the `akka-grpc-runtime` library.
+
+The table below shows direct dependencies of it and the second tab shows all libraries it depends on transitively. Be aware that the `io.grpc.grpc-api` library depends on Guava.
+
+@@dependencies { projectId="akka-grpc-runtime" }
+
 ## Generating Service Stubs
 
 To use a service, such as the Hello World service described in the @ref:[server documentation](../server/index.md),

--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -94,6 +94,14 @@ Maven
 
 For a complete overview of the configuration options see the chapter for your build tool, @ref[sbt](../buildtools/sbt.md), @ref[Gradle](../buildtools/gradle.md) or @ref[Maven](../buildtools/maven.md).
 
+### Dependencies
+
+The Akka gRPC plugin makes your code depend on the `akka-grpc-runtime` library.
+
+The table below shows direct dependencies of it and the second tab shows all libraries it depends on transitively. Be aware that the `io.grpc.grpc-api` library depends on Guava.
+
+@@dependencies { projectId="akka-grpc-runtime" }
+
 ## Writing a service definition
 
 Define the interfaces you want to implement in your project's

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,6 +19,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.24")
 
 // docs
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.33")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")


### PR DESCRIPTION
Show the direct and transitive dependencies of Akka gRPC runtime in the server and client docs.
Specifically name Guava which sometimes causes trouble.