### PR TITLE
Avoid deadlock

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.1+92-764faf46"
+    val akkaHttp = "10.2.1+103-664568a0"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.33.1" // checked synced by GrpcVersionSyncCheckPlugin

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -14,7 +14,7 @@ import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcProtocol.GrpcProtocolReader
 import akka.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
-import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart, Chunked, LastChunk }
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk }
 import akka.http.scaladsl.{ ClientTransport, ConnectionContext, Http }
 import akka.http.scaladsl.model.{ AttributeKey, HttpHeader, HttpRequest, HttpResponse, RequestResponseAssociation, Uri }
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -159,9 +159,6 @@ object AkkaHttpClientUtils {
                   response.entity match {
                     case Chunked(_, chunks) =>
                       chunks
-                        .concat(Source
-                          .maybe[ChunkStreamPart]
-                          .mapMaterializedValue(promise => promise.completeWith(completionFuture.map(_ => None))))
                         .map {
                           case Chunk(data, _) =>
                             data
@@ -174,6 +171,10 @@ object AkkaHttpClientUtils {
                             log.info(s"XXX response $response termination ${c.isSuccess}")
                             trailerPromise.trySuccess(immutable.Seq.empty)
                           }))
+                        // This never adds any data to the stream, but makes sure it fails with the correct error code if applicable
+                        .concat(Source
+                          .maybe[ByteString]
+                          .mapMaterializedValue(promise => promise.completeWith(completionFuture.map(_ => None))))
                         // Make sure we continue reading to get the trailing header even if we're no longer interested in the rest of the body
                         .via(new CancellationBarrierGraphStage)
                         .via(reader.dataFrameDecoder)


### PR DESCRIPTION
The 'concat' is used to make sure the stream fails with the right error
when the trailing headers contain an error status code. To avoid
deadlock we should put that after the watchTermination that successfully
terminates the stream where there are no trailing headers at all.