### PR TITLE
Reduce number of bytes array copies to ByteString.

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -73,7 +73,9 @@ object AbstractGrpcProtocol {
   @inline
   def encodeFrameData(frameType: ByteString, data: ByteString): ByteString = {
     val length = data.length
-    frameType ++ ByteString((length >> 24).toByte, (length >> 16).toByte, (length >> 8).toByte, length.toByte) ++ data
+    val encodedLength = ByteString.fromArrayUnsafe(
+      Array((length >> 24).toByte, (length >> 16).toByte, (length >> 8).toByte, length.toByte))
+    frameType ++ encodedLength ++ data
   }
 
   def writer(protocol: GrpcProtocol, codec: Codec, encodeFrame: Frame => ChunkStreamPart): GrpcProtocolWriter =

--- a/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
@@ -18,7 +18,7 @@ object Gzip extends Codec {
     gzos.write(uncompressed.toArray)
     gzos.flush()
     gzos.close()
-    ByteString(baos.toByteArray)
+    ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 
   override def uncompress(compressed: ByteString): ByteString = {
@@ -31,6 +31,6 @@ object Gzip extends Codec {
       baos.write(buffer, 0, read)
       read = gzis.read(buffer)
     }
-    ByteString(baos.toByteArray)
+    ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 }

--- a/runtime/src/main/scala/akka/grpc/internal/Marshallers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Marshallers.scala
@@ -28,7 +28,7 @@ abstract class BaseMarshaller[T](val protobufSerializer: ProtobufSerializer[T])
       baos.write(buffer, 0, bytesRead)
       bytesRead = stream.read(buffer)
     }
-    protobufSerializer.deserialize(akka.util.ByteString(baos.toByteArray))
+    protobufSerializer.deserialize(akka.util.ByteString.fromArrayUnsafe(baos.toByteArray))
   }
 
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
@@ -6,11 +6,13 @@ package akka.grpc.javadsl
 
 import akka.annotation.ApiMayChange
 import akka.grpc.ProtobufSerializer
+import akka.util.ByteString
 
 @ApiMayChange
 class GoogleProtobufSerializer[T <: com.google.protobuf.Message](clazz: Class[T]) extends ProtobufSerializer[T] {
-  override def serialize(t: T) = akka.util.ByteString(t.toByteArray)
-  override def deserialize(bytes: akka.util.ByteString): T = {
+  override def serialize(t: T): ByteString =
+    ByteString.fromArrayUnsafe(t.toByteArray)
+  override def deserialize(bytes: ByteString): T = {
     val parser = clazz.getMethod("parseFrom", classOf[Array[Byte]])
     parser.invoke(clazz, bytes.toArray).asInstanceOf[T]
   }

--- a/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
@@ -13,7 +13,8 @@ import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
 @ApiMayChange
 class ScalapbProtobufSerializer[T <: GeneratedMessage](companion: GeneratedMessageCompanion[T])
     extends ProtobufSerializer[T] {
-  override def serialize(t: T): ByteString = ByteString(companion.toByteArray(t))
+  override def serialize(t: T): ByteString =
+    ByteString.fromArrayUnsafe(t.toByteArray)
   override def deserialize(bytes: ByteString): T =
     companion.parseFrom(CodedInputStream.newInstance(bytes.asByteBuffer))
 }


### PR DESCRIPTION
Non-functional change. Use `ByteString.fromArrayUnsafe` where safe to save one bytes array copy.

References #1180
