### PR TITLE
Reviews interop tests naming

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
@@ -21,7 +21,7 @@ class GrpcInteropAkkaScalaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers
 class GrpcInteropAkkaJavaWithIoSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.IoGrpc)
 class GrpcInteropAkkaJavaWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Scala)
 class GrpcInteropAkkaJavaWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Java)
-//class GrpcInteropAkkaJavaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Scala)
+class GrpcInteropAkkaJavaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Scala)
 //class GrpcInteropAkkaJavaWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Java)
 
 //--- Aliases

--- a/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
@@ -15,7 +15,6 @@ class GrpcInteropIoWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.IoGrpc
 class GrpcInteropAkkaScalaWithIoSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.IoGrpc)
 class GrpcInteropAkkaScalaWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaNetty.Scala)
 class GrpcInteropAkkaScalaWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaNetty.Java)
-// TODO testing against grpc-java server (problem with the path, still to be diagnosed)
 class GrpcInteropAkkaScalaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaHttp.Scala)
 //class GrpcInteropAkkaScalaWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaHttp.Java)
 

--- a/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
@@ -6,25 +6,49 @@ package akka.grpc.interop
 
 import io.grpc.testing.integration.TestServiceHandlerFactory
 
-class GrpcInteropIoWithIoSpec extends GrpcInteropTests(IoGrpcJavaServerProvider, IoGrpcJavaClientProvider)
-class GrpcInteropIoWithAkkaScalaSpec extends GrpcInteropTests(IoGrpcJavaServerProvider, AkkaNettyClientProviderScala)
-class GrpcInteropIoWithAkkaJavaSpec extends GrpcInteropTests(IoGrpcJavaServerProvider, AkkaNettyClientProviderJava)
+class GrpcInteropIoWithIoSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.IoGrpc)
+class GrpcInteropIoWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.AkkaNetty.Scala)
+class GrpcInteropIoWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.AkkaNetty.Java)
+class GrpcInteropIoWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.AkkaHttp.Scala)
+//class GrpcInteropIoWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.AkkaHttp.Java)
 
-class GrpcInteropAkkaScalaWithIoSpec extends GrpcInteropTests(AkkaHttpServerProviderScala, IoGrpcJavaClientProvider)
-class GrpcInteropAkkaScalaWithAkkaScalaSpec
-    extends GrpcInteropTests(AkkaHttpServerProviderScala, AkkaNettyClientProviderScala)
-class GrpcInteropAkkaScalaWithAkkaJavaSpec
-    extends GrpcInteropTests(AkkaHttpServerProviderScala, AkkaNettyClientProviderJava)
-
+class GrpcInteropAkkaScalaWithIoSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.IoGrpc)
+class GrpcInteropAkkaScalaWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaNetty.Scala)
+class GrpcInteropAkkaScalaWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaNetty.Java)
 // TODO testing against grpc-java server (problem with the path, still to be diagnosed)
-class GrpcInteropAkkaHttpScalaServerWithAkkaHttpScalaClientSpec
-    extends GrpcInteropTests(AkkaHttpServerProviderScala, AkkaHttpClientProviderScala)
+class GrpcInteropAkkaScalaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaHttp.Scala)
+//class GrpcInteropAkkaScalaWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.Akka.Scala, Clients.AkkaHttp.Java)
 
-class GrpcInteropAkkaJavaWithIoSpec extends GrpcInteropTests(AkkaHttpServerProviderJava, IoGrpcJavaClientProvider)
-class GrpcInteropAkkaJavaWithAkkaScalaSpec
-    extends GrpcInteropTests(AkkaHttpServerProviderJava, AkkaNettyClientProviderScala)
-class GrpcInteropAkkaJavaWithAkkaJavaSpec
-    extends GrpcInteropTests(AkkaHttpServerProviderJava, AkkaNettyClientProviderJava)
+class GrpcInteropAkkaJavaWithIoSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.IoGrpc)
+class GrpcInteropAkkaJavaWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Scala)
+class GrpcInteropAkkaJavaWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Java)
+//class GrpcInteropAkkaJavaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Scala)
+//class GrpcInteropAkkaJavaWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Java)
+
+//--- Aliases
+
+object Servers {
+  val IoGrpc = IoGrpcJavaServerProvider
+  object Akka {
+    val Java = AkkaHttpServerProviderJava
+    val Scala = AkkaHttpServerProviderScala
+  }
+}
+
+object Clients {
+  val IoGrpc = IoGrpcJavaClientProvider
+  object AkkaNetty {
+    val Java = AkkaNettyClientProviderJava
+    val Scala = AkkaNettyClientProviderScala
+  }
+  object AkkaHttp {
+    // FIXME: let's have Scala stable and we'll do Java later.
+    // val Java = AkkaHttpClientProviderJava
+    val Scala = AkkaHttpClientProviderScala
+  }
+}
+
+//--- Some more providers
 
 object AkkaHttpServerProviderJava extends AkkaHttpServerProvider {
   val label: String = "akka-grpc java server"

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -14,7 +14,7 @@ import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcProtocol.GrpcProtocolReader
 import akka.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
-import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, Default, LastChunk }
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk }
 import akka.http.scaladsl.{ ClientTransport, ConnectionContext, Http }
 import akka.http.scaladsl.model.{ AttributeKey, HttpHeader, HttpRequest, HttpResponse, RequestResponseAssociation, Uri }
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -24,7 +24,6 @@ import akka.util.ByteString
 import com.github.ghik.silencer.silent
 import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
 import javax.net.ssl.{ KeyManager, SSLContext, TrustManager }
-
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters.FutureOps
 import scala.concurrent.{ Future, Promise }
@@ -197,8 +196,9 @@ object AkkaHttpClientUtils {
                                 .map[akka.grpc.javadsl.Metadata](h => new JavaMetadataImpl(new HeaderMetadataImpl(h)))
                                 .toJava
                           }))
-                    case Default(_, _, _) => throw mapToStatusException(response, Seq.empty)
-                    case e                => throw new IllegalStateException(s"Expected chunked or default response but got $e")
+                    case _ =>
+                      response.entity.discardBytes()
+                      throw mapToStatusException(response, Seq.empty)
                   }
                 case Failure(e) =>
                   Source.failed[O](e).mapMaterializedValue(_ => Future.failed(e))


### PR DESCRIPTION
Standardize the spec names.

Introduce `Servers` and `Clients`.