### PR TITLE
Don't update beyond jgit 5 yet

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -18,4 +18,7 @@ updates.ignore = [
 
 updates.pin = [
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." },
+
+  # https://github.com/akka/akka-grpc/issues/1506
+  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },
 ]


### PR DESCRIPTION
We'll update the build to use jdk11 when we drop support for
jdk8 in #1506

Replaces #1587