### PR TITLE
Fix grpc-web trailer rendering for fast path

### DIFF
--- a/runtime/src/main/mima-filters/2.1.3.backwards.excludes/grpc-web-rendering
+++ b/runtime/src/main/mima-filters/2.1.3.backwards.excludes/grpc-web-rendering
@@ -1,0 +1,3 @@
+# InternalApi
+ProblemFilters.exclude[Problem]("akka.grpc.GrpcProtocol*")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.grpc.internal.AbstractGrpcProtocol.*")

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -87,7 +87,7 @@ object GrpcProtocol {
       messageEncoding: Codec,
       /** Encodes a frame as a part in a chunk stream. */
       encodeFrame: Frame => ChunkStreamPart,
-      /** A shortcut to encode a data frame directly into a ByteString */
+      /** A shortcut to encode a data frame directly into a Response */
       encodeDataToResponse: (ByteString, immutable.Seq[HttpHeader], Trailer) => HttpResponse,
       /** A Flow over a stream of Frame using this frame encoding */
       frameEncoder: Flow[Frame, ChunkStreamPart, NotUsed])

--- a/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcProtocol.scala
@@ -10,11 +10,12 @@ import akka.annotation.InternalStableApi
 import akka.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
 import akka.grpc.internal.{ Codec, Codecs, GrpcProtocolNative, GrpcProtocolWeb, GrpcProtocolWebText }
 import akka.http.javadsl.{ model => jmodel }
-import akka.http.scaladsl.model.{ ContentType, HttpHeader }
+import akka.http.scaladsl.model.{ ContentType, HttpHeader, HttpResponse, Trailer }
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 
+import scala.collection.immutable
 import scala.util.Try
 
 /**
@@ -87,7 +88,7 @@ object GrpcProtocol {
       /** Encodes a frame as a part in a chunk stream. */
       encodeFrame: Frame => ChunkStreamPart,
       /** A shortcut to encode a data frame directly into a ByteString */
-      encodeDataToFrameBytes: ByteString => ByteString,
+      encodeDataToResponse: (ByteString, immutable.Seq[HttpHeader], Trailer) => HttpResponse,
       /** A Flow over a stream of Frame using this frame encoding */
       frameEncoder: Flow[Frame, ChunkStreamPart, NotUsed])
 

--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -8,7 +8,7 @@ import akka.grpc.GrpcProtocol
 import akka.grpc.GrpcProtocol.{ Frame, GrpcProtocolReader, GrpcProtocolWriter }
 import akka.http.javadsl.{ model => jmodel }
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
-import akka.http.scaladsl.model.{ ContentType, MediaType }
+import akka.http.scaladsl.model.{ ContentType, HttpHeader, HttpResponse, MediaType, Trailer }
 import akka.stream.Attributes
 import akka.stream.impl.io.ByteStringParser
 import akka.stream.impl.io.ByteStringParser.{ ByteReader, ParseResult, ParseStep }
@@ -18,6 +18,7 @@ import akka.util.{ ByteString, ByteStringBuilder }
 import io.grpc.StatusException
 
 import java.nio.ByteOrder
+import scala.collection.immutable
 
 abstract class AbstractGrpcProtocol(subType: String) extends GrpcProtocol {
 
@@ -98,12 +99,12 @@ object AbstractGrpcProtocol {
       protocol: GrpcProtocol,
       codec: Codec,
       encodeFrame: Frame => ChunkStreamPart,
-      encodeDataToFrameBytes: ByteString => ByteString): GrpcProtocolWriter =
+      encodeDataToResponse: (ByteString, immutable.Seq[HttpHeader], Trailer) => HttpResponse): GrpcProtocolWriter =
     GrpcProtocolWriter(
       adjustCompressibility(protocol.contentType, codec),
       codec,
       encodeFrame,
-      encodeDataToFrameBytes,
+      encodeDataToResponse,
       Flow[Frame].map(encodeFrame))
 
   def reader(

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
@@ -6,8 +6,20 @@ package akka.grpc.internal
 
 import akka.grpc.GrpcProtocol._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart, LastChunk }
+import akka.http.scaladsl.model.{
+  AttributeKey,
+  AttributeKeys,
+  HttpEntity,
+  HttpHeader,
+  HttpProtocols,
+  HttpResponse,
+  StatusCodes,
+  Trailer
+}
 import akka.util.ByteString
+
 import scala.annotation.nowarn
+import scala.collection.immutable
 
 /**
  * Implementation of the gRPC (`application/grpc+proto`) protocol:
@@ -19,7 +31,7 @@ import scala.annotation.nowarn
 object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
 
   override protected def writer(codec: Codec) =
-    AbstractGrpcProtocol.writer(this, codec, encodeFrame(codec, _), encodeDataToFrameBytes(codec, _))
+    AbstractGrpcProtocol.writer(this, codec, encodeFrame(codec, _), encodeDataToResponse(codec))
 
   override protected def reader(codec: Codec): GrpcProtocolReader =
     AbstractGrpcProtocol.reader(codec, decodeFrame)
@@ -34,6 +46,15 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
         Chunk(AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false))
       case TrailerFrame(headers) => LastChunk(trailer = headers)
     }
+  private def encodeDataToResponse(
+      codec: Codec)(data: ByteString, headers: immutable.Seq[HttpHeader], trailer: Trailer): HttpResponse =
+    new HttpResponse(
+      status = StatusCodes.OK,
+      headers = headers,
+      entity = HttpEntity(contentType, encodeDataToFrameBytes(codec, data)),
+      protocol = HttpProtocols.`HTTP/1.1`,
+      attributes = Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, trailer))
+
   private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString =
     AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false)
 }

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
@@ -7,33 +7,50 @@ package akka.grpc.internal
 import akka.grpc.GrpcProtocol._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart }
-import akka.util.ByteString
+import akka.util.{ ByteString, ByteStringBuilder }
 import io.grpc.{ Status, StatusException }
+
+import scala.collection.immutable
 
 abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol(subType) {
   protected def postEncode(frame: ByteString): ByteString
   protected def preDecode(frame: ByteString): ByteString
 
   override protected def writer(codec: Codec): GrpcProtocolWriter =
-    AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame), encodeDataToFrameBytes(codec, _))
+    AbstractGrpcProtocol.writer(this, codec, frame => encodeFrame(codec, frame), encodeDataToResponse(codec))
 
   override protected def reader(codec: Codec): GrpcProtocolReader =
     AbstractGrpcProtocol.reader(codec, decodeFrame, preDecode)
 
-  @inline
-  private def encodeFrame(codec: Codec, frame: Frame): ChunkStreamPart = {
-    val framed = frame match {
+  private def encodeFrame(codec: Codec, frame: Frame): ChunkStreamPart =
+    Chunk(postEncode(encodeFrameToBytes(codec, frame)))
+
+  private def encodeDataToResponse(
+      codec: Codec)(data: ByteString, headers: immutable.Seq[HttpHeader], trailer: Trailer): HttpResponse =
+    HttpResponse(
+      status = StatusCodes.OK,
+      headers = headers,
+      entity = HttpEntity(contentType, encodeDataToFrameBytes(codec, data, trailer)),
+      protocol = HttpProtocols.`HTTP/1.1`)
+
+  private def encodeDataToFrameBytes(codec: Codec, data: ByteString, trailer: Trailer): ByteString = {
+    val trailerData = encodeTrailerHeaders(trailer.headers.iterator)
+    val trailerFrame =
+      AbstractGrpcProtocol.encodeFrameData(codec.compress(trailerData), codec.isCompressed, isTrailer = true)
+    postEncode(encodeFrameToBytes(codec, DataFrame(data)) ++ trailerFrame)
+  }
+
+  private def encodeFrameToBytes(codec: Codec, frame: Frame): ByteString =
+    frame match {
       case DataFrame(data) =>
         AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false)
       case TrailerFrame(trailer) =>
-        AbstractGrpcProtocol.encodeFrameData(encodeTrailer(trailer), codec.isCompressed, isTrailer = true)
+        AbstractGrpcProtocol.encodeFrameData(
+          codec.compress(encodeTrailerHeaders(trailer.iterator.map(h => h.lowercaseName -> h.value))),
+          codec.isCompressed,
+          isTrailer = true)
     }
-    Chunk(postEncode(framed))
-  }
-  private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString =
-    postEncode(AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false))
 
-  @inline
   private final def decodeFrame(frameHeader: Int, data: ByteString): Frame = {
     (frameHeader & 80) match {
       case 0 => DataFrame(data)
@@ -42,11 +59,15 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
     }
   }
 
-  @inline
-  private final def encodeTrailer(trailer: Seq[HttpHeader]): ByteString =
-    ByteString(trailer.mkString("", "\r\n", "\r\n"))
+  private final def encodeTrailerHeaders(trailerHeaders: Iterator[(String, String)]): ByteString = {
+    val builder = new ByteStringBuilder
+    while (trailerHeaders.hasNext) {
+      val (header, value) = trailerHeaders.next()
+      builder.append(ByteString(header.toLowerCase)).putByte(':').append(ByteString(value)).putByte('\r').putByte('\n')
+    }
+    builder.result()
+  }
 
-  @inline
   private final def decodeTrailer(data: ByteString): List[HttpHeader] = ???
 
 }


### PR DESCRIPTION
Turns out we lost trailer rendering in the performance optimization for strict entities. This is an attempt at adding it back. Would still be good to add some tests. I currently don't have time to develop this further but maybe we can prepare the fix for the next release.

Refs #1465 