### PR TITLE
Adding grpc Scalapb option

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/ProtocSettings.scala
@@ -16,5 +16,6 @@ object ProtocSettings {
     "single_line_to_proto_string",
     "ascii_format_to_string",
     "no_lenses",
-    "retain_source_code_info")
+    "retain_source_code_info",
+    "grpc")
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -85,6 +85,7 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
       case (p, "ascii_format_to_string")      => p.copy(asciiFormatToString = true)
       case (p, "no_lenses")                   => p.copy(lenses = false)
       case (p, "retain_source_code_info")     => p.copy(retainSourceCodeInfo = true)
+      case (p, "grpc")                        => p.copy(grpc = true)
       case (x, _)                             => x
     }
 }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Allows pass-through of the `grpc` ScalaPB generator option.  The intent is to allow the ServiceNameGrpc.scala class to be generated for uses outside the scope of an Akka gRPC client or server.  The case we ran into was consuming the native io.grpc service descriptor in the context of a Gatling test (via [this library](https://github.com/phiSgr/gatling-grpc)).  The option must be explicitly included (defaults to false in the context of `akka-grpc`).

I looked for tests I could extend to cover this but didn't find any, please do point me in the right direction if I managed to overlook them.  
