### PR TITLE
Don't rely on Travis workspaces propagating between build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ env:
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 
+before_script: 
+  - echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
+  - cat ~/.m2/.version
+
 stages:
   - name: drop-travis-caches
     if: env(RUN_DROP_TRAVIS_CACHES_STAGE) = true
@@ -50,8 +54,6 @@ jobs:
     - stage: prepare 
       name: Publish local M2
       script:
-        - echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
-        - cat ~/.m2/.version
         - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
         - find ~/.m2/repository/ -print
       workspaces:
@@ -81,6 +83,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script:
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 
         - cd gradle-plugin 
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
         - find ~/.m2 | grep gradle
@@ -91,6 +94,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script:
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
         - cd gradle-plugin 
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
         - find ~/.m2 | grep gradle
@@ -101,6 +105,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script: 
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 
         - cd gradle-plugin 
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace 
         - cd ../plugin-tester-scala 
@@ -110,6 +115,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script: 
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
         - find ~/.m2/repository/ -print
         - cd gradle-plugin 
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace 
@@ -119,6 +125,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script:
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
         - sbt -jvm-opts .jvmopts-travis akka-grpc-maven-plugin/publishM2
         - cd plugin-tester-java 
         - mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate compile
@@ -126,6 +133,7 @@ jobs:
       workspaces:
         use: mavenLocal
       script:
+        - sbt -jvm-opts .jvmopts-travis akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
         - sbt -jvm-opts .jvmopts-travis akka-grpc-maven-plugin/publishM2
         - cd plugin-tester-scala
         - mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate scala:compile


### PR DESCRIPTION
Workaround for the Travis Ci workspace issues detected in the builds of #1251 
