### PR TITLE
Handle strict responses

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/GrpcInteropSpec.scala
@@ -22,7 +22,7 @@ class GrpcInteropAkkaScalaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers
 class GrpcInteropAkkaJavaWithIoSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.IoGrpc)
 class GrpcInteropAkkaJavaWithAkkaNettyScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Scala)
 class GrpcInteropAkkaJavaWithAkkaNettyJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaNetty.Java)
-//class GrpcInteropAkkaJavaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Scala)
+class GrpcInteropAkkaJavaWithAkkaHttpScalaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Scala)
 //class GrpcInteropAkkaJavaWithAkkaHttpJavaSpec extends GrpcInteropTests(Servers.Akka.Java, Clients.AkkaHttp.Java)
 
 //--- Aliases

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -197,7 +197,7 @@ object AkkaHttpClientUtils {
                                 .toJava
                           }))
                     case _ =>
-                      response.entity.discardBytes
+                      response.entity.discardBytes()
                       throw mapToStatusException(response, Seq.empty)
                   }
                 case Failure(e) =>

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -14,7 +14,7 @@ import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcProtocol.GrpcProtocolReader
 import akka.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
-import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, Default, LastChunk }
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk }
 import akka.http.scaladsl.{ ClientTransport, ConnectionContext, Http }
 import akka.http.scaladsl.model.{ AttributeKey, HttpHeader, HttpRequest, HttpResponse, RequestResponseAssociation, Uri }
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -24,7 +24,6 @@ import akka.util.ByteString
 import com.github.ghik.silencer.silent
 import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
 import javax.net.ssl.{ KeyManager, SSLContext, TrustManager }
-
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters.FutureOps
 import scala.concurrent.{ Future, Promise }
@@ -197,8 +196,8 @@ object AkkaHttpClientUtils {
                                 .map[akka.grpc.javadsl.Metadata](h => new JavaMetadataImpl(new HeaderMetadataImpl(h)))
                                 .toJava
                           }))
-                    case Default(_, _, _) => throw mapToStatusException(response, Seq.empty)
-                    case e                => throw new IllegalStateException(s"Expected chunked or default response but got $e")
+                    case _ =>
+                      throw mapToStatusException(response, Seq.empty)
                   }
                 case Failure(e) =>
                   Source.failed[O](e).mapMaterializedValue(_ => Future.failed(e))

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -197,6 +197,7 @@ object AkkaHttpClientUtils {
                                 .toJava
                           }))
                     case _ =>
+                      response.entity.discardBytes
                       throw mapToStatusException(response, Seq.empty)
                   }
                 case Failure(e) =>


### PR DESCRIPTION
In #1182 we introduced support for HttpReponses mapped as `Default` but some interop tests replay a `404` without payload so that's mapped into `Strict`. In either case, it's not a `Chunked` and we want to map the status.

I'm not sure a match-all solution is the correct one here though.