### PR TITLE
ScalaPB 1.0 and document use of local protoc for OSX ARM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -214,8 +214,7 @@ lazy val pluginTesterScala = Project(id = "akka-grpc-plugin-tester-scala", base 
     skip in publish := true,
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"),
-    Compile / ReflectiveCodeGen.protocOptions += "--include_std_types")
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
   .pluginTestingSettings
 
 lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = file("plugin-tester-java"))
@@ -226,8 +225,7 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
     ReflectiveCodeGen.generatedLanguages := Seq("Java"),
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"),
-    Compile / ReflectiveCodeGen.protocOptions += "--include_std_types")
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"))
   .pluginTestingSettings
 
 lazy val root = Project(id = "akka-grpc", base = file("."))

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -50,6 +50,17 @@ contains the `flat_package` parameter.
 akkaGrpcCodeGeneratorSettings += "single_line_to_proto_string"
 ```
 
+#### Using a local `protoc` command
+
+Protocol Buffers does not distribute binaries of `protoc` for use on Apple Silicon (ARM/M1) for the time being. You may [build `protoc` locally](https://github.com/protocolbuffers/protobuf/tree/master/src) and make ScalaPB use the local build by setting `PB.protocExecutable`.
+
+```scala
+PB.protocExecutable := {
+  if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64") file("/usr/local/bin/protoc")
+  else PB.protocExecutable.value
+}
+```
+
 Available parameters are listed in the [ScalaPB documentation](https://scalapb.github.io/sbt-settings.html).
 
 ### `sbt-protoc` settings
@@ -106,7 +117,7 @@ If you want to use TLS-based negotiation on JDK 8 versions prior to
 [1.8.0_251](https://www.oracle.com/java/technologies/javase/8u251-relnotes.html),
 the server requires a special Java agent for ALPN.
  
-See the [Akka HTTP docs about HTTP/2](https://doc.akka.io/docs/akka-http/10.1/server-side/http2.html#application-layer-protocol-negotiation-alpn-))
+See the @extref:[Akka HTTP docs about HTTP/2](akka-http:server-side/http2.html#application-layer-protocol-negotiation-alpn-)
 for more information.
 
 ## Starting your Akka gRPC server from sbt

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -5,6 +5,7 @@ import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import com.typesafe.tools.mima.plugin.MimaKeys._
+import sbtprotoc.ProtocPlugin.autoImport.PB
 
 object Common extends AutoPlugin {
   override def trigger = allRequirements
@@ -74,5 +75,9 @@ object Common extends AutoPlugin {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     crossScalaVersions := Seq(scala212, scala213),
     mimaReportSignatureProblems := true,
-    scalafmtOnCompile := true)
+    scalafmtOnCompile := true,
+    // https://github.com/akka/akka-grpc/issues/1238
+    PB.protocExecutable := (if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64")
+                              file("/usr/local/bin/protoc")
+                            else PB.protocExecutable.value))
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -75,9 +75,5 @@ object Common extends AutoPlugin {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     crossScalaVersions := Seq(scala212, scala213),
     mimaReportSignatureProblems := true,
-    scalafmtOnCompile := true,
-    // https://github.com/akka/akka-grpc/issues/1238
-    PB.protocExecutable := (if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64")
-                              file("/usr/local/bin/protoc")
-                            else PB.protocExecutable.value))
+    scalafmtOnCompile := true)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,6 +73,11 @@ object Dependencies {
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % "runtime" // Eclipse 1.0
   }
 
+  object Protobuf {
+    val googleCommonProtos =
+      "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"
+  }
+
   object Plugins {
     val sbtProtoc = "com.thesamet" % "sbt-protoc" % BuildInfo.sbtProtocVersion
   }
@@ -126,5 +131,6 @@ object Dependencies {
     Compile.grpcStub,
     Compile.akkaHttpCors,
     Test.scalaTest,
-    Test.scalaTestPlusJunit)
+    Test.scalaTestPlusJunit,
+    Protobuf.googleCommonProtos)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,8 +74,7 @@ object Dependencies {
   }
 
   object Protobuf {
-    val googleCommonProtos =
-      "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"
+    val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % "3.13.0" % "protobuf"
   }
 
   object Plugins {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ enablePlugins(BuildInfoPlugin)
 
 // 1.0.0-RC7-1 sets protocVersion := "3.13.0" (without the -v prefix)
 // https://github.com/protocolbuffers/protobuf/releases/tag/v3.13.0
-val sbtProtocV = "1.0.0-RC7-1"
+val sbtProtocV = "1.0.0"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
 enablePlugins(BuildInfoPlugin)
 
-val sbtProtocV = "0.99.34"
+// 1.0.0-RC7-1 sets protocVersion := "3.13.0" (without the -v prefix)
+// https://github.com/protocolbuffers/protobuf/releases/tag/v3.13.0
+val sbtProtocV = "1.0.0-RC7-1"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 enablePlugins(BuildInfoPlugin)
 
-// 1.0.0-RC7-1 sets protocVersion := "3.13.0" (without the -v prefix)
-// https://github.com/protocolbuffers/protobuf/releases/tag/v3.13.0
 val sbtProtocV = "1.0.0"
 
 buildInfoKeys := Seq[BuildInfoKey]("sbtProtocVersion" -> sbtProtocV)

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -6,3 +6,5 @@ enablePlugins(AkkaGrpcPlugin)
 javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
+
+libraryDependencies += "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -3,8 +3,6 @@ resolvers += Resolver.bintrayRepo("akka", "snapshots")
 
 enablePlugins(AkkaGrpcPlugin)
 
-javacOptions  += "-Xdoclint:all"
+javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
-
-Compile / PB.protocOptions += "--include_std_types"

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -7,4 +7,4 @@ javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
-libraryDependencies += "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.13.0" % "protobuf"

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -6,3 +6,5 @@ enablePlugins(AkkaGrpcPlugin)
 javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
+
+libraryDependencies += "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -3,8 +3,6 @@ resolvers += Resolver.bintrayRepo("akka", "snapshots")
 
 enablePlugins(AkkaGrpcPlugin)
 
-javacOptions  += "-Xdoclint:all"
+javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
-
-Compile / PB.protocOptions += "--include_std_types"

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -7,4 +7,4 @@ javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
-libraryDependencies += "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.10" % "1.18.1-0" % "protobuf"
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.13.0" % "protobuf"


### PR DESCRIPTION
ScalaPB 1.0 (in RC right now) allows setting the `protoc` executable so that a locally built version can be used.

References #1238