### PR TITLE
Fix incompatibilities when using Scala 2.13 artifacts with Scala 3

### DIFF
--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -47,42 +47,41 @@ final class Default@{service.name}Client(settings: GrpcClientSettings)(implicit 
 
   private implicit val ex: ExecutionContext = sys.classicSystem.dispatcher
   private val options = NettyClientUtils.callOptions(settings)
-  private val clientState = new ClientState(settings, akka.event.Logging(sys.classicSystem, this.getClass))
+  private val clientState = new ClientState(settings, akka.event.Logging(sys.classicSystem, classOf[Default@{service.name}Client]))
 
   @for(method <- service.methods) {
-    private def @{method.name}RequestBuilder(channel: akka.grpc.internal.InternalChannel) = {
-      @if(method.methodType == akka.grpc.gen.Unary) {
-        new ScalaUnaryRequestBuilder(@{method.name}Descriptor, channel, options, settings)
-      } else {
-        @if(method.methodType == akka.grpc.gen.ServerStreaming) {
-          new ScalaServerStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
-        } else if(method.methodType == akka.grpc.gen.ClientStreaming) {
-          new ScalaClientStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
-        } else if (method.methodType == akka.grpc.gen.BidiStreaming) {
-          new ScalaBidirectionalStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
-        }
-      }
+  private def @{method.name}RequestBuilder(channel: akka.grpc.internal.InternalChannel) =
+  @if(method.methodType == akka.grpc.gen.Unary) {
+    new ScalaUnaryRequestBuilder(@{method.name}Descriptor, channel, options, settings)
+  } else {
+    @if(method.methodType == akka.grpc.gen.ServerStreaming) {
+    new ScalaServerStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
+    } else if(method.methodType == akka.grpc.gen.ClientStreaming) {
+    new ScalaClientStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
+    } else if (method.methodType == akka.grpc.gen.BidiStreaming) {
+    new ScalaBidirectionalStreamingRequestBuilder(@{method.name}Descriptor, channel, options, settings)
     }
+  }
   }
 
   @for(method <- service.methods) {
-    /**
-     * Lower level "lifted" version of the method, giving access to request metadata etc.
-     * prefer @{method.nameSafe}(@method.parameterType) if possible.
-     */
-    @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
-      override def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
-        @{method.name}RequestBuilder(clientState.internalChannel)
-    } else {
-      override def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
-        @{method.name}RequestBuilder(clientState.internalChannel)
-    }
+  /**
+   * Lower level "lifted" version of the method, giving access to request metadata etc.
+   * prefer @{method.nameSafe}(@method.parameterType) if possible.
+   */
+  @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
+  override def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
+    @{method.name}RequestBuilder(clientState.internalChannel)
+  } else {
+  override def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] =
+    @{method.name}RequestBuilder(clientState.internalChannel)
+  }
 
-    /**
-     * For access to method metadata use the parameterless version of @{method.nameSafe}
-     */
-    def @{method.nameSafe}(in: @method.parameterType): @method.returnType =
-      @{method.nameSafe}().invoke(in)
+  /**
+   * For access to method metadata use the parameterless version of @{method.nameSafe}
+   */
+  def @{method.nameSafe}(in: @method.parameterType): @method.returnType =
+    @{method.nameSafe}().invoke(in)
   }
 
   override def close(): scala.concurrent.Future[akka.Done] = clientState.close()
@@ -98,15 +97,15 @@ object Default@{service.name}Client {
 
 trait @{service.name}ClientPowerApi {
   @for(method <- service.methods) {
-    /**
-     * Lower level "lifted" version of the method, giving access to request metadata etc.
-     * prefer @{method.nameSafe}(@method.parameterType) if possible.
-     */
-    @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
-      def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
-    } else {
-      def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
-    }
+  /**
+   * Lower level "lifted" version of the method, giving access to request metadata etc.
+   * prefer @{method.nameSafe}(@method.parameterType) if possible.
+   */
+  @if(method.methodType == akka.grpc.gen.Unary || method.methodType == akka.grpc.gen.ClientStreaming) {
+  def @{method.nameSafe}(): SingleResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
+  } else {
+  def @{method.nameSafe}(): StreamResponseRequestBuilder[@method.parameterType, @method.outputTypeUnboxed] = ???
+  }
   }
 
 }

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -106,6 +106,13 @@ object AkkaGrpcPlugin extends AutoPlugin {
       (if (config == Compile || config == Test) Seq() // already supported by sbt-protoc by default
        else sbtprotoc.ProtocPlugin.protobufConfigSettings) ++
       Seq(
+        // workaround to allow using Scala 2.13 artifacts in Scala 3 projects
+        scalaBinaryVersion := {
+          CrossVersion.partialVersion(scalaVersion.value) match {
+            case Some((3, _)) => "2.13"
+            case _            => scalaBinaryVersion.value
+          }
+        },
         akkaGrpcCodeGeneratorSettings / target := crossTarget.value / "akka-grpc" / Defaults.nameForSrc(
           configuration.value.name),
         managedSourceDirectories += (akkaGrpcCodeGeneratorSettings / target).value,


### PR DESCRIPTION
This does not add proper Scala 3 support for this project, but only fixes compiler errors when using 2.13 artifacts with Scala 3:

* use 2.13 Scala binary version, when Scala 3 is used, to pull dependencies
* fix type inference with existential types for LogSource
* don't indent generated methods too far to the right

References #1396
