### PR TITLE
Don't update beyond scalatest 3.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,3 +11,7 @@ updates.ignore = [
   { groupId = "com.typesafe.akka", artifactId = "akka-testkit" },
   { groupId = "com.typesafe.akka", artifactId = "akka-multi-node-testkit" },
 ]
+
+updates.pin [
+  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." },
+]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
     val grpc = "1.31.1" // checked synced by GrpcVersionSyncCheckPlugin
 
-    val scalaTest = "3.1.3"
+    val scalaTest = "3.1.4"
 
     val maven = "3.6.3"
   }


### PR DESCRIPTION
Until akka updates, https://github.com/akka/akka/issues/29368

Replaces #1094