### PR TITLE
make sure to include grpc-message for common `UNIMPLEMENTED` errors

### DIFF
--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -53,7 +53,9 @@ class ErrorReportingSpec extends AnyWordSpec with Matchers with ScalaFutures wit
       val response = Http().singleRequest(request).futureValue
 
       response.status should be(StatusCodes.OK)
-      allHeaders(response) should contain(RawHeader("grpc-status", Status.Code.UNIMPLEMENTED.value().toString))
+      val trailers = allHeaders(response)
+      trailers should contain(RawHeader("grpc-status", Status.Code.UNIMPLEMENTED.value().toString))
+      trailers should contain(RawHeader("grpc-message", "Not implemented: UnknownMethod"))
     }
 
     "respond with an 'invalid argument' gRPC error status when calling an method without a request body" in {

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -46,7 +46,10 @@ class ErrorReportingSpec extends AnyWordSpec with Matchers with ScalaFutures wit
       val response = Http().singleRequest(request).futureValue
 
       response.status should be(StatusCodes.OK)
-      allHeaders(response) should contain(RawHeader("grpc-status", Status.Code.UNIMPLEMENTED.value().toString))
+      val trailers = allHeaders(response)
+
+      trailers should contain(RawHeader("grpc-status", Status.Code.UNIMPLEMENTED.value().toString))
+      trailers should contain(RawHeader("grpc-message", "Not implemented: UnknownMethod"))
     }
 
     "respond with an 'invalid argument' gRPC error status when calling an method without a request body" in {

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
@@ -23,7 +23,6 @@ import scala.concurrent.ExecutionException
 object GrpcExceptionHandler {
   private val INTERNAL = Trailers(Status.INTERNAL)
   private val INVALID_ARGUMENT = Trailers(Status.INVALID_ARGUMENT)
-  private val UNIMPLEMENTED = Trailers(Status.UNIMPLEMENTED)
 
   def defaultMapper: jFunction[ActorSystem, jFunction[Throwable, Trailers]] =
     new jFunction[ActorSystem, jFunction[Throwable, Trailers]] {
@@ -45,8 +44,8 @@ object GrpcExceptionHandler {
             else default(system)(e.getCause)
           case grpcException: GrpcServiceException => Trailers(grpcException.status, grpcException.metadata)
           case _: MissingParameterException        => INVALID_ARGUMENT
-          case _: NotImplementedError              => UNIMPLEMENTED
-          case _: UnsupportedOperationException    => UNIMPLEMENTED
+          case e: NotImplementedError              => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
+          case e: UnsupportedOperationException    => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
           case other =>
             system.log.error(other, "Unhandled error: [" + other.getMessage + "]")
             INTERNAL

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcExceptionHandler.scala
@@ -19,15 +19,14 @@ import scala.concurrent.{ ExecutionException, Future }
 object GrpcExceptionHandler {
   private val INTERNAL = Trailers(Status.INTERNAL)
   private val INVALID_ARGUMENT = Trailers(Status.INVALID_ARGUMENT)
-  private val UNIMPLEMENTED = Trailers(Status.UNIMPLEMENTED)
 
   def defaultMapper(system: ActorSystem): PartialFunction[Throwable, Trailers] = {
     case e: ExecutionException =>
       if (e.getCause == null) INTERNAL
       else defaultMapper(system)(e.getCause)
     case grpcException: GrpcServiceException => Trailers(grpcException.status, grpcException.metadata)
-    case _: NotImplementedError              => UNIMPLEMENTED
-    case _: UnsupportedOperationException    => UNIMPLEMENTED
+    case e: NotImplementedError              => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
+    case e: UnsupportedOperationException    => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
     case _: MissingParameterException        => INVALID_ARGUMENT
     case other =>
       system.log.error(other, s"Unhandled error: [${other.getMessage}].")


### PR DESCRIPTION
It seems clients do not gracefully handle UNIMPLEMENTED result and leave people stumped when an exception is thrown that only contains the information `UNIMPLEMENTED` on the client side.

This seems to be a common error because it is reported when the gRPC method is not found (basically a 404 error).

See e.g. https://github.com/akka/akka-http/issues/2957.

Adding a `grpc-message` header for that case would help a lot with debugging.