### PR TITLE
Align protoc versions with protobuf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,9 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
       previousStableVersion.value.map(v => Set(organization.value %% "akka-grpc-runtime" % v)).getOrElse(Set.empty),
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
-    ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"))
+    ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
+    PB.protocVersion := Dependencies.Versions.googleProtobuf
+  )
   .enablePlugins(akka.grpc.build.ReflectiveCodeGen)
   .enablePlugins(ReproducibleBuildsPlugin)
 
@@ -130,7 +132,8 @@ lazy val interopTests = Project(id = "akka-grpc-interop-tests", base = file("int
     parallelExecution := false,
     ReflectiveCodeGen.generatedLanguages := Seq("Scala", "Java"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis")
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"),
+    PB.protocVersion := Dependencies.Versions.googleProtobuf
     // This project should use 'publish/skip := true', but we need
     // to be able to `publishLocal` to run the interop tests as an
     // sbt scripted test

--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,7 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
-    PB.protocVersion := Dependencies.Versions.googleProtobuf
-  )
+    PB.protocVersion := Dependencies.Versions.googleProtobuf)
   .enablePlugins(akka.grpc.build.ReflectiveCodeGen)
   .enablePlugins(ReproducibleBuildsPlugin)
 

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -185,7 +185,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${akka-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v3.11.4">${akka-grpc.protoc-version}</protocVersion>
+        <protocVersion implementation="java.lang.String" default-value="-v3.18.1">${akka-grpc.protoc-version}</protocVersion>
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -94,7 +94,8 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${akka-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v3.11.4">${akka-grpc.protoc-version}</protocVersion>
+        <!-- Keep aligned with Akka gRPC proto-java dependency -->
+        <protocVersion implementation="java.lang.String" default-value="-v3.18.1">${akka-grpc.protoc-version}</protocVersion>
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -186,6 +186,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${akka-grpc.outputDirectory}</outputDirectory>
+        <!-- Keep aligned with Akka gRPC proto-java dependency -->
         <protocVersion implementation="java.lang.String" default-value="-v3.18.1">${akka-grpc.protoc-version}</protocVersion>
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,8 @@ object Dependencies {
 
     val grpc = "1.41.0" // checked synced by GrpcVersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests
+    // If changing this, remember to update protoc plugin version to align in
+    // maven-plugin/src/main/maven/plugin.xml and akka.grpc.sbt.AkkaGrpcPlugin
     val googleProtobuf = "3.18.1"
 
     val scalaTest = "3.1.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,6 +80,7 @@ object Dependencies {
   }
 
   object Protobuf {
+    val protobufJava = "com.google.protobuf" % "protobuf-java" % Versions.googleProtobuf
     val googleCommonProtos = "com.google.protobuf" % "protobuf-java" % Versions.googleProtobuf % "protobuf"
   }
 
@@ -95,10 +96,12 @@ object Dependencies {
     // dependency, but we want to pull it up to
     // at least version 2.5.0
     Compile.collectionCompat,
+    Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Test.scalaTest)
 
   val runtime = l ++= Seq(
     Compile.scalapbRuntime,
+    Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Compile.grpcCore,
     Compile.grpcStub % "provided", // comes from the generators
     Compile.grpcNettyShaded,

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -99,7 +99,8 @@ object AkkaGrpcPlugin extends AutoPlugin {
         // hack to get our (dirty) hands on a proper sbt logger before running the generators
         generatorLogger.logger = streams.value.log
         (Test / PB.recompile).value
-      })
+      },
+      PB.protocVersion := "3.18.1")
 
   def configSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -9,6 +9,7 @@ import akka.grpc.gen.scaladsl.{ ScalaClientCodeGenerator, ScalaServerCodeGenerat
 import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerator, JavaServerCodeGenerator }
 import akka.grpc.gen.{ ProtocSettings, Logger => GenLogger }
 import protocbridge.Generator
+import sbt.Def
 import sbt.Keys._
 import sbt._
 import sbtprotoc.ProtocPlugin
@@ -100,6 +101,7 @@ object AkkaGrpcPlugin extends AutoPlugin {
         generatorLogger.logger = streams.value.log
         (Test / PB.recompile).value
       },
+      // Keep aligned with Akka gRPC proto-java dependency
       PB.protocVersion := "3.18.1")
 
   def configSettings(config: Configuration): Seq[Setting[_]] =

--- a/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/akka/grpc/sbt/AkkaGrpcPlugin.scala
@@ -9,7 +9,6 @@ import akka.grpc.gen.scaladsl.{ ScalaClientCodeGenerator, ScalaServerCodeGenerat
 import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerator, JavaServerCodeGenerator }
 import akka.grpc.gen.{ ProtocSettings, Logger => GenLogger }
 import protocbridge.Generator
-import sbt.Def
 import sbt.Keys._
 import sbt._
 import sbtprotoc.ProtocPlugin


### PR DESCRIPTION
Instead of transitively getting the version selected by ScalaPB (and hardcoded string in Maven plugin)

Indirectly fixes #1238
