### PR TITLE
[wip] Remove obsolete plugin settings

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -26,9 +26,6 @@ Names and default values are provided.
     akkaGrpc {
         generateClient = true
         generateServer = true
-        generatePlay = false
-        usePlayActions = false
-        serverPowerApis = false
         extraGenerators = []       
     }
     ```


### PR DESCRIPTION
play-related settings are noop. They should be, at least, removed from docs.