### PR TITLE
Disable TLS on sample code

### DIFF
--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
@@ -34,7 +34,7 @@ class GreeterClient {
     Materializer materializer = ActorMaterializer.create(system);
 
     // Configure the client by code:
-    GrpcClientSettings settings = GrpcClientSettings.connectToServiceAt("127.0.0.1", 8090, system);
+    GrpcClientSettings settings = GrpcClientSettings.connectToServiceAt("127.0.0.1", 8090, system).withTls(false);
 
     // Or via application.conf:
     // GrpcClientSettings settings = GrpcClientSettings.fromConfig(GreeterService.name, system);

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterClient.scala
@@ -24,7 +24,7 @@ object GreeterClient {
     implicit val ec = sys.dispatcher
 
     // Configure the client by code:
-    val clientSettings = GrpcClientSettings.connectToServiceAt("127.0.0.1", 8080);
+    val clientSettings = GrpcClientSettings.connectToServiceAt("127.0.0.1", 8080).withTls(false)
 
     // Or via application.conf:
     // val clientSettings = GrpcClientSettings.fromConfig(GreeterService.name)


### PR DESCRIPTION
Currently, [the sample code of client](https://doc.akka.io/docs/akka-grpc/current/client/walkthrough.html) is not working properly because [the sample code of server](https://doc.akka.io/docs/akka-grpc/current/client/walkthrough.html) doesn't enable TLS.
I disable client-side TLS like server-side.