### PR TITLE
[propose] update protoc_version to latest one that supports arm64 architecture

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 
 class AkkaGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "3.11.0"
+    static final String PROTOC_VERSION = "3.19.4"
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 


### PR DESCRIPTION
Hi, here is my proposal to update protoc version which will allow to run the project without manually specifying the version of protoc for each project separately. 

For example, [there is](https://github.com/protocolbuffers/protobuf/issues/8062) the same "issue",  (I've got a `Could not find protoc-3.11.0-osx-aarch_64.exe`). 
Also locally tested with 3.19.4 version and all seems ok.

Thanks.