### PR TITLE
Use valid headers in unit tests

### DIFF
--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
@@ -67,7 +67,7 @@ class JGreeterServiceSpec extends Matchers with AnyWordSpecLike with BeforeAndAf
         s"use metadata in replying to single request ($ix)" in {
           val reply = clients.last
             .sayHello()
-            .addHeader(mdName, "<some auth token>")
+            .addHeader(mdName, "Bearer test")
             .invoke(HelloRequest.newBuilder.setName("Alice").build())
           reply.toCompletableFuture.get should ===(HelloReply.newBuilder.setMessage(expResp).build())
         }

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -66,7 +66,7 @@ class GreeterSpec extends Matchers with AnyWordSpecLike with BeforeAndAfterAll w
       ("WrongHeaderName", "Hello, Alice (not authenticated)")).zipWithIndex.foreach {
       case ((mdName, expResp), ix) =>
         s"use metadata in replying to single request ($ix)" in {
-          val reply = clients.last.sayHello().addHeader(mdName, "<some auth token>").invoke(HelloRequest("Alice"))
+          val reply = clients.last.sayHello().addHeader(mdName, "Bearer test").invoke(HelloRequest("Alice"))
           reply.futureValue should ===(HelloReply(expResp))
         }
     }


### PR DESCRIPTION
Remove annoying invalid header warnings in unit test:

```
[WARN] [04/07/2021 10:56:00.405] [GreeterServer-akka.actor.default-dispatcher-9] [akka.actor.ActorSystemImpl(GreeterServer)] Illegal header: Illegal 'authorization' header: Invalid input '<', expected basic-credential-def, oauth2-bearer-token or generic-credentials (line 1, column 1): <some auth token>
```
