### PR TITLE
No -SNAPSHOT postfix for gradle plugin snapshots

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -169,7 +169,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-java
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
 
       - name: Test Gradle Java Scala 2.13
         run: |-
@@ -179,7 +179,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-java
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
 
       - name: Test Gradle Scala 2.12
         run: |-
@@ -189,7 +189,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-scala
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
 
       - name: Test Gradle Scala 2.13
         run: |-
@@ -199,7 +199,7 @@ jobs:
           ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
           find ~/.m2 | grep gradle
           cd ../plugin-tester-scala
-          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.version`
+          ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
 
 
   test-maven:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
         - find ~/.m2 | grep gradle
         - cd ../plugin-tester-java
-        - ./gradlew clean test --console=plain --info --stacktrace  -Dakka.grpc.project.version=`cat ~/.m2/.version`
+        - ./gradlew clean test --console=plain --info --stacktrace  -Dakka.grpc.project.version=$(cat ~/.m2/.version | sed -e s/-SNAPSHOT//)
     - name: Gradle Scala 2.13
       scala: 2.13.3
       workspaces:
@@ -114,7 +114,7 @@ jobs:
         - cd gradle-plugin 
         - ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace 
         - cd ../plugin-tester-scala 
-        - ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=`cat ~/.m2/.version`
+        - ./gradlew clean test --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.m2/.version | sed -e s/-SNAPSHOT//)
     - name: Test Maven Java
       workspaces:
         use: mavenLocal

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -10,7 +10,7 @@ group = "com.lightbend.akka.grpc"
 // https://github.com/palantir/gradle-git-version/issues/97
 
 def tag = "git describe --tags".execute().text.substring(1).split("-g")[0].replace("\n", "")
-def finalVersion = (tag == versionDetails().lastTag.substring(1)) ? tag : tag.reverse().reverse() + "-" + versionDetails().gitHash.substring(0, 8) + "-SNAPSHOT"
+def finalVersion = (tag == versionDetails().lastTag.substring(1)) ? tag : tag.reverse().reverse() + "-" + versionDetails().gitHash.substring(0, 8)
 
 version = finalVersion
 

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -20,6 +20,16 @@ class AkkaGrpcPlugin implements Plugin<Project> {
 
     Project project
 
+    // workaround for test projects, when one only neesd to tests a new plugin version without rebuilding dependencies.
+    String getBaselineVersion(String pluginVersion) {
+        def pv = System.getProperty("akka.grpc.baseline.version", pluginVersion)
+        if (VersionNumber.parse(pv).qualifier) {
+            pv + "-SNAPSHOT"
+        } else {
+            pv
+        }
+    }
+
     @Override
     void apply(Project project) {
 
@@ -38,8 +48,7 @@ class AkkaGrpcPlugin implements Plugin<Project> {
 
         project.pluginManager.apply ProtobufPlugin
 
-        // workaround for test projects, when one only neesd to tests a new plugin version without rebuilding dependencies.
-        def baselineVersion = System.getProperty("akka.grpc.baseline.version", akkaGrpcExt.pluginVersion)
+        def baselineVersion = getBaselineVersion(akkaGrpcExt.pluginVersion)
 
         project.repositories {
             mavenCentral()


### PR DESCRIPTION
Otherwise:

```
> Task :publishPlugins FAILED

FAILURE: Build failed with an exception.

* What went wrong:

Execution failed for task ':publishPlugins'.

> Invalid version '1.1.1-57-18bcff93-SNAPSHOT'. Set 'version' property string must with a string that: 1) is more than 1 and less than 20 characters long; 2) includes a number; and 3) that matches the regular expression: [a-zA-Z0-9\-\.\[\]\:\+]*
```