### PR TITLE
Update to ScalaPB 0.10.6 and support running in a sandboxed classloader.

### DIFF
--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -7,10 +7,13 @@ akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
 val grpcVersion = "1.30.0" // checked synced by GrpcVersionSyncCheckPlugin
 
+val runtimeProject = ProjectRef(file("../"), "akka-grpc-runtime")
+
+val codeGenProject = ProjectRef(file("../"), "akka-grpc-codegen")
+
 val root = project.in(file("."))
   .dependsOn(
-    ProjectRef(file("../"), "akka-grpc-runtime"),
-    ProjectRef(file("../"), "akka-grpc-codegen"),
+    runtimeProject
   )
   // Use this instead of above when importing to IDEA, after publishLocal and replacing the version here
   /*
@@ -18,13 +21,16 @@ val root = project.in(file("."))
     "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % "0.1+32-fd597fcb+20180618-1248"
   ))
   */
-  .settings(libraryDependencies ++= Seq(
-    "io.grpc" % "grpc-testing" % grpcVersion,
-    "org.hdrhistogram" % "HdrHistogram" % "2.1.10",
-    "org.apache.commons" % "commons-math3" % "3.6",
-    "org.scalatest" %% "scalatest" % "3.1.2" % "test",
-    "org.scalatestplus" %% "junit-4-12" % "3.1.2.0" % "test"
-  ))
-
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.grpc" % "grpc-testing" % grpcVersion,
+      "org.hdrhistogram" % "HdrHistogram" % "2.1.10",
+      "org.apache.commons" % "commons-math3" % "3.6",
+      "org.scalatest" %% "scalatest" % "3.1.2" % "test",
+      "org.scalatestplus" %% "junit-4-12" % "3.1.2.0" % "test"
+    ),
+    Compile / PB.generate := ((Compile / PB.generate) dependsOn (
+        codeGenProject / Compile / publishLocal)).value
+  )
 
 javacOptions in compile += "-Xlint:deprecation"

--- a/codegen/src/main/scala/akka/grpc/gen/Logging.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Logging.scala
@@ -50,3 +50,20 @@ class FileLogger(path: String) extends Logger {
     printer.flush()
   }
 }
+
+/** Logger that forwards calls to another Logger via reflection.
+ *
+ *  This enables a code generator that is loaded inside a sandboxed class loader to
+ *  use a logger that lives in a different class loader.
+ */
+class ReflectiveLogger(logger: Object) extends Logger {
+  private val debugMethod = logger.getClass.getMethod("debug", classOf[String])
+  private val infoMethod = logger.getClass.getMethod("info", classOf[String])
+  private val warnMethod = logger.getClass.getMethod("warn", classOf[String])
+  private val errorMethod = logger.getClass.getMethod("error", classOf[String])
+
+  def debug(text: String): Unit = debugMethod.invoke(logger, text)
+  def info(text: String): Unit = infoMethod.invoke(logger, text)
+  def warn(text: String): Unit = warnMethod.invoke(logger, text)
+  def error(text: String): Unit = errorMethod.invoke(logger, text)
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 enablePlugins(BuildInfoPlugin)
 
-val sbtProtocV = "0.99.32"
+val sbtProtocV = "0.99.34"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 
@@ -30,4 +30,4 @@ libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.7.0.20200311
 // scripted testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.6"

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -7,7 +7,7 @@ package akka.grpc.sbt
 import akka.grpc.gen.CodeGenerator.ScalaBinaryVersion
 import akka.grpc.gen.scaladsl.{ ScalaClientCodeGenerator, ScalaServerCodeGenerator, ScalaTraitCodeGenerator }
 import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerator, JavaServerCodeGenerator }
-import akka.grpc.gen.{ Logger => GenLogger, ProtocSettings }
+import akka.grpc.gen.{ Logger => GenLogger, BuildInfo, ProtocSettings }
 import protocbridge.Generator
 import sbt.Keys._
 import sbt.{ GlobFilter, _ }
@@ -148,7 +148,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
         generator match {
           case PB.gens.java =>
             settings.filter(ProtocSettings.protocJava.contains)
-          case protocbridge.JvmGenerator("scala", ScalaPbCodeGenerator) =>
+          case protocbridge.JvmGenerator("scala", ScalaPbCodeGenerator) | scalapb.gen.SandboxedGenerator =>
             settings.filter(ProtocSettings.scalapb.contains)
           case _ =>
             settings
@@ -164,7 +164,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
     import AkkaGrpc._
     def toGen(codeGenerator: akka.grpc.gen.CodeGenerator) = toGenerator(codeGenerator, scalaBinaryVersion, logger)
     // these two are the model/message (protoc) generators
-    def ScalaGenerator: protocbridge.Generator = protocbridge.JvmGenerator("scala", ScalaPbCodeGenerator)
+    def ScalaGenerator: protocbridge.Generator = scalapb.gen.SandboxedGenerator
     // we have a default flat_package, but that doesn't play with the java generator (it fails)
     def JavaGenerator: protocbridge.Generator = PB.gens.java
 
@@ -195,21 +195,37 @@ object AkkaGrpcPlugin extends AutoPlugin {
       codeGenerator: akka.grpc.gen.CodeGenerator,
       scalaBinaryVersion: ScalaBinaryVersion,
       logger: GenLogger): protocbridge.Generator = {
-    val adapter = new ProtocBridgeSbtPluginCodeGenerator(codeGenerator, scalaBinaryVersion, logger)
-    protocbridge.JvmGenerator(codeGenerator.name, adapter)
+    // This matches the sbt binary version (2.12)
+    val codegenScalaBinaryVersion = CrossVersion.binaryScalaVersion(BuildInfo.scalaVersion)
+    protocbridge.SandboxedJvmGenerator(
+      codeGenerator.name,
+      protocbridge.Artifact(BuildInfo.organization, s"${BuildInfo.name}_$codegenScalaBinaryVersion", BuildInfo.version),
+      codeGenerator.suggestedDependencies(scalaBinaryVersion),
+      new ProtocBridgeSbtPluginCodeGenerator(_, codeGenerator.getClass.getName, logger))
   }
 
   /**
-   * Adapts existing [[akka.grpc.gen.CodeGenerator]] into the protocbridge required type
+   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type.
    */
-  private[akka] class ProtocBridgeSbtPluginCodeGenerator(
-      impl: akka.grpc.gen.CodeGenerator,
-      scalaBinaryVersion: ScalaBinaryVersion,
-      logger: GenLogger)
+  private[akka] class ProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: GenLogger)
       extends protocbridge.ProtocCodeGenerator {
-    override def run(request: Array[Byte]): Array[Byte] = impl.run(request, logger)
-    override def suggestedDependencies: Seq[protocbridge.Artifact] = impl.suggestedDependencies(scalaBinaryVersion)
-    override def toString = s"ProtocBridgeSbtPluginCodeGenerator(${impl.name}: $impl)"
+    val genClass = classLoader.loadClass(className)
+    val module = genClass.getField("MODULE$").get(null)
+    private val reflectiveLogger: Object =
+      classLoader
+        .loadClass("akka.grpc.gen.ReflectiveLogger")
+        .asInstanceOf[Class[Object]]
+        .getConstructor(classOf[Object])
+        .newInstance(logger)
+
+    private val runMethods =
+      module.getClass.getMethods
+        .find(m => m.getName == "run" && m.getParameterTypes()(0) == classOf[Array[Byte]])
+        .getOrElse(throw new RuntimeException("Could not find 'run' method that takes an Array[Byte]"))
+
+    override def run(request: Array[Byte]): Array[Byte] =
+      runMethods.invoke(module, request, reflectiveLogger).asInstanceOf[Array[Byte]]
+    override def toString = s"ProtocBridgeSbtPluginCodeGenerator(${className})"
   }
 
 }


### PR DESCRIPTION
This change uses a new functionality of protocbridge which enables
code generators to be loaded via a sandboxed classloader. This eliminates the
possibility of binary compatibility problems with SBT, protobuf-java or ScalaPB
itself. This would also enable moving forward to protobuf-java 3.12.x as it is
incompatible with the version of protobuf-java presently shipped with SBT.