### PR TITLE
Strict unmarshalling

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -156,7 +156,7 @@ public class @{serviceName}HandlerFactory {
         switch(method) {
           @for(method <- service.methods) {
           case "@method.grpcName":
-            response = @{method.unmarshal}(request.entity().getDataBytes(), @method.deserializer.name, mat, reader)
+            response = @{method.unmarshal}(request.entity(), @method.deserializer.name, mat, reader)
               .@{if(method.outputStreaming) { "thenApply" } else { "thenCompose" }}(e -> implementation.@{method.name}(e@{if(powerApis) { ", metadata" } else { "" }}))
               .thenApply(e -> @{method.marshal}(e, @method.serializer.name, writer, system, eHandler));
             break;

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -116,7 +116,7 @@ object @{serviceName}Handler {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
                 @{if(powerApis) { "val metadata = MetadataBuilder.fromHeaders(request.headers)" } else { "" }}
-                @{method.unmarshal}(request.entity.dataBytes)(@method.deserializer.name, mat, reader)
+                @{method.unmarshal}(request.entity)(@method.deserializer.name, mat, reader)
                   .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
                   .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
             }

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
@@ -7,8 +7,8 @@ package akka.grpc.scaladsl
 import akka.actor.ActorSystem
 import akka.grpc.internal.{ GrpcProtocolNative, GrpcRequestHelpers, Identity }
 import akka.grpc.scaladsl.headers.`Status`
-import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
-import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
+import akka.http.scaladsl.model.{ AttributeKeys, HttpEntity, HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk, Strict }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -30,6 +30,7 @@ class GrpcExceptionHandlerSpec
     "produce an INVALID_ARGUMENT error when the expected parameter is not found" in {
       implicit val serializer = TestService.Serializers.SimpleRequestSerializer
       implicit val marshaller = GrpcProtocolNative.newWriter(Identity)
+      // request that missing the actual data
       val unmarshallableRequest = HttpRequest(entity = HttpEntity.empty(GrpcProtocolNative.contentType))
 
       val result: Future[HttpResponse] = GrpcMarshalling
@@ -37,11 +38,14 @@ class GrpcExceptionHandlerSpec
         .map(_ => HttpResponse())
         .recoverWith(GrpcExceptionHandler.default)
 
-      result.futureValue.entity match {
+      val response = result.futureValue
+      response.entity match {
         case Chunked(_, chunks) =>
           chunks.runWith(Sink.seq).futureValue match {
             case Seq(LastChunk("", List(`Status`("3")))) => // ok
           }
+        case _: Strict =>
+          response.attribute(AttributeKeys.trailer).get.headers.contains("grpc-status" -> "3")
         case other =>
           fail(s"Unexpected [$other]")
       }

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
@@ -30,7 +30,7 @@ class GrpcExceptionHandlerSpec
     "produce an INVALID_ARGUMENT error when the expected parameter is not found" in {
       implicit val serializer = TestService.Serializers.SimpleRequestSerializer
       implicit val marshaller = GrpcProtocolNative.newWriter(Identity)
-      // request that missing the actual data
+      // request that is missing the actual data
       val unmarshallableRequest = HttpRequest(entity = HttpEntity.empty(GrpcProtocolNative.contentType))
 
       val result: Future[HttpResponse] = GrpcMarshalling

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.3"
+    val akkaHttp = "10.2.4+48-b667fd93-SNAPSHOT"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.38.1" // checked synced by GrpcVersionSyncCheckPlugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.4+48-b667fd93-SNAPSHOT"
+    val akkaHttp = "10.2.5-M1"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.38.1" // checked synced by GrpcVersionSyncCheckPlugin

--- a/runtime/src/main/mima-filters/2.0.0.backwards.excludes/1372-strict-unmarshalling.excludes
+++ b/runtime/src/main/mima-filters/2.0.0.backwards.excludes/1372-strict-unmarshalling.excludes
@@ -1,0 +1,14 @@
+# Changes to internal classes
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.internal.AbstractGrpcProtocol.reader$default$3")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.internal.AbstractGrpcProtocol.reader")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.internal.AbstractGrpcProtocol.reader$default$3")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.internal.Codec.uncompress")
+
+# akka.grpc.GrpcProtocol marked InternalApi
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolReader.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.grpc.GrpcProtocol#GrpcProtocolReader.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolReader.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.grpc.GrpcProtocol$GrpcProtocolReader$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolReader.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.GrpcProtocol#GrpcProtocolReader.unapply")
+

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -97,7 +97,7 @@ object GrpcProtocol {
   case class GrpcProtocolReader(
       /** The compression codec to be used for data frames */
       messageEncoding: Codec,
-      decodeFrames: ByteString => ByteString,
+      decodeSingleFrame: ByteString => ByteString,
       /** A Flow of Frames over a stream of messages encoded in gRPC framing. */
       frameDecoder: Flow[ByteString, Frame, NotUsed]) {
 

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -97,6 +97,7 @@ object GrpcProtocol {
   case class GrpcProtocolReader(
       /** The compression codec to be used for data frames */
       messageEncoding: Codec,
+      decodeFrames: ByteString => ByteString,
       /** A Flow of Frames over a stream of messages encoded in gRPC framing. */
       frameDecoder: Flow[ByteString, Frame, NotUsed]) {
 

--- a/runtime/src/main/scala/akka/grpc/internal/Codec.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Codec.scala
@@ -11,4 +11,10 @@ abstract class Codec {
 
   def compress(bytes: ByteString): ByteString
   def uncompress(bytes: ByteString): ByteString
+
+  /**
+   * Process the given frame bytes, uncompress if the compression bit is set. Identity
+   * codec will fail with a [[io.grpc.StatusException]] if the compressedBit is set.
+   */
+  def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString
 }

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
@@ -7,7 +7,6 @@ package akka.grpc.internal
 import akka.grpc.GrpcProtocol._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart }
-import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.grpc.{ Status, StatusException }
 
@@ -19,7 +18,7 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
     AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame))
 
   override protected def reader(codec: Codec): GrpcProtocolReader =
-    AbstractGrpcProtocol.reader(codec, decodeFrame, flow => Flow[ByteString].map(preDecode).via(flow))
+    AbstractGrpcProtocol.reader(codec, decodeFrame, preDecode)
 
   @inline
   private def encodeFrame(codec: Codec, frame: Frame): ChunkStreamPart = {

--- a/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
@@ -34,4 +34,8 @@ object Gzip extends Codec {
     } finally gzis.close()
     ByteString.fromArrayUnsafe(baos.toByteArray)
   }
+
+  override def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString =
+    if (compressedBitSet) uncompress(bytes)
+    else bytes
 }

--- a/runtime/src/main/scala/akka/grpc/internal/Identity.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Identity.scala
@@ -5,6 +5,7 @@
 package akka.grpc.internal
 
 import akka.util.ByteString
+import io.grpc.{ Status, StatusException }
 
 object Identity extends Codec {
   override val name = "identity"
@@ -12,4 +13,10 @@ object Identity extends Codec {
   override def compress(bytes: ByteString): ByteString = bytes
 
   override def uncompress(bytes: ByteString): ByteString = bytes
+
+  override def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString =
+    if (compressedBitSet)
+      throw new StatusException(
+        Status.INTERNAL.withDescription("Compressed-Flag bit is set, but a compression encoding is not specified"))
+    else bytes
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
@@ -6,14 +6,13 @@ package akka.grpc.javadsl
 
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import java.util.Optional
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.grpc._
 import akka.grpc.internal._
 import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
-import akka.http.javadsl.model.{ HttpRequest, HttpResponse }
+import akka.http.javadsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 import akka.japi.{ Function => JFunction }
 import akka.stream.Materializer
 import akka.stream.javadsl.Source
@@ -40,6 +39,13 @@ object GrpcMarshalling {
       reader: GrpcProtocolReader): CompletionStage[T] =
     data.via(reader.dataFrameDecoder).map(u.deserialize).runWith(SingleParameterSink.create[T](), mat)
 
+  def unmarshal[T](
+      entity: HttpEntity,
+      u: ProtobufSerializer[T],
+      mat: Materializer,
+      reader: GrpcProtocolReader): CompletionStage[T] =
+    unmarshal(entity.getDataBytes, u, mat, reader)
+
   def unmarshalStream[T](
       data: Source[ByteString, AnyRef],
       u: ProtobufSerializer[T],
@@ -55,6 +61,12 @@ object GrpcMarshalling {
         .via(new CancellationBarrierGraphStage)
         .mapMaterializedValue(japiFunction(_ => NotUsed)))
   }
+  def unmarshalStream[T](
+      entity: HttpEntity,
+      u: ProtobufSerializer[T],
+      @silent("never used") mat: Materializer,
+      reader: GrpcProtocolReader): CompletionStage[Source[T, NotUsed]] =
+    unmarshalStream(entity.getDataBytes, u, mat, reader)
 
   def marshal[T](
       e: T,

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
@@ -64,7 +64,7 @@ object GrpcMarshalling {
   def unmarshalStream[T](
       entity: HttpEntity,
       u: ProtobufSerializer[T],
-      @silent("never used") mat: Materializer,
+      mat: Materializer,
       reader: GrpcProtocolReader): CompletionStage[Source[T, NotUsed]] =
     unmarshalStream(entity.getDataBytes, u, mat, reader)
 

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -20,6 +20,8 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.github.ghik.silencer.silent
 
+import scala.util.Try
+
 object GrpcMarshalling {
   def unmarshal[T](req: HttpRequest)(implicit u: ProtobufSerializer[T], mat: Materializer): Future[T] = {
     negotiated(
@@ -56,7 +58,7 @@ object GrpcMarshalling {
   def unmarshal[T](
       entity: HttpEntity)(implicit u: ProtobufSerializer[T], mat: Materializer, reader: GrpcProtocolReader): Future[T] =
     entity match {
-      case HttpEntity.Strict(_, data) => Future.successful(u.deserialize(reader.decodeSingleFrame(data)))
+      case HttpEntity.Strict(_, data) => Future.fromTry(Try(u.deserialize(reader.decodeSingleFrame(data))))
       case _                          => unmarshal(entity.dataBytes)
     }
 

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -78,7 +78,7 @@ object GrpcMarshalling {
 
   def unmarshalStream[T](entity: HttpEntity)(
       implicit u: ProtobufSerializer[T],
-      @silent("never used") mat: Materializer,
+      mat: Materializer,
       reader: GrpcProtocolReader): Future[Source[T, NotUsed]] =
     unmarshalStream(entity.dataBytes)
 

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -56,9 +56,8 @@ object GrpcMarshalling {
   def unmarshal[T](
       entity: HttpEntity)(implicit u: ProtobufSerializer[T], mat: Materializer, reader: GrpcProtocolReader): Future[T] =
     entity match {
-      case HttpEntity.Strict(_, data) =>
-        Future.successful(u.deserialize(reader.decodeFrames(data)))
-      case _ => unmarshal(entity.dataBytes)
+      case HttpEntity.Strict(_, data) => Future.successful(u.deserialize(reader.decodeSingleFrame(data)))
+      case _                          => unmarshal(entity.dataBytes)
     }
 
   def unmarshalStream[T](data: Source[ByteString, Any])(


### PR DESCRIPTION
Only makes a difference with changes from https://github.com/akka/akka-http/pull/3822. Currently, akka-grpc never sees a strict entity.