### PR TITLE
Prefer linking the spec than the docs of an implementation

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -237,7 +237,7 @@ object AkkaHttpClientUtils {
   }
 
   /**
-   * See https://grpc.github.io/grpc/core/md_doc_http-grpc-status-mapping.html
+   * See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
    */
   private def mapHttpStatus(response: HttpResponse): Status = {
     response.status match {


### PR DESCRIPTION
The repo powering grpc.github.io seems to have been archived? 

https://github.com/grpc/grpc.github.io
