### PR TITLE
Document the correct version of the default protoc used.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,6 +185,7 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
       "akka.version" -> Dependencies.Versions.akka,
       "akka-http.version" -> Dependencies.Versions.akkaHttp,
       "grpc.version" -> Dependencies.Versions.grpc,
+      "protobuf.version" -> Dependencies.Versions.googleProtobuf,
       "project.url" -> "https://doc.akka.io/docs/akka-grpc/current/",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-grpc/current",
       "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",

--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -51,7 +51,7 @@ To additionally generate server "power APIs" that have access to request metadat
 
 ## Protoc version
 
-Default version of `protoc` compiler is 3.4.0.
+Default version of `protoc` compiler is @var[protobuf.version].
 The version and the location of `protoc` can be changed using `protobuf-gradle-plugin` [settings](https://github.com/google/protobuf-gradle-plugin#locate-external-executables).
 
 ## Proto source directory


### PR DESCRIPTION
Documents the correct version of the default `protoc` used by parameterizing the docs with an additional `protobuf.version` property.

**Sample of doc generated:**
![image](https://user-images.githubusercontent.com/1426304/168205481-def29211-efed-49dc-af92-d29fe145e8a4.png)
