### PR TITLE
fix: don't throw if the promise got completed in the meanwhile

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/AkkaNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaNettyGrpcClientGraphStage.scala
@@ -172,7 +172,7 @@ private final class AkkaNettyGrpcClientGraphStage[I, O](
           call = null
         }
         if (!matVal.isCompleted) {
-          matVal.failure(new AbruptStageTerminationException(this))
+          matVal.tryFailure(new AbruptStageTerminationException(this))
         }
       }
 


### PR DESCRIPTION
References #1578.

Switching `failure` to `tryFailure`, because it can happen that the promise gets completed in the meanwhile, in this case we shouldn't throw an exception.