### PR TITLE
Always close GZIPOutputStream

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/GrpcRequestHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcRequestHelpers.scala
@@ -37,7 +37,7 @@ object GrpcRequestHelpers {
     HttpRequest(
       uri = uri,
       method = HttpMethods.POST,
-      // FIXME how can client exclude gzip?
+      // FIXME issue #1382 gzip shouldn't be included by default in Message-Accept-Encoding.
       headers = immutable.Seq(
         `Message-Encoding`(writer.messageEncoding.name),
         `Message-Accept-Encoding`(Codecs.supportedCodecs.map(_.name).mkString(",")),

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcRequestHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcRequestHelpers.scala
@@ -37,6 +37,7 @@ object GrpcRequestHelpers {
     HttpRequest(
       uri = uri,
       method = HttpMethods.POST,
+      // FIXME how can client exclude gzip?
       headers = immutable.Seq(
         `Message-Encoding`(writer.messageEncoding.name),
         `Message-Accept-Encoding`(Codecs.supportedCodecs.map(_.name).mkString(",")),

--- a/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
@@ -15,9 +15,8 @@ object Gzip extends Codec {
   override def compress(uncompressed: ByteString): ByteString = {
     val baos = new ByteArrayOutputStream(uncompressed.size)
     val gzos = new GZIPOutputStream(baos)
-    gzos.write(uncompressed.toArray)
-    gzos.flush()
-    gzos.close()
+    try gzos.write(uncompressed.toArray)
+    finally gzos.close()
     ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 
@@ -26,11 +25,13 @@ object Gzip extends Codec {
 
     val baos = new ByteArrayOutputStream(compressed.size)
     val buffer = new Array[Byte](32 * 1024)
-    var read = gzis.read(buffer)
-    while (read != -1) {
-      baos.write(buffer, 0, read)
-      read = gzis.read(buffer)
-    }
+    try {
+      var read = gzis.read(buffer)
+      while (read != -1) {
+        baos.write(buffer, 0, read)
+        read = gzis.read(buffer)
+      }
+    } finally gzis.close()
     ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 }


### PR DESCRIPTION
* it always included gzip because that's in the Codecs.supportedCodecs
* meaning that the server will gzip the responses
* I think gzip should be off by default, unless the grpc spec says otherwise (gzip is very slow)

I noticed some surprising gzip stuff showing up in profiles of our benchmarks.
