### PR TITLE
Improve marshalling performance

### DIFF
--- a/benchmarks/src/main/scala/akka/grpc/GrpcMarshallingBenchmark.scala
+++ b/benchmarks/src/main/scala/akka/grpc/GrpcMarshallingBenchmark.scala
@@ -1,0 +1,33 @@
+package akka.grpc
+
+import akka.actor.ActorSystem
+import akka.grpc.internal.{ GrpcProtocolNative, Identity }
+import akka.grpc.scaladsl.GrpcMarshalling
+import akka.http.scaladsl.model.HttpResponse
+import akka.stream.scaladsl.Source
+import grpc.reflection.v1alpha.reflection._
+import org.openjdk.jmh.annotations._
+
+// Microbenchmarks for GrpcMarshalling.
+// Does not actually benchmarks the actual marshalling because we dont consume the HttpResponse
+class GrpcMarshallingBenchmark extends CommonBenchmark {
+  implicit val system = ActorSystem("bench")
+  implicit val writer = GrpcProtocolNative.newWriter(Identity)
+  implicit val reader = GrpcProtocolNative.newReader(Identity)
+  implicit val serializer = ServerReflection.Serializers.ServerReflectionRequestSerializer
+
+  @Benchmark
+  def marshall(): HttpResponse = {
+    GrpcMarshalling.marshal(ServerReflectionRequest())
+  }
+
+  @Benchmark
+  def marshallStream(): HttpResponse = {
+    GrpcMarshalling.marshalStream(Source.repeat(ServerReflectionRequest()).take(10000))
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    system.terminate()
+  }
+}

--- a/benchmarks/src/main/scala/akka/grpc/HandlerProcessingBenchmark.scala
+++ b/benchmarks/src/main/scala/akka/grpc/HandlerProcessingBenchmark.scala
@@ -30,7 +30,7 @@ class HandlerProcessingBenchmark extends CommonBenchmark {
   val in = Source.repeat(ServerReflectionRequest()).take(10000)
   val request: HttpRequest = {
     implicit val serializer = ServerReflection.Serializers.ServerReflectionRequestSerializer
-    GrpcRequestHelpers(Uri("https://unused.example/" + ServerReflection.name + "/ServerReflectionInfo"), in)
+    GrpcRequestHelpers(Uri("https://unused.example/" + ServerReflection.name + "/ServerReflectionInfo"), Nil, in)
   }
 
   val handler: HttpRequest => Future[HttpResponse] = ServerReflectionHandler(new ServerReflection {


### PR DESCRIPTION
References #1349

Before
```
[info] GrpcMarshallingBenchmark.marshall        thrpt    3  126666.347 ± 15574.678  ops/s
[info] GrpcMarshallingBenchmark.marshallStream  thrpt    3  114767.059 ±  2759.197  ops/s
```

after `concatCheap`

```
[info] GrpcMarshallingBenchmark.marshall        thrpt    3  256018.599 ± 60197.380  ops/s
[info] GrpcMarshallingBenchmark.marshallStream  thrpt    3  221998.871 ± 83522.412  ops/s
```

As @jrudolph said maybe these microoptimizations are not worth it, so feel free to close the PR
