### PR TITLE
Make sure scalatest outputs stack traces

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -70,6 +70,7 @@ object Common extends AutoPlugin {
     libraryDependencies ++= Seq(
       compilerPlugin(("com.github.ghik" % "silencer-plugin" % silencerVersion).cross(CrossVersion.full)),
       ("com.github.ghik" % "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.full)),
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     crossScalaVersions := Seq(scala212, scala213),
     mimaReportSignatureProblems := true,
     scalafmtOnCompile := true)


### PR DESCRIPTION
Otherwise tests that fail inside a helper function are hard to diagnose