### PR TITLE
Fix request/response issues with grpc-web-text (#1459)

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -117,12 +117,12 @@ object AbstractGrpcProtocol {
 
     // strict decoder
     def decoder(bs: ByteString): ByteString = try {
-      val reader = new ByteReader(bs)
+      val reader = new ByteReader(strictAdapter(bs))
       val frameType = reader.readByte()
       val length = reader.readIntBE()
       val data = reader.take(length)
       if (reader.hasRemaining) throw new IllegalStateException("Unexpected data")
-      if ((frameType & 0x80) == 0) strictAdapter(codec.uncompress((frameType & 1) == 1, data))
+      if ((frameType & 0x80) == 0) codec.uncompress((frameType & 1) == 1, data)
       else throw new IllegalStateException("Cannot read unknown frame")
     } catch { case ByteStringParser.NeedMoreData => throw new MissingParameterException }
 

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcResponseHelpers.scala
@@ -80,7 +80,7 @@ object GrpcResponseHelpers {
       status = StatusCodes.OK,
       headers = headers,
       entity = entity,
-      protocol = HttpProtocols.`HTTP/2.0`,
+      protocol = HttpProtocols.`HTTP/1.1`,
       attributes = Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, trailer))
 
   def apply[T](e: Source[T, NotUsed], status: Future[Status])(


### PR DESCRIPTION
* Modify strict decode path in AbstractGrpcPrototocol to apply the
flow adapter before reading frame.
* Modify GrpcResponseHelper.responseWithTrailers to create the
HttpResponse with HTTP 1/1 to fix exception in HttpResponseRender.
This  isn't technically correct, but it matches the behavior of
akka-grpc v2.0.0 and appears to work with both HTTP/1.1 and HTTP/2.0.

References #1459 
