### PR TITLE
(Draft) Interceptor implementing circuit breaking

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -16,12 +16,21 @@ import io.grpc.CallOptions
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
 import io.grpc.netty.shaded.io.grpc.netty.NegotiationType
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
-import io.grpc.netty.shaded.io.netty.handler.ssl.{ SslContext, SslContextBuilder }
-
+import io.grpc.netty.shaded.io.netty.handler.ssl.{SslContext, SslContextBuilder}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Promise
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
+
+import akka.pattern.CircuitBreaker
+import io.grpc.Channel
+import io.grpc.ClientCall
+import io.grpc.ClientInterceptor
+import io.grpc.ClientInterceptors
+import io.grpc.ForwardingClientCallListener
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
+import io.grpc.Status
 
 /**
  * INTERNAL API
@@ -157,3 +166,5 @@ object NettyClientUtils {
       case _                 => defaultOptions
     }
 }
+
+

--- a/runtime/src/main/scala/akka/grpc/netty/NettyCircuitBreakerInterceptor.scala
+++ b/runtime/src/main/scala/akka/grpc/netty/NettyCircuitBreakerInterceptor.scala
@@ -1,0 +1,57 @@
+package akka.grpc.netty
+
+import akka.pattern.CircuitBreaker
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.ClientCall
+import io.grpc.ClientInterceptor
+import io.grpc.ClientInterceptors
+import io.grpc.ForwardingClientCallListener
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
+import io.grpc.Status
+
+/**
+ * A `io.grpc.ClientInterceptor` that prevents downstream overload wrapping the calls with a circuit breaker.
+ */
+class NettyCircuitBreakerInterceptor(breaker: CircuitBreaker) extends ClientInterceptor {
+
+  private class Listener[RespT](delegate: ClientCall.Listener[RespT])
+      extends ForwardingClientCallListener.SimpleForwardingClientCallListener[RespT](delegate) {
+    override def onClose(status: Status, trailers: Metadata): Unit = {
+      if (status.isOk) {
+        breaker.succeed()
+      } else {
+        breaker.fail()
+      }
+
+      super.onClose(status, trailers)
+    }
+  }
+
+  override def interceptCall[ReqT, RespT](
+      method: MethodDescriptor[ReqT, RespT],
+      callOptions: CallOptions,
+      next: Channel): ClientCall[ReqT, RespT] =
+    new ClientInterceptors.CheckedForwardingClientCall[ReqT, RespT](next.newCall(method, callOptions)) {
+
+      override def checkedStart(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit = {
+        delegate().start(new Listener(responseListener), headers)
+      }
+
+      override def isReady: Boolean = {
+        if (breaker.isClosed || breaker.isHalfOpen) {
+          super.isReady
+        } else {
+          throw new IllegalStateException("Circuit Breaker is open. Can't send messages.")
+        }
+      }
+
+      override def sendMessage(message: ReqT): Unit = {
+        if (breaker.isClosed || breaker.isHalfOpen) {
+          delegate().sendMessage(message)
+        }
+      }
+    }
+
+}


### PR DESCRIPTION
References #138

A [recommended way to include Circuit Breakers on a `grpc-java` client](https://github.com/grpc/grpc-java/issues/7281#issuecomment-668785443) is using `Interceptor`'s. Based on a [linked sample](https://gist.github.com/eungju/226274b3dacb3203de3514bcf1c54505#file-circuitbreakerclientinterceptor-kt) this PR provides an `io.grpc.Interceptor` that uses an Akka Circuit Breaker.

There's a [sandbox project](https://github.com/ignasi35/akka-grpc-circuit-breaker-sandbox) to play with this code a bit.

TODO: test, document, API,...
