### PR TITLE
Use `onlyIf` condition instead disable `javaCompile` task.

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPlugin.groovy
@@ -148,9 +148,9 @@ class AkkaGrpcPlugin implements Plugin<Project> {
         }
 
         project.afterEvaluate { Project p ->
-
-            if (akkaGrpcExt.scala && p.sourceSets.main.allJava.isEmpty()) {
-                p.tasks.getByName("compileJava").enabled = false
+            //Check exist java source before run compileJava.
+            p.tasks.getByName("compileJava").onlyIf {
+                !p.sourceSets.main.allJava.isEmpty()
             }
 
             def scalaVersion = autodetectScala()


### PR DESCRIPTION
Java sources can be created in other Gradle tasks. If we check java sources that existed after evaluation, we skipped sources generated by other Gradle tasks and disable `compileJava`.
To fix this behavior, we need to use the `onlyIf` task condition.
