### PR TITLE
Fix for (slow) memory leak in ClientState

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
       val file = assembly.value
       Assemblies.mkBatAssembly(file)
     },
-    buildInfoKeys ++= BuildInfoKey.ofN(organization, name, version, scalaVersion, sbtVersion),
+    buildInfoKeys ++= Seq[BuildInfoKey](organization, name, version, scalaVersion, sbtVersion),
     buildInfoKeys += "runtimeArtifactName" -> akkaGrpcRuntimeName,
     buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,

--- a/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/ClientState.scala
@@ -12,6 +12,7 @@ import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
+import akka.grpc.scaladsl.Grpc
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
@@ -29,14 +30,17 @@ final class ClientState(@InternalStableApi val internalChannel: InternalChannel)
   def this(settings: GrpcClientSettings, log: LoggingAdapter)(implicit sys: ClassicActorSystemProvider) =
     this(NettyClientUtils.createChannel(settings, log)(sys.classicSystem.dispatcher))
 
-  sys.classicSystem.whenTerminated.foreach(_ => close())(sys.classicSystem.dispatcher)
+  Grpc(sys).registerClient(this)
 
   def closedCS(): CompletionStage[Done] = closed().toJava
   def closeCS(): CompletionStage[Done] = close().toJava
 
   def closed(): Future[Done] = internalChannel.done
 
-  def close(): Future[Done] = ChannelUtils.close(internalChannel)
+  def close(): Future[Done] = {
+    Grpc(sys).deregisterClient(this)
+    ChannelUtils.close(internalChannel)
+  }
 }
 
 /**

--- a/runtime/src/main/scala/akka/grpc/scaladsl/Grpc.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/Grpc.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.grpc.scaladsl
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+import akka.Done
+import akka.actor.{ CoordinatedShutdown, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import akka.annotation.InternalApi
+import akka.grpc.internal.ClientState
+
+import java.util.concurrent.ConcurrentHashMap
+
+/** INTERNAL API */
+@InternalApi
+private[grpc] final class GrpcImpl(system: ExtendedActorSystem) extends Extension {
+  private val clients = new ConcurrentHashMap[ClientState, Unit]
+
+  CoordinatedShutdown(system).addTask("before-actor-system-terminate", "close-grpc-clients") { () =>
+    implicit val ec = system.dispatcher
+    Future
+      .sequence(
+        clients
+          .keySet()
+          .asScala
+          .map(client =>
+            client.close().recover {
+              case e =>
+                system.log.error(e, s"Failed to gracefully close $client, proceeding with shutdown anyway")
+                Done
+            }))
+      .map(_ => Done)
+  }
+
+  /** INTERNAL API */
+  @InternalApi
+  def registerClient(client: ClientState): Unit =
+    clients.put(client, ())
+
+  /** INTERNAL API */
+  @InternalApi
+  def deregisterClient(client: ClientState): Unit =
+    clients.remove(client)
+}
+
+/** INTERNAL API */
+@InternalApi
+private[grpc] object Grpc extends ExtensionId[GrpcImpl] with ExtensionIdProvider {
+  override def createExtension(system: ExtendedActorSystem): GrpcImpl = new GrpcImpl(system)
+
+  override def lookup: ExtensionId[_ <: Extension] = Grpc
+}


### PR DESCRIPTION
`ClientState` registered a `whenTerminated` callback to close the client when
the actor system terminates. However, this `whenTerminated` callback is never
removed, meaning it will hold on to the `ClientState`, causing a (small)
memory leak each time a client is instantiated.

This PR is intended to fix the problem, but doesn't work due to what
looks like an extension initialization deadlock. That reminds of
https://github.com/akka/akka/pull/28046 but it also seems present when I
switch to master, which is on Akka 2.6

Refs https://github.com/akka/akka-grpc/issues/1257
