### PR TITLE
List the com.google.protobuf protos version in BuildInfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
     buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
     buildInfoKeys += "grpcVersion" → Dependencies.Versions.grpc,
-    buildInfoKeys += "googleCommonProtobufVersion" → Dependencies.Versions.googleCommonProtobuf,
+    buildInfoKeys += "googleProtobufVersion" → Dependencies.Versions.googleProtobuf,
     buildInfoPackage := "akka.grpc.gen",
     artifact in (Compile, assembly) := {
       val art = (artifact in (Compile, assembly)).value

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
     buildInfoKeys += "akkaVersion" → Dependencies.Versions.akka,
     buildInfoKeys += "akkaHttpVersion" → Dependencies.Versions.akkaHttp,
     buildInfoKeys += "grpcVersion" → Dependencies.Versions.grpc,
+    buildInfoKeys += "googleCommonProtobufVersion" → Dependencies.Versions.googleCommonProtobuf,
     buildInfoPackage := "akka.grpc.gen",
     artifact in (Compile, assembly) := {
       val art = (artifact in (Compile, assembly)).value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
     val grpc = "1.37.0" // checked synced by GrpcVersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests
-    val googleCommonProtobuf = "3.15.8"
+    val googleProtobuf = "3.15.8"
 
     val scalaTest = "3.1.4"
 
@@ -75,7 +75,7 @@ object Dependencies {
   }
 
   object Protobuf {
-    val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % Versions.googleCommonProtobuf % "protobuf"
+    val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % Versions.googleProtobuf % "protobuf"
   }
 
   object Plugins {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,8 @@ object Dependencies {
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.37.0" // checked synced by GrpcVersionSyncCheckPlugin
+    // Even referenced explicitly in the sbt-plugin's sbt-tests
+    val googleCommonProtobuf = "3.15.8"
 
     val scalaTest = "3.1.4"
 
@@ -73,7 +75,7 @@ object Dependencies {
   }
 
   object Protobuf {
-    val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % "3.15.8" % "protobuf"
+    val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % Versions.googleCommonProtobuf % "protobuf"
   }
 
   object Plugins {

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -7,4 +7,4 @@ javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.15.8" % "protobuf"
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % akka.grpc.gen.BuildInfo.googleProtobufVersion % "protobuf"

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -7,4 +7,4 @@ javacOptions += "-Xdoclint:all"
 
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.15.8" % "protobuf"
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % akka.grpc.gen.BuildInfo.googleProtobufVersion % "protobuf"


### PR DESCRIPTION
While it is not fundamental to keep the version of `"com.google.protobuf" % "protobuf-java" % "3.15.8" % "protobuf"` in projects using Akka gRPC in sync, it seems useful to expose the version anyway.﻿

