### PR TITLE
let scala-steward upgrade sbt-protoc

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,4 @@
 updates.ignore = [
-  { groupId = "com.thesamet", artifactId = "sbt-protoc" },
   { groupId = "com.typesafe", artifactId = "ssl-config-core" },
 
   { groupId = "com.typesafe.akka", artifactId = "akka-actor" },


### PR DESCRIPTION
sbt-protoc has reached 1.x, so there is no reason to handle bumps manually

History
- https://github.com/akka/akka-grpc/pull/594/files
- https://github.com/akka/akka-grpc/pull/702#discussion_r341852976