### PR TITLE
Remove reflection usage in GoogleProtobufSerializer (#1285)

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Serializer.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Serializer.scala
@@ -12,6 +12,6 @@ object Serializer {
   def apply(messageType: Descriptor): Serializer =
     Serializer(
       messageType.getName + "Serializer",
-      s"new GoogleProtobufSerializer<>(${Method.getMessageType(messageType)}.class)",
+      s"new GoogleProtobufSerializer<>(${Method.getMessageType(messageType)}.parser())",
       Method.getMessageType(messageType))
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
@@ -12,13 +12,12 @@ import com.google.protobuf.Parser
 @ApiMayChange
 class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[T]) extends ProtobufSerializer[T] {
 
-  // For binary compatibility in generated sources, can be dropped in version 2.x
+  @deprecated("Kept for binary compatibility, use the main constructor instead", since = "akka-grpc 1.1.2")
   def this(clazz: Class[T]) =
     this(clazz.getMethod("parser").invoke(clazz).asInstanceOf[Parser[T]])
 
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
-  override def deserialize(bytes: ByteString): T = {
+  override def deserialize(bytes: ByteString): T =
     parser.parseFrom(bytes.toArray)
-  }
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
@@ -7,13 +7,18 @@ package akka.grpc.javadsl
 import akka.annotation.ApiMayChange
 import akka.grpc.ProtobufSerializer
 import akka.util.ByteString
+import com.google.protobuf.Parser
 
 @ApiMayChange
-class GoogleProtobufSerializer[T <: com.google.protobuf.Message](clazz: Class[T]) extends ProtobufSerializer[T] {
+class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[T]) extends ProtobufSerializer[T] {
+
+  // For binary compatibility in generated sources, can be dropped in version 2.x
+  def this(clazz: Class[T]) =
+    this(clazz.getMethod("parser").invoke(clazz).asInstanceOf[Parser[T]])
+
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
   override def deserialize(bytes: ByteString): T = {
-    val parser = clazz.getMethod("parseFrom", classOf[Array[Byte]])
-    parser.invoke(clazz, bytes.toArray).asInstanceOf[T]
+    parser.parseFrom(bytes.toArray)
   }
 }


### PR DESCRIPTION
References #1285

Open question is how best handle binary compatibility, is the given auxiliary constructor enough? Should it be marked as deprecated?
