### PR TITLE
Akka HTTP-based client with 'persistent' connections

### DIFF
--- a/interop-tests/src/test/resources/application.conf
+++ b/interop-tests/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 akka.http {
-    client {
-        http2.log-frames = true
+    client.http2 {
+        log-frames = true
+        max-persistent-attempts = 10
     }
     server {
         default-host-header = "localhost.com"

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -95,9 +95,9 @@ object AkkaHttpClientUtils {
             }
           }
 
-        builder.withCustomHttpsConnectionContext(connectionContext).http2()
+        builder.withCustomHttpsConnectionContext(connectionContext).managedPersistentHttp2()
       } else {
-        builder.http2WithPriorKnowledge()
+        builder.managedPersistentHttp2WithPriorKnowledge()
       }
 
     val (queue, doneFuture) =


### PR DESCRIPTION
The first 2 tests succeed, the tests that require failover to
another server (as expected) still fail.

Requires https://github.com/akka/akka-http/pull/3685