### PR TITLE
Test Akka HTTP-based client against io.grpc server

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
@@ -16,9 +16,10 @@ class GrpcInteropAkkaScalaWithAkkaScalaSpec
 class GrpcInteropAkkaScalaWithAkkaJavaSpec
     extends GrpcInteropTests(AkkaHttpServerProviderScala, AkkaNettyClientProviderJava)
 
-// TODO testing against grpc-java server (problem with the path, still to be diagnosed)
 class GrpcInteropAkkaHttpScalaServerWithAkkaHttpScalaClientSpec
     extends GrpcInteropTests(AkkaHttpServerProviderScala, AkkaHttpClientProviderScala)
+class GrpcInteropIoServerWithAkkaHttpScalaClientSpec
+    extends GrpcInteropTests(IoGrpcJavaServerProvider, AkkaHttpClientProviderScala)
 
 class GrpcInteropAkkaJavaWithIoSpec extends GrpcInteropTests(AkkaHttpServerProviderJava, IoGrpcJavaClientProvider)
 class GrpcInteropAkkaJavaWithAkkaScalaSpec


### PR DESCRIPTION
This is now possible since #1182 brought both implementations up to par