### PR TITLE
Make it clear that Jetty ALPN is not supported anymore

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -29,7 +29,7 @@ Names and default values are provided.
         generatePlay = false
         usePlayActions = false
         serverPowerApis = false
-        extraGenerators = []       
+        extraGenerators = []
     }
     ```
     @@@
@@ -51,12 +51,12 @@ To additionally generate server "power APIs" that have access to request metadat
 
 ## Protoc version
 
-Default version of `protoc` compiler is 3.4.0. 
+Default version of `protoc` compiler is 3.4.0.
 The version and the location of `protoc` can be changed using `protobuf-gradle-plugin` [settings](https://github.com/google/protobuf-gradle-plugin#locate-external-executables).
 
 ## Proto source directory
 
-By default the plugin looks for `.proto` files under 
+By default the plugin looks for `.proto` files under
 
 * `src/main/protobuf`
 * `src/main/proto`
@@ -73,9 +73,13 @@ explicit by duplicating the proto definitions in your project.
 
 This is supported by `protobuf-gradle-plugin` and explained [here](https://github.com/google/protobuf-gradle-plugin#protos-in-dependencies).
 
+## JDK 8 support
+
+If you want to use TLS-based negotiation on JDK 8, Akka gRPC requires JDK 8 update 252 or later. JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN agent has been [dropped in Akka HTTP 10.2.0](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#http-2-support-requires-jdk-8-update-252-or-later), and therefore is not supported by Akka gRPC.
+
 ## Starting your Akka gRPC server from gradle
 
-Build script needs a custom task 
+Build script needs a custom task
 
 `build.gradle`
 :   @@@vars
@@ -92,32 +96,6 @@ Then, the server can then be started from the command line with:
 ```
 ./gradlew runServer
 ```
-
-## JDK 8 support
-
-If you want to use TLS-based negotiation on JDK 8 versions prior to
-[1.8.0_251](https://www.oracle.com/java/technologies/javase/8u251-relnotes.html),
-the server requires a special Java agent for ALPN.
-
-Doing this from inside of Gradle requires some configuration in the `build.gradle`:
-
-`build.gradle` for JVM 8 prior to update 251
-:   @@@vars
-    ```gradle
-    configurations {
-      alpnagent
-    }
-    dependencies {
-      // Configuration for modules that use Jetty ALPN agent
-      alpnagent 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.10'
-    }
-    task runServer(type: JavaExec) {
-      classpath = sourceSets.main.runtimeClasspath
-      main = 'com.example.helloworld.GreeterServer'
-      jvmArgs "-javaagent:" + configurations.alpnagent.asPath
-    }
-    ```
-    @@@
 
 ## Play Framework support
 

--- a/docs/src/main/paradox/buildtools/maven.md
+++ b/docs/src/main/paradox/buildtools/maven.md
@@ -82,60 +82,14 @@ proto definitions from a dependency classpath. This is not yet supported
 for Maven and @ref[Gradle](gradle.md). If you are interested in this feature
 it is tracked in issue [#152](https://github.com/akka/akka-grpc/issues/152).
 
+## JDK 8 support
+
+If you want to use TLS-based negotiation on JDK 8, Akka gRPC requires JDK 8 update 252 or later. JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN agent has been [dropped in Akka HTTP 10.2.0](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#http-2-support-requires-jdk-8-update-252-or-later), and therefore is not supported by Akka gRPC.
+
 ## Starting your Akka gRPC server from Maven
 
-If you want to use TLS-based negotiation on JDK 8 versions prior to
-[1.8.0_251](https://www.oracle.com/java/technologies/javase/8u251-relnotes.html),
-the server requires a special Java agent for ALPN.
+You can start your gRPC application as usual with:
 
-Doing this from inside of Maven requires some configuration:
-
-`pom.xml` for JVM 8
-:   ```xml
-    <dependencies>
-      <dependency>
-        <groupId>org.mortbay.jetty.alpn</groupId>
-        <artifactId>jetty-alpn-agent</artifactId>
-        <version>2.0.10</version>
-        <scope>runtime</scope>
-      </dependency>
-    <dependencies>
-     ...
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.5.1</version>
-        <executions>
-          <execution>
-            <id>getClasspathFilenames</id>
-            <goals>
-              <!-- provides the jars of the classpath as properties inside of Maven
-                   so that we can refer to one of the jars in the exec plugin config below -->
-              <goal>properties</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-javaagent:${org.mortbay.jetty.alpn:jetty-alpn-agent:jar}</argument>
-            <argument>-classpath</argument>
-            <classpath />
-            <argument>com.example.MainClass</argument>
-          </arguments>
-        </configuration>
-      </plugin>
-    </plugins>
-    ```
-
-The server can then be started from the command line with:
-
+```bash
+mvn compile exec:exec
 ```
-mvn compile dependency:properties exec:exec
-```
-

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -68,7 +68,6 @@ Available parameters are listed in the [ScalaPB documentation](https://scalapb.g
 To tune the `sbt-protoc` [additional options](https://github.com/thesamet/sbt-protoc#additional-options) such as the proto source directory
 you can configure them like this:
 
-
 ```scala
   .settings(
     inConfig(Compile)(Seq(
@@ -76,6 +75,7 @@ you can configure them like this:
     ))
   )
 ```
+
 The above, for example, removes `descriptor.proto` from the list of files to be processed.
 
 By default protobuf files are looked for in `src/main/protobuf` (and `src/main/proto`).
@@ -113,17 +113,12 @@ libraryDependencies += "com.example" %% "my-grpc-service" % "1.0.0" % "protobuf"
 
 ## JDK 8 support
 
-If you want to use TLS-based negotiation on JDK 8 versions prior to
-[1.8.0_251](https://www.oracle.com/java/technologies/javase/8u251-relnotes.html),
-the server requires a special Java agent for ALPN.
- 
-See the @extref:[Akka HTTP docs about HTTP/2](akka-http:server-side/http2.html#application-layer-protocol-negotiation-alpn-)
-for more information.
+If you want to use TLS-based negotiation on JDK 8, Akka gRPC requires JDK 8 update 252 or later. JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN agent has been [dropped in Akka HTTP 10.2.0](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#http-2-support-requires-jdk-8-update-252-or-later), and therefore is not supported by Akka gRPC.
 
 ## Starting your Akka gRPC server from sbt
 
 You can start your gRPC application as usual with:
 
-```
-runMain io.grpc.examples.helloworld.GreeterServer
+```bash
+sbt "runMain io.grpc.examples.helloworld.GreeterServer"
 ```


### PR DESCRIPTION
As documented here:

https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#http-2-support-requires-jdk-8-update-252-or-later﻿
