### PR TITLE
Make server codegen more deterministic by ensuring service methods ordering #988

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Service.scala
@@ -20,7 +20,7 @@ final case class Service(
     serverPowerApi: Boolean,
     usePlayActions: Boolean,
     comment: Option[String] = None) {
-  def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
+  def serializers: Seq[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).distinct
   def packageDir = packageName.replace('.', '/')
 }
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -19,7 +19,7 @@ case class Service(
     serverPowerApi: Boolean,
     usePlayActions: Boolean,
     comment: Option[String] = None) {
-  def serializers: Set[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).toSet
+  def serializers: Seq[Serializer] = (methods.map(_.deserializer) ++ methods.map(_.serializer)).distinct
   def packageDir = packageName.replace('.', '/')
 }
 

--- a/codegen/src/main/twirl/templates/JavaClient/GenMethodImports.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/GenMethodImports.scala.txt
@@ -12,5 +12,5 @@
       case akka.grpc.gen.ClientStreaming => singleResponse
       case akka.grpc.gen.ServerStreaming => streamResponse
       case akka.grpc.gen.BidiStreaming => streamResponse
-  }.toSet.mkString("\n")
+  }.distinct.mkString("\n")
 }

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -24,7 +24,7 @@ import akka.grpc.internal.ClientState
 @{
   def withSingleResponse(stmt: String) = Set("import akka.grpc.scaladsl.SingleResponseRequestBuilder", stmt)
   def withStreamResponse(stmt: String) = Set("import akka.grpc.scaladsl.StreamResponseRequestBuilder", stmt)
-  service.methods.toSet.flatMap { method: akka.grpc.gen.scaladsl.Method =>
+  service.methods.distinct.flatMap { method: akka.grpc.gen.scaladsl.Method =>
 
     val statements = method.methodType match {
       case akka.grpc.gen.Unary => withSingleResponse("import akka.grpc.internal.ScalaUnaryRequestBuilder")


### PR DESCRIPTION
From what I could tell, the `.toSet` transformations related to `Service.methods` were done to remove duplicates. Changing to a `Seq` via `.distinct` to ensure the ordering is deterministic.

Tests continue to pass with `sbt test`.

Also checked the example produced by 
```
sbt "project akka-grpc-plugin-tester-scala" test
sbt "project akka-grpc-plugin-tester-java" test
```
and they look consistent with what was generated before.