### PR TITLE
Generate version.conf file in runtime jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ jobs:
     
     - stage: test
       name: Scripted gen-scala-server
-      script: sbt "; project sbt-akka-grpc; scripted gen-scala-server/*"
+      script: sbt -jvm-opts .jvmopts-travis "; project sbt-akka-grpc; scripted gen-scala-server/*"
     - name: Scripted gen-java
-      script: sbt "; project sbt-akka-grpc; scripted gen-java/*"
+      script: sbt -jvm-opts .jvmopts-travis "; project sbt-akka-grpc; scripted gen-java/*"
     - name: Gradle Java Scala 2.12 
       scala: 2.12.11
       workspaces:
@@ -124,7 +124,7 @@ jobs:
     
     - stage: publish
       script: sbt -jvm-opts .jvmopts-travis ++2.12.11 publish && git status && sbt -jvm-opts .jvmopts-travis ++2.13.1 akka-grpc-runtime/publish ++2.13.1! akka-grpc-codegen/publish
-      name: sbt publish
+      name: sbt -jvm-opts .jvmopts-travis publish
     - script: openssl aes-256-cbc -K $encrypted_9c9c33071881_key -iv $encrypted_9c9c33071881_iv -in gradle.properties.enc -out ./gradle-plugin/gradle.properties -d && cd gradle-plugin && ./gradlew publishPlugins
       name: Gradle plugin
     - script: eval "$(ssh-agent -s)" && echo $SCP_SECRET | base64 -d > /tmp/id_rsa && chmod 600 /tmp/id_rsa && ssh-add /tmp/id_rsa && sbt -jvm-opts .jvmopts-travis akka-grpc-docs/publishRsync

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
       val file = assembly.value
       Assemblies.mkBatAssembly(file)
     },
-    buildInfoKeys ++= BuildInfoKey.ofN(organization, name, version, scalaVersion, sbtVersion),
+    buildInfoKeys ++= Seq[BuildInfoKey](organization, name, version, scalaVersion, sbtVersion),
     buildInfoKeys += "runtimeArtifactName" -> akkaGrpcRuntimeName,
     buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
@@ -43,6 +43,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
 
 lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
   .settings(Dependencies.runtime)
+  .settings(VersionGenerator.settings)
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head)

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -1,0 +1,24 @@
+import sbt.Keys._
+import sbt._
+
+/**
+ * Generate version.conf file based on the version setting.
+ *
+ * This was adapted from https://github.com/akka/akka/blob/v2.6.8/project/VersionGenerator.scala
+ */
+object VersionGenerator {
+
+  val settings: Seq[Setting[_]] = inConfig(Compile)(
+    Seq(
+      resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.grpc.version = "%s"
+         |"""))
+  )
+
+  def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
+    val file = locate(dir.value)
+    val content = template.stripMargin.format(version.value)
+    if (!file.exists || IO.read(file) != content) IO.write(file, content)
+    Seq(file)
+  }
+
+}

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -9,7 +9,8 @@ import sbt._
 object VersionGenerator {
 
   val settings: Seq[Setting[_]] = inConfig(Compile)(
-    Seq(resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.grpc.version = "%s"
+    Seq(
+      resourceGenerators += generateVersion(resourceManaged, _ / "akka-grpc-version.conf", """|akka.grpc.version = "%s"
          |""")))
 
   def generateVersion(dir: SettingKey[File], locate: File => File, template: String) =

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -9,16 +9,15 @@ import sbt._
 object VersionGenerator {
 
   val settings: Seq[Setting[_]] = inConfig(Compile)(
-    Seq(
-      resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.grpc.version = "%s"
-         |"""))
-  )
+    Seq(resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.grpc.version = "%s"
+         |""")))
 
-  def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
-    val file = locate(dir.value)
-    val content = template.stripMargin.format(version.value)
-    if (!file.exists || IO.read(file) != content) IO.write(file, content)
-    Seq(file)
-  }
+  def generateVersion(dir: SettingKey[File], locate: File => File, template: String) =
+    Def.task[Seq[File]] {
+      val file = locate(dir.value)
+      val content = template.stripMargin.format(version.value)
+      if (!file.exists || IO.read(file) != content) IO.write(file, content)
+      Seq(file)
+    }
 
 }


### PR DESCRIPTION
Add a `version.conf` file to make the Akka gRPC version available outside of class files.
This complements the generated `akka.grpc.gen.BuildInfo` class.
