### PR TITLE
fix: implicit scala-library version

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -165,7 +165,8 @@ class AkkaGrpcPlugin implements Plugin<Project> {
 
         def scalaVersions = cfg.incoming.resolutionResult.allDependencies
             .findAll { it.requested.moduleIdentifier.name == 'scala-library' }
-            .collect { it.requested.versionConstraint.toString() }.collect { it.split("\\.").init().join(".") }.unique()
+            .collect { it.requested.versionConstraint.toString() }.collect { it.split("\\.").init().join(".") }
+            .findAll { it }.unique().sort()
 
         if (scalaVersions.size() != 1) {
             throw new GradleException("$PLUGIN_CODE requires a single major.minor version of `org.scala-lang:scala-library` in compileClasspath.\nFound $scalaVersions")


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #1069 #1067 

@raboof this is a fix for advanced usages of `Gradle`  - while dependency versions are not declared explicitly, but instead constraints are used to align version across multi build projects \ BOMs etc.