### PR TITLE
Expose helpers to bridge external generators to sbt

### DIFF
--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -111,6 +111,7 @@ object ReflectiveCodeGen extends AutoPlugin {
     val tb = universe.runtimeMirror(loader).mkToolBox()
     val source =
       s"""import akka.grpc.sbt.AkkaGrpcPlugin
+          |import akka.grpc.sbt.GeneratorBridge
           |import AkkaGrpcPlugin.autoImport._
           |import AkkaGrpc._
           |import akka.grpc.gen.scaladsl._
@@ -126,7 +127,7 @@ object ReflectiveCodeGen extends AutoPlugin {
           |(targetPath: java.io.File, settings: Seq[String]) => {
           |  val generators =
           |    AkkaGrpcPlugin.generatorsFor(sources, languages, scalaBinaryVersion, logger) ++
-          |    Seq($extraGenerators).map(gen => AkkaGrpcPlugin.toGenerator(gen, scalaBinaryVersion, akka.grpc.gen.StdoutLogger))
+          |    Seq($extraGenerators).map(gen => GeneratorBridge.sandboxedGenerator(gen, scalaBinaryVersion, akka.grpc.gen.StdoutLogger))
           |  AkkaGrpcPlugin.targetsFor(targetPath, settings, generators)
           |}
         """.stripMargin

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -7,7 +7,7 @@ package akka.grpc.sbt
 import akka.grpc.gen.CodeGenerator.ScalaBinaryVersion
 import akka.grpc.gen.scaladsl.{ ScalaClientCodeGenerator, ScalaServerCodeGenerator, ScalaTraitCodeGenerator }
 import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerator, JavaServerCodeGenerator }
-import akka.grpc.gen.{ Logger => GenLogger, BuildInfo, ProtocSettings }
+import akka.grpc.gen.{ ProtocSettings, Logger => GenLogger }
 import protocbridge.Generator
 import sbt.Keys._
 import sbt.{ GlobFilter, _ }
@@ -111,7 +111,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
             akkaGrpcGeneratedLanguages.value,
             ScalaBinaryVersion(scalaBinaryVersion.value),
             generatorLogger) ++ akkaGrpcExtraGenerators.value.map(g =>
-            toGenerator(g, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger))
+            GeneratorBridge.sandboxedGenerator(g, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger))
         },
         // configure the proto gen automatically by adding our codegen:
         PB.targets ++=
@@ -162,7 +162,8 @@ object AkkaGrpcPlugin extends AutoPlugin {
       scalaBinaryVersion: ScalaBinaryVersion,
       logger: GenLogger): Seq[protocbridge.Generator] = {
     import AkkaGrpc._
-    def toGen(codeGenerator: akka.grpc.gen.CodeGenerator) = toGenerator(codeGenerator, scalaBinaryVersion, logger)
+    def toGen(codeGenerator: akka.grpc.gen.CodeGenerator) =
+      GeneratorBridge.sandboxedGenerator(codeGenerator, scalaBinaryVersion, logger)
     // these two are the model/message (protoc) generators
     def ScalaGenerator: protocbridge.Generator = scalapb.gen.SandboxedGenerator
     // we have a default flat_package, but that doesn't play with the java generator (it fails)
@@ -190,42 +191,13 @@ object AkkaGrpcPlugin extends AutoPlugin {
     else generators
   }
 
-  // this transforms the Akka gRPC API generators to the right protocbridge type
-  def toGenerator(
-      codeGenerator: akka.grpc.gen.CodeGenerator,
-      scalaBinaryVersion: ScalaBinaryVersion,
-      logger: GenLogger): protocbridge.Generator = {
-    // This matches the sbt binary version (2.12)
-    val codegenScalaBinaryVersion = CrossVersion.binaryScalaVersion(BuildInfo.scalaVersion)
-    protocbridge.SandboxedJvmGenerator(
-      codeGenerator.name,
-      protocbridge.Artifact(BuildInfo.organization, s"${BuildInfo.name}_$codegenScalaBinaryVersion", BuildInfo.version),
-      codeGenerator.suggestedDependencies(scalaBinaryVersion),
-      new ProtocBridgeSbtPluginCodeGenerator(_, codeGenerator.getClass.getName, logger))
-  }
+  def sandboxedGenerator(codeGenerator: akka.grpc.gen.CodeGenerator): Def.Initialize[protocbridge.Generator] =
+    Def.setting {
+      GeneratorBridge.sandboxedGenerator(codeGenerator, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger)
+    }
 
-  /**
-   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type.
-   */
-  private[akka] class ProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: GenLogger)
-      extends protocbridge.ProtocCodeGenerator {
-    val genClass = classLoader.loadClass(className)
-    val module = genClass.getField("MODULE$").get(null)
-    private val reflectiveLogger: Object =
-      classLoader
-        .loadClass("akka.grpc.gen.ReflectiveLogger")
-        .asInstanceOf[Class[Object]]
-        .getConstructor(classOf[Object])
-        .newInstance(logger)
-
-    private val runMethods =
-      module.getClass.getMethods
-        .find(m => m.getName == "run" && m.getParameterTypes()(0) == classOf[Array[Byte]])
-        .getOrElse(throw new RuntimeException("Could not find 'run' method that takes an Array[Byte]"))
-
-    override def run(request: Array[Byte]): Array[Byte] =
-      runMethods.invoke(module, request, reflectiveLogger).asInstanceOf[Array[Byte]]
-    override def toString = s"ProtocBridgeSbtPluginCodeGenerator(${className})"
-  }
-
+  def jvmGenerator(codeGenerator: akka.grpc.gen.CodeGenerator): Def.Initialize[protocbridge.Generator] =
+    Def.setting {
+      GeneratorBridge.jvmGenerator(codeGenerator, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger)
+    }
 }

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -111,7 +111,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
             akkaGrpcGeneratedLanguages.value,
             ScalaBinaryVersion(scalaBinaryVersion.value),
             generatorLogger) ++ akkaGrpcExtraGenerators.value.map(g =>
-            GeneratorBridge.sandboxedGenerator(g, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger))
+            GeneratorBridge.plainGenerator(g, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger))
         },
         // configure the proto gen automatically by adding our codegen:
         PB.targets ++=
@@ -191,13 +191,15 @@ object AkkaGrpcPlugin extends AutoPlugin {
     else generators
   }
 
+  /** Sandbox a CodeGenerator, to prepare it to be added to akkaGrpcGenerators */
   def sandboxedGenerator(codeGenerator: akka.grpc.gen.CodeGenerator): Def.Initialize[protocbridge.Generator] =
     Def.setting {
       GeneratorBridge.sandboxedGenerator(codeGenerator, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger)
     }
 
-  def jvmGenerator(codeGenerator: akka.grpc.gen.CodeGenerator): Def.Initialize[protocbridge.Generator] =
+  /** Convert a CodeGenerator, to prepare it to be added to akkaGrpcGenerators without sandboxing */
+  def plainGenerator(codeGenerator: akka.grpc.gen.CodeGenerator): Def.Initialize[protocbridge.Generator] =
     Def.setting {
-      GeneratorBridge.jvmGenerator(codeGenerator, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger)
+      GeneratorBridge.plainGenerator(codeGenerator, ScalaBinaryVersion(scalaBinaryVersion.value), generatorLogger)
     }
 }

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
@@ -22,7 +22,7 @@ object GeneratorBridge {
       codeGenerator.suggestedDependencies(scalaBinaryVersion),
       new SandboxedProtocBridgeSbtPluginCodeGenerator(_, codeGenerator.getClass.getName, logger))
   }
-  def jvmGenerator(
+  def plainGenerator(
       codeGenerator: akka.grpc.gen.CodeGenerator,
       scalaBinaryVersion: ScalaBinaryVersion,
       logger: akka.grpc.gen.Logger): protocbridge.Generator = {
@@ -30,8 +30,10 @@ object GeneratorBridge {
     protocbridge.JvmGenerator(codeGenerator.name, adapter)
   }
 
-  /** INTERNAL API */
-  class PlainProtocBridgeSbtPluginCodeGenerator(
+  /**
+   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type without sandboxing.
+   */
+  private class PlainProtocBridgeSbtPluginCodeGenerator(
       impl: akka.grpc.gen.CodeGenerator,
       scalaBinaryVersion: ScalaBinaryVersion,
       logger: akka.grpc.gen.Logger)
@@ -42,11 +44,9 @@ object GeneratorBridge {
   }
 
   /**
-   * INTERNAL API
-   *
-   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type.
+   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type with sandboxing..
    */
-  class SandboxedProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: Logger)
+  private class SandboxedProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: Logger)
       extends protocbridge.ProtocCodeGenerator {
     val genClass = classLoader.loadClass(className)
     val module = genClass.getField("MODULE$").get(null)

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.grpc.sbt
+
+import akka.grpc.gen.Logger
+import akka.grpc.gen.BuildInfo
+import akka.grpc.gen.CodeGenerator.ScalaBinaryVersion
+import sbt.CrossVersion
+
+object GeneratorBridge {
+  def sandboxedGenerator(
+      codeGenerator: akka.grpc.gen.CodeGenerator,
+      scalaBinaryVersion: ScalaBinaryVersion,
+      logger: Logger): protocbridge.Generator = {
+    // This matches the sbt binary version (2.12)
+    val codegenScalaBinaryVersion = CrossVersion.binaryScalaVersion(BuildInfo.scalaVersion)
+    protocbridge.SandboxedJvmGenerator(
+      codeGenerator.name,
+      protocbridge.Artifact(BuildInfo.organization, s"${BuildInfo.name}_$codegenScalaBinaryVersion", BuildInfo.version),
+      codeGenerator.suggestedDependencies(scalaBinaryVersion),
+      new SandboxedProtocBridgeSbtPluginCodeGenerator(_, codeGenerator.getClass.getName, logger))
+  }
+  def jvmGenerator(
+      codeGenerator: akka.grpc.gen.CodeGenerator,
+      scalaBinaryVersion: ScalaBinaryVersion,
+      logger: akka.grpc.gen.Logger): protocbridge.Generator = {
+    val adapter = new PlainProtocBridgeSbtPluginCodeGenerator(codeGenerator, scalaBinaryVersion, logger)
+    protocbridge.JvmGenerator(codeGenerator.name, adapter)
+  }
+
+  /** INTERNAL API */
+  class PlainProtocBridgeSbtPluginCodeGenerator(
+      impl: akka.grpc.gen.CodeGenerator,
+      scalaBinaryVersion: ScalaBinaryVersion,
+      logger: akka.grpc.gen.Logger)
+      extends protocbridge.ProtocCodeGenerator {
+    override def run(request: Array[Byte]): Array[Byte] = impl.run(request, logger)
+    override def suggestedDependencies: Seq[protocbridge.Artifact] = impl.suggestedDependencies(scalaBinaryVersion)
+    override def toString = s"PlainProtocBridgeSbtPluginCodeGenerator($${impl.name}: $$impl)"
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type.
+   */
+  class SandboxedProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: Logger)
+      extends protocbridge.ProtocCodeGenerator {
+    val genClass = classLoader.loadClass(className)
+    val module = genClass.getField("MODULE$").get(null)
+    private val reflectiveLogger: Object =
+      classLoader
+        .loadClass("akka.grpc.gen.ReflectiveLogger")
+        .asInstanceOf[Class[Object]]
+        .getConstructor(classOf[Object])
+        .newInstance(logger)
+
+    private val runMethods =
+      module.getClass.getMethods
+        .find(m => m.getName == "run" && m.getParameterTypes()(0) == classOf[Array[Byte]])
+        .getOrElse(throw new RuntimeException("Could not find 'run' method that takes an Array[Byte]"))
+
+    override def run(request: Array[Byte]): Array[Byte] =
+      runMethods.invoke(module, request, reflectiveLogger).asInstanceOf[Array[Byte]]
+    override def toString = s"SandboxedProtocBridgeSbtPluginCodeGenerator(${className})"
+  }
+
+}

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/GeneratorBridge.scala
@@ -31,7 +31,7 @@ object GeneratorBridge {
   }
 
   /**
-   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type without sandboxing.
+   * Convert a [[akka.grpc.gen.CodeGenerator]] into the protocbridge-required type (without sandboxing).
    */
   private class PlainProtocBridgeSbtPluginCodeGenerator(
       impl: akka.grpc.gen.CodeGenerator,
@@ -44,7 +44,7 @@ object GeneratorBridge {
   }
 
   /**
-   * Uses reflection to load a [[akka.grpc.gen.CodeGenerator]] and turns it into protocbridge required type with sandboxing..
+   * Convert a [[akka.grpc.gen.CodeGenerator]] into the protocbridge-required type, with sandboxing.
    */
   private class SandboxedProtocBridgeSbtPluginCodeGenerator(classLoader: ClassLoader, className: String, logger: Logger)
       extends protocbridge.ProtocCodeGenerator {


### PR DESCRIPTION
Possible solution to #1096, this way the project registering
the additional generator can decide for itself whether to use
sandboxing.

From here the step to just providing something directly to
PB.targets is pretty small as well.