### PR TITLE
Percent-encode grpc-message

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -13,6 +13,8 @@ object Common extends AutoPlugin {
 
   override def requires = JvmPlugin
 
+  private val consoleDisabledOptions = Seq("-Xfatal-warnings", "-Ywarn-unused", "-Ywarn-unused-import")
+
   override def globalSettings =
     Seq(
       organization := "com.lightbend.akka.grpc",
@@ -51,6 +53,7 @@ object Common extends AutoPlugin {
       "-P:silencer:globalFilters=Use LazyList instead of Stream",
       // ignore imports in templates
       "-P:silencer:pathFilters=.*.txt"),
+    Compile / console / scalacOptions ~= (_ filterNot consoleDisabledOptions.contains),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -53,7 +53,7 @@ object Common extends AutoPlugin {
       "-P:silencer:globalFilters=Use LazyList instead of Stream",
       // ignore imports in templates
       "-P:silencer:pathFilters=.*.txt"),
-    Compile / console / scalacOptions ~= (_ filterNot consoleDisabledOptions.contains),
+    Compile / console / scalacOptions ~= (_.filterNot(consoleDisabledOptions.contains)),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",

--- a/runtime/src/main/scala/akka/grpc/scaladsl/headers/PercentEncoding.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/headers/PercentEncoding.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright 2016, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package akka.grpc.scaladsl.headers
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+/**
+ * Excerpt from https://github.com/grpc/grpc/blob/7c9e8b425166276232653725de32ea0422a39b33/doc/PROTOCOL-HTTP2.md#responses:
+ *
+ * The value portion of Status-Message is conceptually a Unicode string description of the error, physically encoded as
+ * UTF-8 followed by percent-encoding. Percent-encoding is specified in RFC 3986 §2.1, although the form used here has
+ * different restricted characters. When decoding invalid values, implementations MUST NOT error or throw away the
+ * message. At worst, the implementation can abort decoding the status message altogether such that the user would
+ * received the raw percent-encoded form. Alternatively, the implementation can decode valid portions while leaving
+ * broken %-encodings as-is or replacing them with a replacement character (e.g., '?' or the Unicode replacement
+ * character).
+ */
+private[grpc] object PercentEncoding {
+  // Copied with slight adaptations from https://github.com/grpc/grpc-java/blob/79e75bace40cea7e4be72e7dcd1f41c3ad6ee857/api/src/main/java/io/grpc/Status.java#L582
+  object Encoder {
+    private val HexArr: Array[Byte] =
+      Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
+    def encode(value: String): String = {
+      val valueBytes = value.getBytes(StandardCharsets.UTF_8)
+      val firstIndexToEscape = valueBytes.indexWhere(isEscapingChar(_))
+      if (firstIndexToEscape == -1)
+        new String(valueBytes)
+      else
+        encodeSlow(valueBytes, firstIndexToEscape)
+    }
+
+    private def isEscapingChar(b: Byte): Boolean = b < ' ' || b >= '~' || b == '%'
+
+    private def encodeSlow(valueBytes: Array[Byte], riArg: Int): String = {
+      var ri = riArg
+      val escapedBytes = new Array[Byte](riArg + ((valueBytes.length - riArg) * 3))
+      // copy over the good bytes
+      if (riArg != 0) System.arraycopy(valueBytes, 0, escapedBytes, 0, riArg)
+      var wi = ri
+
+      while (ri < valueBytes.length) {
+        val b = valueBytes(ri)
+        // Manually implement URL encoding, per the gRPC spec.
+        if (isEscapingChar(b)) {
+          escapedBytes.update(wi, '%')
+          escapedBytes.update(wi + 1, HexArr((b >> 4) & 0xf))
+          escapedBytes.update(wi + 2, HexArr(b & 0xf))
+          wi += 3
+        } else {
+          escapedBytes.update(wi, b)
+          wi += 1
+        }
+        ri += 1
+      }
+      new String(escapedBytes, 0, wi, StandardCharsets.US_ASCII)
+    }
+  }
+
+  // Copied with slight adaptations from https://github.com/grpc/grpc-java/blob/79e75bace40cea7e4be72e7dcd1f41c3ad6ee857/api/src/main/java/io/grpc/Status.java#L626
+  object Decoder {
+    private val TransferEncoding = StandardCharsets.US_ASCII
+
+    def decode(value: String): String =
+      if (value.indexOf('%') > -1)
+        decodeSlow(value)
+      else
+        value
+
+    private def decodeSlow(value: String): String = {
+      val source = value.getBytes(TransferEncoding)
+      val buf = ByteBuffer.allocate(source.length)
+      var i = 0
+      while (i < source.length) {
+        if (source(i) == '%' && i + 2 < source.length) {
+          try {
+            buf.put(Integer.parseInt(new String(source, i + 1, 2, TransferEncoding), 16).toByte)
+            i += 3
+          } catch {
+            case _: NumberFormatException =>
+              buf.put(source(i))
+              i += 1
+          }
+        } else {
+          buf.put(source(i))
+          i += 1
+        }
+      }
+      new String(buf.array, 0, buf.position(), StandardCharsets.UTF_8)
+    }
+  }
+
+}

--- a/runtime/src/test/scala/akka/grpc/scaladsl/headers/HeadersSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/scaladsl/headers/HeadersSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.scaladsl.headers
 
 import org.scalatest.matchers.should.Matchers

--- a/runtime/src/test/scala/akka/grpc/scaladsl/headers/HeadersSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/scaladsl/headers/HeadersSpec.scala
@@ -1,0 +1,84 @@
+package akka.grpc.scaladsl.headers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+class HeadersSpec extends AnyWordSpec with Matchers {
+  "Status-Message.value()" should {
+    "use percent-encoding" in {
+      // test cases taken from https://github.com/grpc/grpc-java/blob/79e75bace40cea7e4be72e7dcd1f41c3ad6ee857/api/src/test/java/io/grpc/StatusTest.java#L65
+      val inAndExpectedOut = Table(
+        ("raw input", "expected encoded value"),
+        ("my favorite character is i", "my favorite character is i"),
+        ("my favorite character is \n", "my favorite character is %0A"),
+        ("my favorite character is \u0000", "my favorite character is %00"),
+        ("my favorite character is %", "my favorite character is %25"),
+        ("my favorite character is 𐀁", "my favorite character is %F0%90%80%81"),
+        // \ud801 is a high surrogate, a lone surrogate character is getting decoded as ? with UTF-8
+        ("my favorite character is \ud801", "my favorite character is ?"),
+        // \udc37 is a low surrogate, a lone surrogate character is getting decoded as ? with UTF-8
+        ("my favorite character is \udc37", "my favorite character is ?"),
+        // a pair of surrogate characters is fine
+        ("my favorite character is " + 0xdbff.toChar + 0xdfff.toChar, "my favorite character is %F4%8F%BF%BF"))
+
+      forAll(inAndExpectedOut) { (in, expected) =>
+        new `Status-Message`(in).value() should equal(expected)
+      }
+    }
+  }
+
+  "Status-Message.parse()" should {
+    "should decode percent-encoded values" in {
+      // test cases taken from https://github.com/grpc/grpc-java/blob/79e75bace40cea7e4be72e7dcd1f41c3ad6ee857/api/src/test/java/io/grpc/StatusTest.java#L65
+      val inAndExpectedOut = Table(
+        ("raw input", "expected decoded value"),
+        (Array[Byte]('H', 'e', 'l', 'l', 'o'), "Hello"),
+        (Array[Byte]('H', '%', '6', '1', 'o'), "Hao"),
+        (Array[Byte]('H', '%', '0', 'A', 'o'), "H\no"),
+        (Array[Byte]('%', 'F', '0', '%', '9', '0', '%', '8', '0', '%', '8', '1'), "𐀁"),
+        (Array[Byte]('a', 'b', 'c', '%', 'C', '5', '%', '8', '2'), "abcł"))
+
+      forAll(inAndExpectedOut) { (in, expected) =>
+        val actual = `Status-Message`.parse(new String(in))
+        actual.get.unencodedValue should equal(expected)
+      }
+    }
+
+    "should decode as is in case two chars following percent cannot be decoded as hex" in {
+      val inAndExpectedOut = Table(
+        ("raw input", "expected decoded value"),
+        (Array[Byte]('%', 'G'), "%G"),
+        (Array[Byte]('%', 'G', '0'), "%G0"),
+        (Array[Byte]('%', 'G', '0', '%', ',', '0'), "%G0%,0"),
+        (Array[Byte]('%', '%', '0', '%', '%'), "%%0%%"))
+
+      forAll(inAndExpectedOut) { (in, expected) =>
+        val actual = `Status-Message`.parse(new String(in))
+        actual.get.unencodedValue should equal(expected)
+      }
+    }
+  }
+
+  "Status-Message.value() and Status-Message.parse()" should {
+    "roundtrip for UTF-8 encodable sequence of bytes" in {
+      val examples = Table(
+        "examples",
+        "example%",
+        "yet another%%example",
+        "abc\ndef",
+        "abc\ndef\n",
+        "abc\r\ndef\r\n",
+        "abc\r\n\r\ndef\r\n",
+        "Καλημέρα κόσμε",
+        "コンニチハ",
+        "zażółć gęślą jaźń")
+
+      examples.foreach { in =>
+        val encoded = new `Status-Message`(in).value()
+        val decoded = `Status-Message`.parse(encoded).get.unencodedValue
+        decoded should equal(in)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Having such code:

```
new GrpcServiceException(Status.INVALID_ARGUMENT.withDescriptionSafe(e.getMessage))
```

may result in issuing invalid response if `e.getMessage` contains `\n` character. Since `grpc-message` is being transported with http headers it cannot contain arbitrary characters, see more [here](https://github.com/grpc/grpc-go/issues/576). What's recommended by standard is to percent-encode the message, see the [spec](https://github.com/grpc/grpc/issues/4672).

It's been added to grpc-java in [this PR](https://github.com/grpc/grpc-java/pull/1517/files).

## Why it is relevant

I saw this issue happening in a production setting. scalapb error messages can contain `\n` and it's getting problematic if you use linkerd. Linkerd will treat such response as incorrect. As a consequence the client will not see the original `grpc-status: 3, grpc-message: meaningful message` but `grpc-status: 13, grpc-message: protocol error: unspecific protocol error detected`.

## Solution

Copy and adapt grpc-java percent-encoding implementation.

## Other

I am not sure what's the most appropriate way of giving credits to grpc-java. Both project are on Apache 2.0 license, not sure what's required from license standpoint
