### PR TITLE
Encode logfile option with URLEncoder

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/Main.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Main.scala
@@ -5,6 +5,7 @@
 package akka.grpc.gen
 
 import java.io.ByteArrayOutputStream
+import java.net.URLDecoder
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerator, JavaServerCodeGenerator }
@@ -45,7 +46,8 @@ object Main extends App {
   private val extraGenerators: List[String] =
     parameters.getOrElse("extra_generators", "").split(";").toList.filter(_ != "")
 
-  private val logger = parameters.get("logfile").map(new FileLogger(_)).getOrElse(SilencedLogger)
+  private val logger: Logger =
+    parameters.get("logfile_enc").map(URLDecoder.decode(_, "utf-8")).map(new FileLogger(_)).getOrElse(SilencedLogger)
 
   val out = {
     val codeGenerators =

--- a/codegen/src/main/scala/akka/grpc/gen/Main.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/Main.scala
@@ -46,8 +46,14 @@ object Main extends App {
   private val extraGenerators: List[String] =
     parameters.getOrElse("extra_generators", "").split(";").toList.filter(_ != "")
 
+  // Prefer logfile_enc with fallback to logfile
   private val logger: Logger =
-    parameters.get("logfile_enc").map(URLDecoder.decode(_, "utf-8")).map(new FileLogger(_)).getOrElse(SilencedLogger)
+    parameters
+      .get("logfile_enc")
+      .map(URLDecoder.decode(_, "utf-8"))
+      .orElse(parameters.get("logfile"))
+      .map(new FileLogger(_))
+      .getOrElse(SilencedLogger)
 
   val out = {
     val codeGenerators =

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -11,6 +11,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.util.GradleVersion
 import org.gradle.util.VersionNumber
 
+import java.net.URLEncoder
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -125,7 +126,7 @@ class AkkaGrpcPlugin implements Plugin<Project> {
                             option "server_power_apis=${akkaGrpcExt.serverPowerApis}"
                             option "use_play_actions=${akkaGrpcExt.usePlayActions}"
                             option "extra_generators=${akkaGrpcExt.extraGenerators.join(';')}"
-                            option "logfile=${project.projectDir.toPath().relativize(logFile).toString()}"
+                            option "logfile_enc=${URLEncoder.encode(logFile.toString(), "utf-8")}"
                             if (akkaGrpcExt.includeStdTypes) {
                                 option "include_std_types=true"
                             }


### PR DESCRIPTION
References #786

## Issue
Currently, applying the gradle plugin to a subproject will fail gradle build from root project dir, due to a mismatch in the expectation of where the `logfile` is located. The gradle plugin calculates a relative path to the subproject, while the protoc codegen plugin evaluates it as relative to the current working dir (which is root dir).

## Background
There had been several back-and-forths regarding how to pass the `logfile` option in the past, ranging from one-off character substitution, to relative paths, to absolute paths (see #674 and #787). The root of the problem is that protoc codegen plugin options are passed in as a single string, encoded in a special format like this:

```
--akkaGrpc_out=<key1>=<value1>,<key2>=<value2>:<out_dir>
```

 It's easy to see how several characters play a special role in this encoding, and thus should not appear in keys or values: `[=,:]`.

This problem was originally surfaced as a Windows-only problem, where absolute file paths include `C:\` (see #669). However, it doesn't actually matter if we are passing `logfile` as absolute or relative, since those special characters mentioned above can creep in either way. Granted, no sane person would name their files like that, but it's possible.

## Proposed fix
Encode `logfile` with [URLEncoder](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLEncoder.html) when composing options, and decode it with [URLDecoder](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLDecoder.html) inside the protoc codegen plugin. This is a well-known encoding scheme that allows only `[a-zA-Z0-9.-*_+%]` in the encoded output. Note that none of the special characters mentioned above are allowed here.

I also renamed the option to `logfile_enc` to make it an explicit breaking change, in case the codegen plugin is being used in other context. But I don't feel strongly about this, so feel free to suggest otherwise.

## Testing
Verified to fix #786 on my Mac. Would be great if someone can help test this on a Windows machine.
