### PR TITLE
Fix syntax on release-drafter.yml

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        with:
-          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
           # config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The instructions at https://github.com/release-drafter/release-drafter#usage are wrong and the workflow doesn't run.

I think this is correct syntax, now. 
