### PR TITLE
support ScalaPB package/file-level customization

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
@@ -4,6 +4,8 @@
 
 package akka.grpc.gen
 
+import com.github.ghik.silencer.silent
+import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
 import protocbridge.Artifact
@@ -22,8 +24,13 @@ trait CodeGenerator {
   /** Takes Scala binary version and returns suggested dependency Seq */
   def suggestedDependencies: ScalaBinaryVersion => Seq[Artifact]
 
-  final def run(request: Array[Byte], logger: Logger): Array[Byte] =
-    run(CodeGeneratorRequest.parseFrom(request), logger: Logger).toByteArray
+  def registerExtensions(@silent("never used") registry: ExtensionRegistry): Unit = {}
+
+  final def run(request: Array[Byte], logger: Logger): Array[Byte] = {
+    val registry = ExtensionRegistry.newInstance
+    registerExtensions(registry)
+    run(CodeGeneratorRequest.parseFrom(request, registry), logger: Logger).toByteArray
+  }
 }
 
 object CodeGenerator {

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -11,9 +11,12 @@ import com.google.protobuf.compiler.PluginProtos.{ CodeGeneratorRequest, CodeGen
 import scalapb.compiler.GeneratorParams
 import protocbridge.Artifact
 import com.github.ghik.silencer.silent
+import com.google.protobuf.ExtensionRegistry
 import protocgen.CodeGenRequest
+import scalapb.options.Scalapb
 
 abstract class ScalaCodeGenerator extends CodeGenerator {
+
   // Override this to add generated files per service
   def perServiceContent: Set[(Logger, Service) => immutable.Seq[CodeGeneratorResponse.File]] = Set.empty
 
@@ -30,6 +33,12 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
           BuildInfo.organization,
           BuildInfo.runtimeArtifactName + "_" + scalaBinaryVersion.prefix,
           BuildInfo.version))
+
+  override def registerExtensions(registry: ExtensionRegistry): Unit = {
+    // Allow the embedded ScalaPB compiler helper classes to observe package/file-level options,
+    // so that properties looked up through DescriptorImplicits are in line with ScalaPB generated stubs
+    Scalapb.registerAllExtensions(registry)
+  }
 
   // generate services code here, the data types we want to leave to scalapb
   override def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse = {

--- a/docs/src/main/paradox/proto.md
+++ b/docs/src/main/paradox/proto.md
@@ -38,6 +38,7 @@ whose name is determined by the `java_outer_classname` setting. By setting the
 `java_multiple_files` option, the message classes will be generated in separate files,
 but the 'outer' class is still generated with some metadata and utilities.
 
-The Scala code generation uses the mechanism described in the
-[ScalaPB documentation](https://scalapb.github.io/customizations.html)
-with the `flat_package` option enabled.
+The Scala code generation runs with the
+[`flat_package` generator option](https://scalapb.github.io/docs/sbt-settings/#additional-options-to-the-generator) enabled by default.
+Customizations can be added on a
+[per-file and/or per-package basis](https://scalapb.github.io/customizations.html).

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -84,6 +84,12 @@ object AkkaGrpcPlugin extends AutoPlugin {
       akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client, AkkaGrpc.Server),
       akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala),
       akkaGrpcExtraGenerators := Seq.empty,
+      libraryDependencies ++= {
+        if (akkaGrpcGeneratedLanguages.value.contains(AkkaGrpc.Scala))
+          // Make scalapb.proto available for import in user-defined protos for file and package-level options
+          Seq("com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf")
+        else Seq()
+      },
       PB.recompile in Compile := {
         // hack to get our (dirty) hands on a proper sbt logger before running the generators
         generatorLogger.logger = streams.value.log

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
@@ -1,0 +1,7 @@
+resolvers += Resolver.sonatypeRepo("staging")
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+
+enablePlugins(AkkaGrpcPlugin)
+
+// Don't enable it flat_package globally, but via a package-level option instead (see package.proto)
+akkaGrpcCodeGeneratorSettings -= "flat_package"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+option java_package = "example.myapp.helloworld.grpc";
+
+package helloworld;
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/protobuf/package.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/protobuf/package.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package helloworld;
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  scope: PACKAGE
+  flat_package: true
+};

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/scala/example/myapp/helloworld/GreeterServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/src/main/scala/example/myapp/helloworld/GreeterServiceImpl.scala
@@ -1,0 +1,19 @@
+package example.myapp.helloworld
+
+import scala.concurrent.Future
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+import example.myapp.helloworld.grpc._
+
+class GreeterServiceImpl extends GreeterService {
+  override def sayHello(in: HelloRequest): Future[HelloReply] = ???
+
+  override def streamHellos(in: Source[HelloRequest, NotUsed]): Source[HelloReply, NotUsed] = ???
+
+  override def itKeepsTalking(in: Source[HelloRequest, NotUsed]): Future[HelloReply] = ???
+
+  override def itKeepsReplying(in: HelloRequest): Source[HelloReply, NotUsed] = ???
+
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/test
@@ -1,0 +1,5 @@
+> protocGenerate
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
+> compile


### PR DESCRIPTION
See https://scalapb.github.io/docs/customizations

On master, code won't compile if package/file-level options are used to change `flat_package` as only ScalaPB honors the request.