### PR TITLE
[WIP] stack of different performance improvements

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -156,7 +156,7 @@ public class @{serviceName}HandlerFactory {
         switch(method) {
           @for(method <- service.methods) {
           case "@method.grpcName":
-            response = @{method.unmarshal}(request.entity().getDataBytes(), @method.deserializer.name, mat, reader)
+            response = @{method.unmarshal}(request.entity(), @method.deserializer.name, mat, reader)
               .@{if(method.outputStreaming) { "thenApply" } else { "thenCompose" }}(e -> implementation.@{method.name}(e@{if(powerApis) { ", metadata" } else { "" }}))
               .thenApply(e -> @{method.marshal}(e, @method.serializer.name, writer, system, eHandler));
             break;

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -116,7 +116,7 @@ object @{serviceName}Handler {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
                 @{if(powerApis) { "val metadata = MetadataBuilder.fromHeaders(request.headers)" } else { "" }}
-                @{method.unmarshal}(request.entity.dataBytes)(@method.deserializer.name, mat, reader)
+                @{method.unmarshal}(request.entity)(@method.deserializer.name, mat, reader)
                   .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
                   .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
             }

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
@@ -7,8 +7,8 @@ package akka.grpc.scaladsl
 import akka.actor.ActorSystem
 import akka.grpc.internal.{ GrpcProtocolNative, GrpcRequestHelpers, Identity }
 import akka.grpc.scaladsl.headers.`Status`
-import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
-import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
+import akka.http.scaladsl.model.{ AttributeKeys, HttpEntity, HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk, Strict }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -30,6 +30,7 @@ class GrpcExceptionHandlerSpec
     "produce an INVALID_ARGUMENT error when the expected parameter is not found" in {
       implicit val serializer = TestService.Serializers.SimpleRequestSerializer
       implicit val marshaller = GrpcProtocolNative.newWriter(Identity)
+      // request that missing the actual data
       val unmarshallableRequest = HttpRequest(entity = HttpEntity.empty(GrpcProtocolNative.contentType))
 
       val result: Future[HttpResponse] = GrpcMarshalling
@@ -37,11 +38,14 @@ class GrpcExceptionHandlerSpec
         .map(_ => HttpResponse())
         .recoverWith(GrpcExceptionHandler.default)
 
-      result.futureValue.entity match {
+      val response = result.futureValue
+      response.entity match {
         case Chunked(_, chunks) =>
           chunks.runWith(Sink.seq).futureValue match {
             case Seq(LastChunk("", List(`Status`("3")))) => // ok
           }
+        case _: Strict =>
+          response.attribute(AttributeKeys.trailer).get.headers.contains("grpc-status" -> "3")
         case other =>
           fail(s"Unexpected [$other]")
       }

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -39,6 +39,14 @@
       <version>${grpc.version}</version>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
   <build>
     <plugins>
       <plugin>

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -52,6 +52,14 @@
       <version>${grpc.version}</version>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -18,7 +18,7 @@ object Common extends AutoPlugin {
       organization := "com.lightbend.akka.grpc",
       organizationName := "Lightbend Inc.",
       organizationHomepage := Some(url("https://www.lightbend.com/")),
-      resolvers += Resolver.sonatypeRepo("staging"),
+      //resolvers += Resolver.sonatypeRepo("staging"),
       homepage := Some(url("https://akka.io/")),
       scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-grpc"), "git@github.com:akka/akka-grpc")),
       developers += Developer(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -18,7 +18,7 @@ object Common extends AutoPlugin {
       organization := "com.lightbend.akka.grpc",
       organizationName := "Lightbend Inc.",
       organizationHomepage := Some(url("https://www.lightbend.com/")),
-      //resolvers += Resolver.sonatypeRepo("staging"),
+      resolvers += Resolver.sonatypeRepo("staging"),
       homepage := Some(url("https://akka.io/")),
       scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-grpc"), "git@github.com:akka/akka-grpc")),
       developers += Developer(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -76,5 +76,7 @@ object Common extends AutoPlugin {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     crossScalaVersions := Seq(scala212, scala213),
     mimaReportSignatureProblems := true,
-    scalafmtOnCompile := true)
+    scalafmtOnCompile := true,
+    resolvers += "akka-http-snapshot-repository" at "https://oss.sonatype.org/content/repositories/snapshots",
+  )
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -77,6 +77,5 @@ object Common extends AutoPlugin {
     crossScalaVersions := Seq(scala212, scala213),
     mimaReportSignatureProblems := true,
     scalafmtOnCompile := true,
-    resolvers += "akka-http-snapshot-repository" at "https://oss.sonatype.org/content/repositories/snapshots",
-  )
+    resolvers += "akka-http-snapshot-repository".at("https://oss.sonatype.org/content/repositories/snapshots"))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.4+26-75aec5f7-SNAPSHOT"
+    val akkaHttp = "10.2.4+48-b667fd93-SNAPSHOT"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.38.0" // checked synced by GrpcVersionSyncCheckPlugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     // We don't force Akka updates because downstream projects can upgrade
     // themselves. For more information see
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-    val akka = "2.6.15"
+    val akka = "2.6.9"
     val akkaBinary = "2.6"
     val akkaHttp = "10.2.3"
     val akkaHttpBinary = "10.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.3"
+    val akkaHttp = "10.2.4+26-75aec5f7-SNAPSHOT"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.38.0" // checked synced by GrpcVersionSyncCheckPlugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     // We don't force Akka updates because downstream projects can upgrade
     // themselves. For more information see
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-    val akka = "2.6.9"
+    val akka = "2.6.15"
     val akkaBinary = "2.6"
     val akkaHttp = "10.2.3"
     val akkaHttpBinary = "10.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.6.9"
     val akkaBinary = "2.6"
-    val akkaHttp = "10.2.4+48-b667fd93-SNAPSHOT"
+    val akkaHttp = "10.2.4+83-c5aaab40-SNAPSHOT"
     val akkaHttpBinary = "10.2"
 
     val grpc = "1.38.0" // checked synced by GrpcVersionSyncCheckPlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,7 +26,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 
 // For RawText
-libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.11.1.202105131744-r"
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.12.0.202106070339-r"
 
 // scripted testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/runtime/src/main/mima-filters/2.0.0.backwards.excludes/1365-marshal-to-strict.excludes
+++ b/runtime/src/main/mima-filters/2.0.0.backwards.excludes/1365-marshal-to-strict.excludes
@@ -1,0 +1,8 @@
+# Changes in classes marked as internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolWriter.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.grpc.GrpcProtocol#GrpcProtocolWriter.copy$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolWriter.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.grpc.GrpcProtocol$GrpcProtocolWriter$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.GrpcProtocol#GrpcProtocolWriter.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.GrpcProtocol#GrpcProtocolWriter.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.internal.AbstractGrpcProtocol.writer")

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -88,6 +88,8 @@ object GrpcProtocol {
       messageEncoding: Codec,
       /** Encodes a frame as a part in a chunk stream. */
       encodeFrame: Frame => ChunkStreamPart,
+      /** A shortcut to encode a data frame directly into a ByteString */
+      encodeDataToFrameBytes: ByteString => ByteString,
       /** A Flow over a stream of Frame using this frame encoding */
       frameEncoder: Flow[Frame, ChunkStreamPart, NotUsed])
 

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -99,6 +99,7 @@ object GrpcProtocol {
   case class GrpcProtocolReader(
       /** The compression codec to be used for data frames */
       messageEncoding: Codec,
+      decodeSingleFrame: ByteString => ByteString,
       /** A Flow of Frames over a stream of messages encoded in gRPC framing. */
       frameDecoder: Flow[ByteString, Frame, NotUsed]) {
 

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -65,8 +65,6 @@ trait GrpcProtocol {
 @InternalApi
 object GrpcProtocol {
 
-  private val protocols: Seq[GrpcProtocol] = Seq(GrpcProtocolNative, GrpcProtocolWeb, GrpcProtocolWebText)
-
   /** A frame in a logical gRPC protocol stream */
   sealed trait Frame
 
@@ -124,7 +122,13 @@ object GrpcProtocol {
    * Detects which gRPC protocol variant is indicated by a mediatype.
    * @return a [[GrpcProtocol]] matching the request mediatype if known.
    */
-  def detect(mediaType: jmodel.MediaType): Option[GrpcProtocol] = protocols.find(_.mediaTypes.contains(mediaType))
+  def detect(mediaType: jmodel.MediaType): Option[GrpcProtocol] = mediaType.subType match {
+    // FIXME: do we need to check mainType?
+    case "grpc" | "grpc+proto"                   => Some(GrpcProtocolNative)
+    case "grpc-web" | "grpc-web+proto"           => Some(GrpcProtocolWeb)
+    case "grpc-web-text" | "grpc-web-text+proto" => Some(GrpcProtocolWebText)
+    case _                                       => None
+  }
 
   /**
    * Calculates the gRPC protocol encoding to use for an interaction with a gRPC client.

--- a/runtime/src/main/scala/akka/grpc/ProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/ProtobufSerializer.scala
@@ -6,7 +6,11 @@ package akka.grpc
 
 import akka.util.ByteString
 
+import java.nio.ByteBuffer
+
 trait ProtobufSerializer[T] {
   def serialize(t: T): ByteString
   def deserialize(bytes: ByteString): T
+
+  def deserialize(buffer: ByteBuffer): T
 }

--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -15,7 +15,7 @@ import akka.stream.impl.io.ByteStringParser.{ ByteReader, ParseResult, ParseStep
 import akka.stream.scaladsl.Flow
 import akka.stream.stage.GraphStageLogic
 import akka.util.ByteString
-import io.grpc.{ Status, StatusException }
+import io.grpc.StatusException
 
 abstract class AbstractGrpcProtocol(subType: String) extends GrpcProtocol {
 
@@ -57,7 +57,7 @@ object AbstractGrpcProtocol {
   def fieldType(codec: Codec) = if (codec == Identity) notCompressed else compressed
 
   /**
-   * Adjusts thye compressibility of a content type to suit a message encoding.
+   * Adjusts the compressibility of a content type to suit a message encoding.
    * @param contentType the content type for the gRPC protocol.
    * @param codec the message encoding being used to encode objects.
    * @return the provided content type, with the compressibility adapted to reflect whether HTTP transport level compression should be used.
@@ -93,9 +93,25 @@ object AbstractGrpcProtocol {
   def reader(
       codec: Codec,
       decodeFrame: (Int, ByteString) => Frame,
-      flowAdapter: Flow[ByteString, Frame, NotUsed] => Flow[ByteString, Frame, NotUsed] = identity)
-      : GrpcProtocolReader =
-    GrpcProtocolReader(codec, flowAdapter(Flow.fromGraph(new GrpcFramingDecoderStage(codec, decodeFrame))))
+      flowAdapter: ByteString => ByteString = null): GrpcProtocolReader = {
+    val strictAdapter: ByteString => ByteString = if (flowAdapter eq null) identity else flowAdapter
+    val adapter: Flow[ByteString, Frame, NotUsed] => Flow[ByteString, Frame, NotUsed] =
+      if (flowAdapter eq null) identity
+      else x => Flow[ByteString].map(flowAdapter).via(x)
+
+    // strict decoder
+    def decoder(bs: ByteString): ByteString = try {
+      val reader = new ByteReader(bs)
+      val frameType = reader.readByte()
+      val length = reader.readIntBE()
+      val data = reader.take(length)
+      if (reader.hasRemaining) throw new IllegalStateException("Unexpected data")
+      if ((frameType & 0x80) == 0) strictAdapter(codec.uncompress((frameType & 1) == 1, data))
+      else throw new IllegalStateException("Cannot read unknown frame")
+    } catch { case ByteStringParser.NeedMoreData => throw new MissingParameterException }
+
+    GrpcProtocolReader(codec, decoder, adapter(Flow.fromGraph(new GrpcFramingDecoderStage(codec, decodeFrame))))
+  }
 
   class GrpcFramingDecoderStage(codec: Codec, deframe: (Int, ByteString) => Frame) extends ByteStringParser[Frame] {
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
@@ -118,21 +134,15 @@ object AbstractGrpcProtocol {
         sealed case class ReadFrame(frameType: Int, length: Int) extends Step {
           private val compression = (frameType & 0x01) == 1
 
-          override def parse(reader: ByteReader): ParseResult[Frame] = {
-            if (compression) codec match {
-              case Identity =>
-                failStage(
-                  new StatusException(
-                    Status.INTERNAL.withDescription(
-                      "Compressed-Flag bit is set, but a compression encoding is not specified")))
+          override def parse(reader: ByteReader): ParseResult[Frame] =
+            try ParseResult(
+              Some(deframe(frameType, codec.uncompress(compression, reader.take(length)))),
+              ReadFrameHeader)
+            catch {
+              case s: StatusException =>
+                failStage(s) // handle explicitly to avoid noisy log
                 ParseResult(None, Failed)
-              case _ =>
-                ParseResult(Some(deframe(frameType, codec.uncompress(reader.take(length)))), ReadFrameHeader)
             }
-            else {
-              ParseResult(Some(deframe(frameType, reader.take(length))), ReadFrameHeader)
-            }
-          }
         }
 
         final case object Failed extends Step {

--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -78,11 +78,16 @@ object AbstractGrpcProtocol {
     frameType ++ encodedLength ++ data
   }
 
-  def writer(protocol: GrpcProtocol, codec: Codec, encodeFrame: Frame => ChunkStreamPart): GrpcProtocolWriter =
+  def writer(
+      protocol: GrpcProtocol,
+      codec: Codec,
+      encodeFrame: Frame => ChunkStreamPart,
+      encodeDataToFrameBytes: ByteString => ByteString): GrpcProtocolWriter =
     GrpcProtocolWriter(
       adjustCompressibility(protocol.contentType, codec),
       codec,
       encodeFrame,
+      encodeDataToFrameBytes,
       Flow[Frame].map(encodeFrame))
 
   def reader(

--- a/runtime/src/main/scala/akka/grpc/internal/Codec.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Codec.scala
@@ -11,4 +11,10 @@ abstract class Codec {
 
   def compress(bytes: ByteString): ByteString
   def uncompress(bytes: ByteString): ByteString
+
+  /**
+   * Process the given frame bytes, uncompress if the compression bit is set. Identity
+   * codec will fail with a [[io.grpc.StatusException]] if the compressedBit is set.
+   */
+  def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString
 }

--- a/runtime/src/main/scala/akka/grpc/internal/Codecs.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Codecs.scala
@@ -57,7 +57,8 @@ object Codecs {
    * @return the specified codec to uncompress data frame bodies with, [[Identity]] if no encoding was specified, or [[Failure]] if an unsupported encoding was specified.
    */
   def detect(message: jm.HttpMessage): Try[Codec] =
-    detect(`Message-Encoding`.findIn(extractHeaders(message)))
+    detect(message.asInstanceOf[sm.HttpMessage].header[`Message-Encoding`].map(_.value))
+  //detect(extractHeaders(message).find(_.name == "grpc-encoding"))
 
   /**
    * Determines the `Message-Encoding` specified in a gRPC stream to be unmarshalled.

--- a/runtime/src/main/scala/akka/grpc/internal/Codecs.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Codecs.scala
@@ -18,16 +18,6 @@ object Codecs {
   private val supportedNames: Set[String] = supportedCodecs.map(_.name).toSet
   private val supportedByName = supportedCodecs.map(c => c.name -> c).toMap
 
-  private def extractHeaders(request: jm.HttpMessage): Iterable[jm.HttpHeader] = {
-    request match {
-      case sReq: sm.HttpMessage =>
-        sReq.headers
-      case _ =>
-        import scala.collection.JavaConverters._
-        request.getHeaders.asScala
-    }
-  }
-
   /**
    * Determines the message encoding to use for a server response to a client.
    *
@@ -35,8 +25,8 @@ object Codecs {
    * @return a codec to compress data frame bodies with, which will be [[Identity]] unless the client specifies support for another supported encoding.
    */
   def negotiate(request: jm.HttpRequest): Codec = {
-    val headers = extractHeaders(request)
-    val accepted = `Message-Accept-Encoding`.findIn(headers)
+    val accepted =
+      request.asInstanceOf[sm.HttpMessage].header[`Message-Accept-Encoding`].map(_.values).getOrElse(Array.empty)
 
     if (accepted.length == 0) {
       Identity

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
@@ -33,9 +33,6 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
       case DataFrame(data)       => Chunk(encodeDataToFrameBytes(codec, data))
       case TrailerFrame(headers) => LastChunk(trailer = headers)
     }
-  private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString = {
-    val compressedFlag = AbstractGrpcProtocol.fieldType(codec)
-    AbstractGrpcProtocol.encodeFrameData(compressedFlag, codec.compress(data))
-  }
-
+  private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString =
+    AbstractGrpcProtocol.encodeFrameDataCheap(codec != Identity, codec.compress(data))
 }

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
@@ -34,6 +34,8 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
     case Identity => identityReader
     case Gzip     => gzipReader
   }
+  override def newWriter(codec: Codec): GrpcProtocolWriter = writer(codec)
+  override def newReader(codec: Codec): GrpcProtocolReader = reader(codec)
 
   @inline
   private def decodeFrame(@silent("never used") frameType: Int, data: ByteString) = DataFrame(data)

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
@@ -7,7 +7,6 @@ package akka.grpc.internal
 import akka.grpc.GrpcProtocol._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart }
-import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.grpc.{ Status, StatusException }
 
@@ -19,7 +18,7 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
     AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame), encodeDataToFrameBytes(codec, _))
 
   override protected def reader(codec: Codec): GrpcProtocolReader =
-    AbstractGrpcProtocol.reader(codec, decodeFrame, flow => Flow[ByteString].map(preDecode).via(flow))
+    AbstractGrpcProtocol.reader(codec, decodeFrame, preDecode)
 
   @inline
   private def encodeFrame(codec: Codec, frame: Frame): ChunkStreamPart = {

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
@@ -16,7 +16,7 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
   protected def preDecode(frame: ByteString): ByteString
 
   override protected def writer(codec: Codec): GrpcProtocolWriter =
-    AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame))
+    AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame), encodeDataToFrameBytes(codec, _))
 
   override protected def reader(codec: Codec): GrpcProtocolReader =
     AbstractGrpcProtocol.reader(codec, decodeFrame, flow => Flow[ByteString].map(preDecode).via(flow))
@@ -30,6 +30,10 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
     }
     val framed = AbstractGrpcProtocol.encodeFrameData(frameType, codec.compress(data))
     Chunk(postEncode(framed))
+  }
+  private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString = {
+    val dataFrameType = AbstractGrpcProtocol.fieldType(codec)
+    postEncode(AbstractGrpcProtocol.encodeFrameData(dataFrameType, codec.compress(data)))
   }
 
   @inline

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.InternalApi
 import akka.grpc.{ ProtobufSerializer, Trailers }
-import akka.grpc.GrpcProtocol.{ DataFrame, GrpcProtocolWriter, TrailerFrame }
+import akka.grpc.GrpcProtocol.{ GrpcProtocolWriter, TrailerFrame }
 import akka.grpc.scaladsl.{ headers, GrpcExceptionHandler }
 import akka.http.scaladsl.model.{
   AttributeKeys,
@@ -57,8 +57,7 @@ object GrpcResponseHelpers {
       writer: GrpcProtocolWriter,
       system: ClassicActorSystemProvider): HttpResponse =
     try {
-      val data = DataFrame(m.serialize(e))
-      val strictEntity = HttpEntity.Strict(writer.contentType, writer.encodeFrame(data).data)
+      val strictEntity = HttpEntity.Strict(writer.contentType, writer.encodeDataToFrameBytes((m.serialize(e))))
       responseWithTrailers(
         headers.`Message-Encoding`(writer.messageEncoding.name) :: Nil,
         strictEntity,

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
@@ -12,6 +12,7 @@ import akka.grpc.{ ProtobufSerializer, Trailers }
 import akka.grpc.GrpcProtocol.{ GrpcProtocolWriter, TrailerFrame }
 import akka.grpc.scaladsl.{ headers, GrpcExceptionHandler }
 import akka.http.scaladsl.model.{
+  AttributeKey,
   AttributeKeys,
   HttpEntity,
   HttpHeader,
@@ -80,7 +81,7 @@ object GrpcResponseHelpers {
       headers = headers,
       entity = entity,
       protocol = HttpProtocols.`HTTP/2.0`,
-      attributes = Map(AttributeKeys.trailer -> trailer))
+      attributes = Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, trailer))
 
   def apply[T](e: Source[T, NotUsed], status: Future[Status])(
       implicit m: ProtobufSerializer[T],

--- a/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Gzip.scala
@@ -34,4 +34,8 @@ object Gzip extends Codec {
     } finally gzis.close()
     ByteString.fromArrayUnsafe(baos.toByteArray)
   }
+
+  override def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString =
+    if (compressedBitSet) uncompress(bytes)
+    else bytes
 }

--- a/runtime/src/main/scala/akka/grpc/internal/Identity.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/Identity.scala
@@ -5,6 +5,7 @@
 package akka.grpc.internal
 
 import akka.util.ByteString
+import io.grpc.{ Status, StatusException }
 
 object Identity extends Codec {
   override val name = "identity"
@@ -12,4 +13,10 @@ object Identity extends Codec {
   override def compress(bytes: ByteString): ByteString = bytes
 
   override def uncompress(bytes: ByteString): ByteString = bytes
+
+  override def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString =
+    if (compressedBitSet)
+      throw new StatusException(
+        Status.INTERNAL.withDescription("Compressed-Flag bit is set, but a compression encoding is not specified"))
+    else bytes
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
@@ -9,6 +9,8 @@ import akka.grpc.ProtobufSerializer
 import akka.util.ByteString
 import com.google.protobuf.Parser
 
+import java.nio.ByteBuffer
+
 @ApiMayChange
 class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[T]) extends ProtobufSerializer[T] {
 
@@ -20,4 +22,6 @@ class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[
     ByteString.fromArrayUnsafe(t.toByteArray)
   override def deserialize(bytes: ByteString): T =
     parser.parseFrom(bytes.toArray)
+
+  override def deserialize(buffer: ByteBuffer): T = parser.parseFrom(buffer)
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
@@ -63,7 +63,7 @@ object GrpcMarshalling {
       system: ClassicActorSystemProvider,
       eHandler: JFunction[ActorSystem, JFunction[Throwable, Trailers]] = GrpcExceptionHandler.defaultMapper)
       : HttpResponse =
-    marshalStream(Source.single(e), m, writer, system, eHandler)
+    GrpcResponseHelpers.responseForSingleElement(e, scalaAnonymousPartialFunction(eHandler))(m, writer, system)
 
   def marshalStream[T](
       e: Source[T, NotUsed],

--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcMarshalling.scala
@@ -6,14 +6,13 @@ package akka.grpc.javadsl
 
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import java.util.Optional
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.grpc._
 import akka.grpc.internal._
 import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
-import akka.http.javadsl.model.{ HttpRequest, HttpResponse }
+import akka.http.javadsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 import akka.japi.{ Function => JFunction }
 import akka.stream.Materializer
 import akka.stream.javadsl.Source
@@ -40,6 +39,13 @@ object GrpcMarshalling {
       reader: GrpcProtocolReader): CompletionStage[T] =
     data.via(reader.dataFrameDecoder).map(u.deserialize).runWith(SingleParameterSink.create[T](), mat)
 
+  def unmarshal[T](
+      entity: HttpEntity,
+      u: ProtobufSerializer[T],
+      mat: Materializer,
+      reader: GrpcProtocolReader): CompletionStage[T] =
+    unmarshal(entity.getDataBytes, u, mat, reader)
+
   def unmarshalStream[T](
       data: Source[ByteString, AnyRef],
       u: ProtobufSerializer[T],
@@ -55,6 +61,12 @@ object GrpcMarshalling {
         .via(new CancellationBarrierGraphStage)
         .mapMaterializedValue(japiFunction(_ => NotUsed)))
   }
+  def unmarshalStream[T](
+      entity: HttpEntity,
+      u: ProtobufSerializer[T],
+      @silent("never used") mat: Materializer,
+      reader: GrpcProtocolReader): CompletionStage[Source[T, NotUsed]] =
+    unmarshalStream(entity.getDataBytes, u, mat, reader)
 
   def marshal[T](
       e: T,

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -75,7 +75,7 @@ object GrpcMarshalling {
       eHandler: ActorSystem => PartialFunction[Throwable, Trailers] = GrpcExceptionHandler.defaultMapper)(
       implicit m: ProtobufSerializer[T],
       writer: GrpcProtocolWriter,
-      @silent("never used") /* but public API, kept for compat */ system: ClassicActorSystemProvider): HttpResponse =
+      system: ClassicActorSystemProvider): HttpResponse =
     GrpcResponseHelpers.responseForSingleElement(e, eHandler)
 
   def marshalStream[T](

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -21,6 +21,7 @@ import akka.util.ByteString
 import com.github.ghik.silencer.silent
 
 import java.nio.ByteBuffer
+import scala.util.{ Failure, Success }
 
 object BufferPool {
   private val size = 65536
@@ -67,8 +68,8 @@ object GrpcMarshalling {
 
   def negotiated[T](req: HttpRequest, f: (GrpcProtocolReader, GrpcProtocolWriter) => Future[T]): Option[Future[T]] =
     GrpcProtocol.negotiate(req).map {
-      case (maybeReader, writer) =>
-        maybeReader.map(reader => f(reader, writer)).fold(Future.failed, identity)
+      case (Success(reader), writer) => f(reader, writer)
+      case (Failure(ex), _)          => Future.failed(ex)
     }
 
   def unmarshal[T](data: Source[ByteString, Any])(

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -75,8 +75,8 @@ object GrpcMarshalling {
       eHandler: ActorSystem => PartialFunction[Throwable, Trailers] = GrpcExceptionHandler.defaultMapper)(
       implicit m: ProtobufSerializer[T],
       writer: GrpcProtocolWriter,
-      system: ClassicActorSystemProvider): HttpResponse =
-    marshalStream(Source.single(e), eHandler)
+      @silent("never used") /* but public API, kept for compat */ system: ClassicActorSystemProvider): HttpResponse =
+    GrpcResponseHelpers.responseForSingleElement(e, eHandler)
 
   def marshalStream[T](
       e: Source[T, NotUsed],

--- a/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/GrpcMarshalling.scala
@@ -7,7 +7,6 @@ package akka.grpc.scaladsl
 import io.grpc.Status
 
 import scala.concurrent.Future
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
@@ -15,11 +14,10 @@ import akka.annotation.InternalApi
 import akka.grpc._
 import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
 import akka.grpc.internal._
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
+import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse, Uri }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-
 import com.github.ghik.silencer.silent
 
 object GrpcMarshalling {
@@ -28,7 +26,7 @@ object GrpcMarshalling {
       req,
       (r, _) => {
         implicit val reader: GrpcProtocolReader = r
-        unmarshal(req.entity.dataBytes)
+        unmarshal(req.entity)
       }).getOrElse(throw new GrpcServiceException(Status.UNIMPLEMENTED))
   }
 
@@ -39,7 +37,7 @@ object GrpcMarshalling {
       req,
       (r, _) => {
         implicit val reader: GrpcProtocolReader = r
-        unmarshalStream(req.entity.dataBytes)
+        unmarshalStream(req.entity)
       }).getOrElse(throw new GrpcServiceException(Status.UNIMPLEMENTED))
   }
 
@@ -55,6 +53,12 @@ object GrpcMarshalling {
       reader: GrpcProtocolReader): Future[T] = {
     data.via(reader.dataFrameDecoder).map(u.deserialize).runWith(SingleParameterSink())
   }
+  def unmarshal[T](
+      entity: HttpEntity)(implicit u: ProtobufSerializer[T], mat: Materializer, reader: GrpcProtocolReader): Future[T] =
+    entity match {
+      case HttpEntity.Strict(_, data) => Future.successful(u.deserialize(reader.decodeSingleFrame(data)))
+      case _                          => unmarshal(entity.dataBytes)
+    }
 
   def unmarshalStream[T](data: Source[ByteString, Any])(
       implicit u: ProtobufSerializer[T],
@@ -69,6 +73,12 @@ object GrpcMarshalling {
         // don't want the cancellation bubbled out
         .via(new CancellationBarrierGraphStage))
   }
+
+  def unmarshalStream[T](entity: HttpEntity)(
+      implicit u: ProtobufSerializer[T],
+      @silent("never used") mat: Materializer,
+      reader: GrpcProtocolReader): Future[Source[T, NotUsed]] =
+    unmarshalStream(entity.dataBytes)
 
   def marshal[T](
       e: T = Identity,

--- a/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
@@ -6,15 +6,24 @@ package akka.grpc.scaladsl
 
 import akka.annotation.ApiMayChange
 import akka.grpc.ProtobufSerializer
+import akka.io.DirectByteBufferPool
 import akka.util.ByteString
 import com.google.protobuf.CodedInputStream
 import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
+
+import java.nio.ByteBuffer
 
 @ApiMayChange
 class ScalapbProtobufSerializer[T <: GeneratedMessage](companion: GeneratedMessageCompanion[T])
     extends ProtobufSerializer[T] {
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
-  override def deserialize(bytes: ByteString): T =
-    companion.parseFrom(CodedInputStream.newInstance(bytes.asByteBuffer))
+  override def deserialize(bytes: ByteString): T = {
+    val buffer = ByteBuffer.allocateDirect(bytes.length)
+    try {
+      bytes.copyToBuffer(buffer)
+      buffer.flip()
+      companion.parseFrom(CodedInputStream.newInstance(buffer))
+    } finally DirectByteBufferPool.tryCleanDirectByteBuffer(buffer)
+  }
 }

--- a/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
@@ -6,7 +6,6 @@ package akka.grpc.scaladsl
 
 import akka.annotation.ApiMayChange
 import akka.grpc.ProtobufSerializer
-import akka.io.DirectByteBufferPool
 import akka.util.ByteString
 import com.google.protobuf.CodedInputStream
 import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
@@ -18,12 +17,7 @@ class ScalapbProtobufSerializer[T <: GeneratedMessage](companion: GeneratedMessa
     extends ProtobufSerializer[T] {
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
-  override def deserialize(bytes: ByteString): T = {
-    val buffer = ByteBuffer.allocateDirect(bytes.length)
-    try {
-      bytes.copyToBuffer(buffer)
-      buffer.flip()
-      companion.parseFrom(CodedInputStream.newInstance(buffer))
-    } finally DirectByteBufferPool.tryCleanDirectByteBuffer(buffer)
-  }
+  override def deserialize(bytes: ByteString): T =
+    companion.parseFrom(CodedInputStream.newInstance(bytes.asByteBuffer))
+  override def deserialize(buffer: ByteBuffer): T = companion.parseFrom(CodedInputStream.newInstance(buffer))
 }


### PR DESCRIPTION
I put these out here because it might take me a while to sort these all out properly. If anyone wants to help, you could pick out one of those and get them ready into a proper PR.

Especially using direct buffers for protobuf deserialization looks quite promising, in particular, if the input buffer comes from a ByteString and would have to be copied anyway. It seems, protobuf can use Unsafe access to those buffers to decode UTF8 strings much faster.