### PR TITLE
Docu: default discovery method

### DIFF
--- a/docs/src/main/paradox/client/configuration.md
+++ b/docs/src/main/paradox/client/configuration.md
@@ -62,7 +62,7 @@ Scala
 Java
 :  @@snip [GrpcClientSettingsCompileOnly](/runtime/src/test/java/jdocs/akka/grpc/client/GrpcClientSettingsCompileOnly.java) { #sd-settings }
 
-Alternatively if a `SimpleServiceDiscovery` instance is available elsewhere in your system it can be passed in:
+Alternatively if a default instance is available (configured by `akka.discovery.method`) in your system it can be use like this:
 
 Scala
 :  @@snip [GrpcClientSettingsCompileOnly](/runtime/src/test/scala/docs/akka/grpc/client/GrpcClientSettingsCompileOnly.scala) { #provide-sd }


### PR DESCRIPTION
Remove the old discovery `SimpleServiceDiscovery` naming. Highlight the fact that the default configured method is picked up for this example.
