### PR TITLE
Make it configurable the dispatcher to use for akka grpc client

### DIFF
--- a/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaClient/Client.scala.txt
@@ -36,14 +36,14 @@ public abstract class @{service.name}Client extends @{service.name}ClientPowerAp
       private final Materializer mat;
       private final ExecutionContext ec;
 
-      private Default@{service.name}Client(GrpcClientSettings settings, ClassicActorSystemProvider sys) {
+      private Default@{service.name}Client(GrpcClientSettings settings, ClassicActorSystemProvider sys,  ExecutionContext ec) {
         this.settings = settings;
         this.mat = SystemMaterializer.get(sys).materializer();
-        this.ec = sys.classicSystem().dispatcher();
+        this.ec = ec;
         this.clientState = new ClientState(
           settings,
           akka.event.Logging$.MODULE$.apply(sys.classicSystem(), Default@{service.name}Client.class, akka.event.LogSource$.MODULE$.<Default@{service.name}Client>fromAnyClass()),
-          sys);
+          sys, ec);
         this.options = NettyClientUtils.callOptions(settings);
 
         sys.classicSystem().getWhenTerminated().whenComplete((v, e) -> close());

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -41,14 +41,13 @@ import akka.grpc.internal.ClientState
 trait @{service.name}Client extends @{service.name} with @{service.name}ClientPowerApi with AkkaGrpcClient
 
 object @{service.name}Client {
-  def apply(settings: GrpcClientSettings)(implicit sys: ClassicActorSystemProvider): @{service.name}Client =
+  def apply(settings: GrpcClientSettings)(implicit sys: ClassicActorSystemProvider, ec: ExecutionContext): @{service.name}Client =
     new Default@{service.name}Client(settings)
 }
 
-final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit sys: ClassicActorSystemProvider) extends @{service.name}Client {
+final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit sys: ClassicActorSystemProvider, ec: ExecutionContext) extends @{service.name}Client {
   import Default@{service.name}Client._
 
-  private implicit val ex: ExecutionContext = sys.classicSystem.dispatcher
   private val options = NettyClientUtils.callOptions(settings)
   private val clientState = new ClientState(settings, akka.event.Logging(sys.classicSystem, this.getClass))
 

--- a/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
@@ -14,7 +14,7 @@ import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
 
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * INTERNAL API
@@ -23,13 +23,16 @@ import scala.concurrent.Future
  */
 @InternalApi
 final class ClientState(@InternalStableApi val internalChannel: InternalChannel)(
-    implicit sys: ClassicActorSystemProvider) {
+    implicit sys: ClassicActorSystemProvider,
+    ec: ExecutionContext) {
 
   @InternalStableApi
-  def this(settings: GrpcClientSettings, log: LoggingAdapter)(implicit sys: ClassicActorSystemProvider) =
-    this(NettyClientUtils.createChannel(settings, log)(sys.classicSystem.dispatcher))
+  def this(settings: GrpcClientSettings, log: LoggingAdapter)(
+      implicit sys: ClassicActorSystemProvider,
+      ec: ExecutionContext) =
+    this(NettyClientUtils.createChannel(settings, log)(ec))
 
-  sys.classicSystem.whenTerminated.foreach(_ => close())(sys.classicSystem.dispatcher)
+  sys.classicSystem.whenTerminated.foreach(_ => close())(ec)
 
   def closedCS(): CompletionStage[Done] = closed().toJava
   def closeCS(): CompletionStage[Done] = close().toJava


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

The goal of this PR is to make it configurable the generated Akka gRPC client code to use a custom dispatcher rather than the actor system dispatcher where the client is running. These are some of the use cases:

- This will help to spawn another dispatcher to make gRPC calls in case someone decide to block the call within an actor which may block a thread in the main Akka dispatcher. 
