### PR TITLE
Introduces a build and test GH workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -156,6 +156,11 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
+      - name: Gather version
+        run: |-
+          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
+          cat ~/.m2/.version
+
       - name: Test Gradle Java Scala 2.12
         run: |-
           cp .jvmopts-travis .jvmopts
@@ -222,6 +227,11 @@ jobs:
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
+
+      - name: Gather version
+        run: |-
+          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
+          cat ~/.m2/.version
 
       - name: Test Maven Java
         run: |-

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,9 +68,13 @@ jobs:
       matrix:
         include:
           - SCALA_VERSION: 2.12.11
+            JABBA_JDK: 1.8.0-275
+          - SCALA_VERSION: 2.12.11
+            JABBA_JDK: 1.11.0-9
           - SCALA_VERSION: 2.13.3
-          - JABBA_JDK: 1.8.0-275
-          - JABBA_JDK: 1.11.0-9
+            JABBA_JDK: 1.8.0-275
+          - SCALA_VERSION: 2.13.3
+            JABBA_JDK: 1.11.0-9
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,8 +158,8 @@ jobs:
 
       - name: Gather version
         run: |-
-          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
-          cat ~/.m2/.version
+          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.version
+          cat ~/.version
 
       - name: Test Gradle Java Scala 2.12
         run: |-
@@ -169,7 +169,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-java
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
 
       - name: Test Gradle Java Scala 2.13
         run: |-
@@ -179,7 +179,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-java
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
 
       - name: Test Gradle Scala 2.12
         run: |-
@@ -189,7 +189,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-scala
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
 
       - name: Test Gradle Scala 2.13
         run: |-
@@ -199,8 +199,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-scala
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
-
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
 
 
   test-maven:
@@ -230,8 +229,8 @@ jobs:
 
       - name: Gather version
         run: |-
-          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.m2/.version
-          cat ~/.m2/.version
+          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8` > ~/.version
+          cat ~/.version
 
       - name: Test Maven Java
         run: |-
@@ -239,7 +238,7 @@ jobs:
           sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
           sbt akka-grpc-maven-plugin/publishM2
           cd plugin-tester-java
-          mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate compile
+          mvn -Dakka.grpc.project.version=`cat ~/.version` akka-grpc:generate compile
 
       - name: Test Maven Scala
         run: |-
@@ -247,4 +246,4 @@ jobs:
           sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
           sbt akka-grpc-maven-plugin/publishM2
           cd plugin-tester-scala
-          mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate scala:compile
+          mvn -Dakka.grpc.project.version=`cat ~/.version` akka-grpc:generate scala:compile

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,20 +1,232 @@
-name: PR Checks
+name: Validate and test
 
 on:
   pull_request:
-    branches: [ master ]
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  check-code-style:
+    name: Checks
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-        check-latest: true
-    - name: Run tests
-      run: env
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Code style check and binary-compatibility check
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt scalafmtCheckAll scalafmtSbtCheck headerCheckAll grpcVersionSyncCheck ++2.13.3 mimaReportBinaryIssues ++2.12.11 mimaReportBinaryIssues
 
+
+  compile-benchmarks:
+    name: Compile Benchmarks
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+      - name: Compile benchmarks
+        run: |-
+          cd benchmark-java
+          sbt test:compile
+
+
+  compile-and-test:
+    name: Compile and test
+    runs-on: ubuntu-18.04
+    fail-fast: false
+    matrix:
+      include:
+        - SCALA_VERSION: 2.12.11
+        - SCALA_VERSION: 2.13.3
+        - JABBA_JDK: 1.8.0-275
+        - JABBA_JDK: 1.11.0-9
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK ${{ matrix.JABBA_JDK }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@${{ matrix.JABBA_JDK }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Compile and test for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
+        run: sbt ++${{ matrix.SCALA_VERSION }} test
+
+
+  test-sbt:
+    name: sbt scripted tests
+    runs-on: ubuntu-18.04
+    fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 8
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8.0-275
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Scripted gen-scala-server
+        run: cp .jvmopts-travis .jvmopts && sbt "; project sbt-akka-grpc; scripted gen-scala-server/*"
+
+      - name: Scripted gen-java
+        run: cp .jvmopts-travis .jvmopts && sbt "; project sbt-akka-grpc; scripted gen-java/*"
+
+
+  test-gradle:
+    name: Gradle tests
+    runs-on: ubuntu-18.04
+    fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 8
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8.0-275
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Test Gradle Java Scala 2.12
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2
+          cd gradle-plugin
+          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
+          find ~/.m2 | grep gradle
+          cd ../plugin-tester-java
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+
+      - name: Test Gradle Java Scala 2.13
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
+          cd gradle-plugin
+          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
+          find ~/.m2 | grep gradle
+          cd ../plugin-tester-java
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+
+      - name: Test Gradle Scala 2.12
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2
+          cd gradle-plugin
+          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
+          find ~/.m2 | grep gradle
+          cd ../plugin-tester-scala
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+
+      - name: Test Gradle Scala 2.13
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
+          cd gradle-plugin
+          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
+          find ~/.m2 | grep gradle
+          cd ../plugin-tester-scala
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+
+
+
+  test-maven:
+    name: Maven tests
+    runs-on: ubuntu-18.04
+    fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 8
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8.0-275
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Test Maven Java
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
+          sbt akka-grpc-maven-plugin/publishM2
+          cd plugin-tester-java
+          mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate compile
+
+      - name: Test Maven Scala
+        run: |-
+          cp .jvmopts-travis .jvmopts
+          sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 ++2.12.11 akka-grpc-runtime/publishM2 ++2.13.3 akka-grpc-runtime/publishM2
+          sbt akka-grpc-maven-plugin/publishM2
+          cd plugin-tester-scala
+          mvn -Dakka.grpc.project.version=`cat ~/.m2/.version` akka-grpc:generate scala:compile

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,13 +63,14 @@ jobs:
   compile-and-test:
     name: Compile and test
     runs-on: ubuntu-18.04
-    fail-fast: false
-    matrix:
-      include:
-        - SCALA_VERSION: 2.12.11
-        - SCALA_VERSION: 2.13.3
-        - JABBA_JDK: 1.8.0-275
-        - JABBA_JDK: 1.11.0-9
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - SCALA_VERSION: 2.12.11
+          - SCALA_VERSION: 2.13.3
+          - JABBA_JDK: 1.8.0-275
+          - JABBA_JDK: 1.11.0-9
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -97,7 +98,8 @@ jobs:
   test-sbt:
     name: sbt scripted tests
     runs-on: ubuntu-18.04
-    fail-fast: false
+    strategy:
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -128,7 +130,8 @@ jobs:
   test-gradle:
     name: Gradle tests
     runs-on: ubuntu-18.04
-    fail-fast: false
+    strategy:
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -194,7 +197,8 @@ jobs:
   test-maven:
     name: Maven tests
     runs-on: ubuntu-18.04
-    fail-fast: false
+    strategy:
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ env:
     # encrypt with: travis encrypt TECH_HUB_TOKEN=...
     - secure: "sFbpTppagGo56idzNXn3qOYwtRb8q/+Zjcen7KV3uNno3U1asfKVNoEj6UMxwCnmPn8BnrRtq2aVHIjDmItDwMHEPQ51Wm+0hxAw15o9yh15/MIoc+yu+VfOSXAYb9pEcMVbIyYzyR/qi2vsBTIJuloUDK/KPmmrUldx1hgFd567WmwHiXwiu/4BePWqsXGiCEjq5nQuO5XS+4uFDdpXlfX6wcQsU6o2ztD60wNAQwdDL751d8TNZNajWi5R9fD7xWV2wsewhGhl5E43o/HiY+Z/h1Kt/f3UGbhj7vZNTHAd901ZEG9QacFxQXaQWYOutlrO+eDBgRKd+27PLNpTLymF1Ht47xcERjpH0lgps02pDoSoFGzRYoHNQYAjA2BXK3GZHcLYmnPCB+5pbw1D4lsX8xQ8y5yO29gE4uCTx7P15bVt7/KbgUTdWfLtOQGyOd/jS9RTplHNAG2fBW2pa5nS4KNmON1UO3vNcsWv/zEHv48ASSLxpC3NxWkwS+zOkt0uORyXlxi0teOajWA7dmalC+9VpKf5kuAZvKM0xYxN5Yqt+6UELtTQnle3fTLnKcE584+eo/RdCgvGD6N0RJHN/UKl7sP7hvTF7w/SbcAaI/jv31N+oVV79UyMLqm1U8HRGg2HLMSHiRbYFSOYmsQ5/sYWn7RsJIroDKpFd+I="
   matrix:
-    - TRAVIS_JDK=adopt@1.8-0
+    # https://github.com/akka/akka-grpc/issues/1332
+    - TRAVIS_JDK=adopt@1.8.0-275
     - TRAVIS_JDK=adopt@1.11-0
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh

--- a/interop-tests/src/test/resources/application.conf
+++ b/interop-tests/src/test/resources/application.conf
@@ -1,7 +1,6 @@
 akka.http {
     client.http2 {
         log-frames = true
-        max-persistent-attempts = 10
     }
     server {
         default-host-header = "localhost.com"

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -39,7 +39,7 @@ class NonBalancingIntegrationSpec(backend: String)
   implicit val mat = SystemMaterializer(system).materializer
   implicit val ec = system.dispatcher
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, Span(10, org.scalatest.time.Millis))
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(15.seconds, Span(10, org.scalatest.time.Millis))
 
   "Using pick-first (non load balanced clients)" should {
     "send requests to a single endpoint" in {

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -39,7 +39,7 @@ class NonBalancingIntegrationSpec(backend: String)
   implicit val mat = SystemMaterializer(system).materializer
   implicit val ec = system.dispatcher
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(15.seconds, Span(10, org.scalatest.time.Millis))
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(3.seconds, Span(10, org.scalatest.time.Millis))
 
   s"Using pick-first (non load balanced clients) - $backend" should {
     "send requests to a single endpoint" in {
@@ -150,7 +150,8 @@ class NonBalancingIntegrationSpec(backend: String)
       val client = GreeterServiceClient(GrpcClientSettings.usingServiceDiscovery("greeter", discovery).withTls(false))
 
       for (i <- 1 to 100) {
-        client.sayHello(HelloRequest(s"Hello $i")).futureValue
+        println(s" Sending request [$i]")
+        client.sayHello(HelloRequest(s"Hello $i")).map(_ => println(s" Received response number [$i]")).futureValue
       }
 
       service.greetings.get should be(1 + 100)

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -34,14 +34,14 @@ class NonBalancingIntegrationSpec(backend: String)
     with BeforeAndAfterAll
     with ScalaFutures {
   implicit val system = ActorSystem(
-    "NonBalancingIntegrationSpec",
+    s"NonBalancingIntegrationSpec-$backend",
     ConfigFactory.parseString(s"""akka.grpc.client."*".backend = "$backend" """).withFallback(ConfigFactory.load()))
   implicit val mat = SystemMaterializer(system).materializer
   implicit val ec = system.dispatcher
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(15.seconds, Span(10, org.scalatest.time.Millis))
 
-  "Using pick-first (non load balanced clients)" should {
+  s"Using pick-first (non load balanced clients) - $backend" should {
     "send requests to a single endpoint" in {
       val service1 = new CountingGreeterServiceImpl()
       val service2 = new CountingGreeterServiceImpl()

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -39,7 +39,7 @@ class NonBalancingIntegrationSpec(backend: String)
   implicit val mat = SystemMaterializer(system).materializer
   implicit val ec = system.dispatcher
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(3.seconds, Span(10, org.scalatest.time.Millis))
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, Span(10, org.scalatest.time.Millis))
 
   s"Using pick-first (non load balanced clients) - $backend" should {
     "send requests to a single endpoint" in {

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -134,13 +134,6 @@ class NonBalancingIntegrationSpec(backend: String)
       val service = new CountingGreeterServiceImpl()
       val server = Http().newServerAt("127.0.0.1", 0).bind(GreeterServiceHandler(service)).futureValue
 
-      // A first successful request. A vanilla probe...
-      val discoveryHappyPath = new MutableServiceDiscovery(List(server.localAddress))
-      val serviceClient =
-        GreeterServiceClient(GrpcClientSettings.usingServiceDiscovery("greeter", discoveryHappyPath).withTls(false))
-      serviceClient.sayHello(HelloRequest(s"Hello")).futureValue
-
-      // ... and now we test the endpoint selection.
       val discovery =
         new MutableServiceDiscovery(
           List(
@@ -154,7 +147,7 @@ class NonBalancingIntegrationSpec(backend: String)
         client.sayHello(HelloRequest(s"Hello $i")).map(_ => println(s" Received response number [$i]")).futureValue
       }
 
-      service.greetings.get should be(1 + 100)
+      service.greetings.get should be(100)
     }
 
     "eventually fail when no valid endpoints are provided" in {


### PR DESCRIPTION
References #1324 (built on top of #1326 so the PR runs the new workflow)

This is part of the migrations:

1. from Travis to GH Actions (#1324)
	1. migrate compile and test
	2. migrate release jobs 	
2. from Bintray to Sonatype (#1323)

This first PR is down-scoped to migrating the build and test jobs (1.1). 

Once these compile and test jobs (`1.1`) in GH Actions are stable, I would migrate the release jobs from Travis/Bintray to GHActions/Sonatype in a single PR. That is,  I would do `1.2.` and `2.` at once.


