### PR TITLE
Run Link Validator on PR

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,8 +1,7 @@
 name: Link Validator
 
 on:
-  pull_request_target:
-    branches: [main, master]
+  pull_request:
   schedule:
     - cron:  '0 6 * * 1'
 


### PR DESCRIPTION
The `pull_request_target` trigger gives access to GitHub secrets which is insecure and not required for this workflow.

References #1213