### PR TITLE
Generate method names with backquotes for reserved keywords in Scala

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -48,6 +48,12 @@ case class Method(
       case (true, true)   => BidiStreaming
     }
   }
+
+  val nameSafe = {
+    if (name == "match") {
+      s"""`$name`""".stripMargin
+    } else name
+  }
 }
 
 object Method {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -50,7 +50,7 @@ case class Method(
   }
 
   val nameSafe: String =
-    if (reservedWords.contains(name)) s"""`$name`""".stripMargin
+    if (reservedWords.contains(name)) s"""`$name`"""
     else name
 
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -49,11 +49,10 @@ case class Method(
     }
   }
 
-  val nameSafe = {
-    if (name == "match") {
-      s"""`$name`""".stripMargin
-    } else name
-  }
+  val nameSafe: String =
+    if (reservedWords.contains(name)) s"""`$name`""".stripMargin
+    else name
+
 }
 
 object Method {
@@ -76,4 +75,50 @@ object Method {
     import ops._
     messageType.scalaType.fullName
   }
+
+  // https://github.com/scalapb/ScalaPB/blob/master/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala#L1038
+  private val reservedWords = Set(
+    "abstract",
+    "case",
+    "catch",
+    "class",
+    "def",
+    "do",
+    "else",
+    "enum",
+    "extends",
+    "false",
+    "final",
+    "finally",
+    "for",
+    "forSome",
+    "if",
+    "implicit",
+    "import",
+    "lazy",
+    "macro",
+    "match",
+    "new",
+    "null",
+    "object",
+    "override",
+    "package",
+    "private",
+    "protected",
+    "return",
+    "sealed",
+    "super",
+    "then",
+    "this",
+    "throw",
+    "trait",
+    "try",
+    "true",
+    "type",
+    "val",
+    "var",
+    "while",
+    "with",
+    "yield",
+    "ne")
 }

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -82,7 +82,7 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
     }
 
     /**
-     * For access to method metadata use the parameterless version of @{method.name}
+     * For access to method metadata use the parameterless version of @{method.nameSafe}
      */
     def @{method.nameSafe}(in: @method.parameterType): @method.returnType =
       @{method.nameSafe}().invoke(in)

--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -71,21 +71,21 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
   @for(method <- service.methods) {
     /**
      * Lower level "lifted" version of the method, giving access to request metadata etc.
-     * prefer @{method.name}(@method.parameterType) if possible.
+     * prefer @{method.nameSafe}(@method.parameterType) if possible.
      */
     @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
-      override def @{method.name}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
+      override def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
         @{method.name}RequestBuilder(clientState.internalChannel)
     } else {
-      override def @{method.name}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
+      override def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
         @{method.name}RequestBuilder(clientState.internalChannel)
     }
 
     /**
      * For access to method metadata use the parameterless version of @{method.name}
      */
-    def @{method.name}(in: @method.parameterType): @method.returnType =
-      @{method.name}().invoke(in)
+    def @{method.nameSafe}(in: @method.parameterType): @method.returnType =
+      @{method.nameSafe}().invoke(in)
   }
 
   override def close(): scala.concurrent.Future[akka.Done] = clientState.close()
@@ -123,12 +123,12 @@ trait @{service.name}ClientPowerApi {
   @for(method <- service.methods) {
     /**
      * Lower level "lifted" version of the method, giving access to request metadata etc.
-     * prefer @{method.name}(@method.parameterType) if possible.
+     * prefer @{method.nameSafe}(@method.parameterType) if possible.
      */
     @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
-      def @{method.name}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
+      def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
     } else {
-      def @{method.name}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
+      def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
     }
   }
 

--- a/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/ApiTrait.scala.txt
@@ -13,7 +13,7 @@ trait @{service.name} {
   @for(method <- service.methods) {
   @for(comment <- method.comment) {/**
 @{java.util.regex.Pattern.compile("^\\s?(.*)$", java.util.regex.Pattern.MULTILINE).matcher(comment).replaceAll("   * $1")}   */}
-  def @{method.name}(in: @method.parameterType): @method.returnType
+  def @{method.nameSafe}(in: @method.parameterType): @method.returnType
   }
 }
 

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -97,7 +97,7 @@ object @{serviceName}Handler {
             case "@method.grpcName" =>
                 @{if(powerApis) { "val metadata = MetadataBuilder.fromHeaders(request.headers)" } else { "" }}
                 @{method.unmarshal}(request.entity.dataBytes)(@method.deserializer.name, mat, reader)
-                  .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.name}(_@{if(powerApis) { ", metadata" } else { "" }}))
+                  .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
                   .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
             }
             case m => scala.concurrent.Future.failed(new NotImplementedError(s"Not implemented: $m"))

--- a/codegen/src/main/twirl/templates/ScalaServer/PowerApiTrait.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/PowerApiTrait.scala.txt
@@ -14,6 +14,6 @@ import akka.grpc.scaladsl.Metadata
  */
 trait @{service.name}PowerApi {
   @for(method <- service.methods) {
-  def @{method.name}(in: @method.parameterType, metadata: Metadata): @method.returnType
+  def @{method.nameSafe}(in: @method.parameterType, metadata: Metadata): @method.returnType
   }
 }

--- a/plugin-tester-scala/src/main/proto/echo.proto
+++ b/plugin-tester-scala/src/main/proto/echo.proto
@@ -8,6 +8,8 @@ package echo;
 // The greeting service definition.
 service EchoService {
     rpc Echo (EchoMessage) returns (EchoMessage) {}
+    rpc Match (EchoMessage) returns (EchoMessage) {};
+
 }
 
 message EchoMessage {

--- a/plugin-tester-scala/src/main/scala/example/myapp/echo/EchoServiceImpl.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/echo/EchoServiceImpl.scala
@@ -10,4 +10,6 @@ import example.myapp.echo.grpc._
 
 class EchoServiceImpl extends EchoService {
   def echo(in: EchoMessage): Future[EchoMessage] = Future.successful(in)
+
+  override def `match`(in: EchoMessage): Future[EchoMessage] = Future.successful(in)
 }


### PR DESCRIPTION
Fixes the generation of method names that clash with reserved keywords. E.g.:

```
syntax = "proto3";

service HelloWorldService {
  rpc Match(...) returns (...) {};
}
```

would generate something like 
```
def `match`(...) 
```