### PR TITLE
Sync gRPC versions between the Gradle plugin and the rest of the project.

### DIFF
--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
@@ -9,7 +9,7 @@ class AkkaGrpcPluginExtension {
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 
-    static final String GRPC_VERSION = "1.32.1"
+    static final String GRPC_VERSION = "1.46.0" // checked synced by VersionSyncCheckPlugin
 
     static final String PLUGIN_CODE = 'com.lightbend.akka.grpc.gradle'
 

--- a/project/VersionSyncCheckPlugin.scala
+++ b/project/VersionSyncCheckPlugin.scala
@@ -23,11 +23,12 @@ object VersionSyncCheckPlugin extends AutoPlugin {
     grpcVersionSyncCheck := versionSyncCheckImpl(
       "gRPC",
       Dependencies.Versions.grpc,
-      raw"""[Gg][Rr][Pp][Cc].?[Vv]ersion.{1,9}(\d+\.\d+\.\d+)""".r.unanchored,
+      raw"""(?i)grpc.?(?i)version.{1,9}(\d+\.\d+\.\d+)""".r.unanchored,
       Seq(
         Paths.get("plugin-tester-java/pom.xml"),
         Paths.get("plugin-tester-scala/pom.xml"),
-        Paths.get("sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt"))).value,
+        Paths.get("sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt"),
+        Paths.get("gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy"))).value,
     googleProtobufVersionSyncCheck := versionSyncCheckImpl(
       "Google Protobuf",
       Dependencies.Versions.googleProtobuf,


### PR DESCRIPTION
Resolves https://github.com/akka/akka-grpc/issues/262.

Originally, the goal was for the Gradle plugin to not depend on `io.groc:grpc-stub:1.32.1`, due to it being vulnerable to [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908).

The approach was to keep the Gradle plugin's version in sync with the rest of the project, naturally resulting in an updated version of its gRPC dependencies.

Changes:
- Update gRPC version used in the Gradle plugin from `1.32.1` to `1.46.0`.
- Add `AkkaGrpcPluginException.groovy` as an artifact to be version-checked.

