### PR TITLE
Fix sonatype profile name

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -8,12 +8,13 @@ import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInf
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import sbtprotoc.ProtocPlugin.autoImport.PB
+import xerial.sbt.Sonatype
 import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
 
 object Common extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin
+  override def requires = JvmPlugin && Sonatype
 
   private val consoleDisabledOptions = Seq("-Xfatal-warnings", "-Ywarn-unused", "-Ywarn-unused-import")
 


### PR DESCRIPTION
This broke in e89e3ded3ceaea11862d58f7db30764ef2b11cd5, probably because
putting `Common` in a proper package changed the ordering and caused
the default `sonatypeProfileName` to take precendence over our custom
one. Specifying the dependency between the two plugins seems to make it
work again.