### PR TITLE
run link-validator without git

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -25,7 +25,7 @@ jobs:
         uses: coursier/cache-action@v5
 
       - name: sbt site
-        run: sbt akka-grpc-docs/makeSite
+        run: echo "previousStableVersion in ThisBuild := Some(\"x\")\nisSnapshot in ThisBuild := false" > a.sbt && sbt akka-grpc-docs/makeSite
 
       - name: Install Coursier command line tool
         run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs


### PR DESCRIPTION
The git command-line tool is needed for sbt-dynver to find the latest
stable version to use with mima.