### PR TITLE
Don't cancel the incoming stream after reading the parameter

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
     val grpc = "1.31.1" // checked synced by GrpcVersionSyncCheckPlugin
 
-    val scalaTest = "3.1.3"
+    val scalaTest = "3.1.4"
 
     val maven = "3.6.3"
   }
@@ -66,6 +66,7 @@ object Dependencies {
     val scalaTestPlusJunit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % "test" // Apache V2
     val akkaDiscoveryConfig = "com.typesafe.akka" %% "akka-discovery" % Versions.akka % "test"
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test"
+    val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka % "test"
   }
 
   object Runtime {
@@ -117,7 +118,8 @@ object Dependencies {
     Runtime.logback,
     Test.scalaTest.withConfigurations(Some("compile")),
     Test.scalaTestPlusJunit.withConfigurations(Some("compile")),
-    Test.akkaTestkit)
+    Test.akkaTestkit,
+    Test.akkaStreamTestkit)
 
   val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen

--- a/runtime/src/main/scala/akka/grpc/internal/SingleParameterSink.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/SingleParameterSink.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.grpc.internal
+
+import java.util.concurrent.CompletionStage
+
+import akka.annotation.InternalApi
+import akka.stream.scaladsl.Sink
+import akka.stream.{ javadsl, AbruptStageTerminationException, Attributes, Inlet, SinkShape }
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler }
+
+import scala.concurrent.{ Future, Promise }
+
+/**
+ * Stage that reads a single parameter from the stream
+ *
+ *  This sink does not, like 'Sink.head', complete the stage as soon as the first element has arrived.
+ *  This is important to avoid triggering the stream teardown after consuming the first message.
+ *
+ * INTERNAL API
+ */
+@InternalApi private[internal] final class SingleParameterStage[T]
+    extends GraphStageWithMaterializedValue[SinkShape[T], Future[T]] {
+
+  val in: Inlet[T] = Inlet("singleParameterSink.in")
+
+  override def shape: SinkShape[T] = SinkShape.of(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[T]) = {
+    val p: Promise[T] = Promise()
+    (
+      new GraphStageLogic(shape) with InHandler {
+        override def preStart(): Unit = pull(in)
+
+        def onPush(): Unit = {
+          p.success(grab(in))
+          // We expect only a completion
+          pull(in)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (!p.isCompleted) {
+            p.failure(new MissingParameterException())
+          }
+          completeStage()
+        }
+
+        override def onUpstreamFailure(ex: Throwable): Unit = {
+          p.tryFailure(ex)
+          failStage(ex)
+        }
+
+        override def postStop(): Unit = {
+          if (!p.isCompleted) p.failure(new AbruptStageTerminationException(this))
+        }
+
+        setHandler(in, this)
+      },
+      p.future)
+  }
+
+}
+object SingleParameterSink {
+  def apply[T](): Sink[T, Future[T]] =
+    Sink.fromGraph(new SingleParameterStage[T]).withAttributes(Attributes.name("singleParameterSink"))
+
+  def create[T](): javadsl.Sink[T, CompletionStage[T]] = {
+    import scala.compat.java8.FutureConverters._
+    new javadsl.Sink(SingleParameterSink().mapMaterializedValue(_.toJava))
+  }
+}

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -17,7 +17,7 @@ import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
 import akka.grpc.internal._
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
 import com.github.ghik.silencer.silent
@@ -53,11 +53,7 @@ object GrpcMarshalling {
       implicit u: ProtobufSerializer[T],
       mat: Materializer,
       reader: GrpcProtocolReader): Future[T] = {
-    import mat.executionContext
-    data.via(reader.dataFrameDecoder).map(u.deserialize).runWith(Sink.headOption).flatMap {
-      case Some(element) => Future.successful(element)
-      case None          => Future.failed(new MissingParameterException())
-    }
+    data.via(reader.dataFrameDecoder).map(u.deserialize).runWith(SingleParameterSink())
   }
 
   def unmarshalStream[T](data: Source[ByteString, Any])(


### PR DESCRIPTION
Should fix one of the issues identified in #1081. Unfortunately even with this change, the problem still reproduces, which I didn't expect - so this still needs a closer look.
