### PR TITLE
Add proto3 optionals support.

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/JavaCodeGenerator.scala
@@ -29,6 +29,7 @@ abstract class JavaCodeGenerator extends CodeGenerator {
 
   override def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse = {
     val b = CodeGeneratorResponse.newBuilder
+    b.setSupportedFeatures(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL.getNumber)
 
     // generate services code here, the data types we want to leave to scalapb
 

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/ScalaCodeGenerator.scala
@@ -43,6 +43,7 @@ abstract class ScalaCodeGenerator extends CodeGenerator {
   // generate services code here, the data types we want to leave to scalapb
   override def run(request: CodeGeneratorRequest, logger: Logger): CodeGeneratorResponse = {
     val b = CodeGeneratorResponse.newBuilder
+    b.setSupportedFeatures(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL.getNumber)
 
     // Currently per-invocation options, intended to become per-service options eventually
     // https://github.com/akka/akka-grpc/issues/451


### PR DESCRIPTION
This change makes the Scala and Java generators declare that they support proto3
optionals (see https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md)

As akka-grpc generators operate at the message-level (rather than the
field-level) it is unexpected that any other changes in akka-grpc are
necessary.
