### PR TITLE
fix: allow messages with the same name from different packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,11 +131,11 @@ lazy val interopTests = Project(id = "akka-grpc-interop-tests", base = file("int
     ReflectiveCodeGen.generatedLanguages := Seq("Scala", "Java"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"),
-    PB.protocVersion := Dependencies.Versions.googleProtobuf
+    PB.protocVersion := Dependencies.Versions.googleProtobuf,
     // This project should use 'publish/skip := true', but we need
     // to be able to `publishLocal` to run the interop tests as an
-    // sbt scripted test
-  )
+    // sbt scripted test. At least skip scaladoc generation though.
+    Compile / doc := (Compile / doc / target).value)
   .settings(inConfig(Test)(Seq(
     reStart / mainClass := (Test / run / mainClass).value, {
       import spray.revolver.Actions._

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Method.scala
@@ -16,15 +16,16 @@ final case class Method(
     inputStreaming: Boolean,
     outputType: Descriptor,
     outputStreaming: Boolean,
-    comment: Option[String] = None) {
+    comment: Option[String] = None,
+    method: MethodDescriptor) {
   import Method._
 
   require(
     !ReservedWords.contains(name),
     s"The method name `$name` is a reserved word in Java, please change it in your proto")
 
-  def deserializer = Serializer(inputType)
-  def serializer = Serializer(outputType)
+  def deserializer = Serializer(method, inputType)
+  def serializer = Serializer(method, outputType)
 
   def unmarshal =
     if (inputStreaming) "GrpcMarshalling.unmarshalStream"
@@ -72,7 +73,8 @@ object Method {
       descriptor.toProto.getClientStreaming,
       descriptor.getOutputType,
       descriptor.toProto.getServerStreaming,
-      comment)
+      comment,
+      descriptor)
   }
 
   private def methodName(name: String) =

--- a/codegen/src/main/scala/akka/grpc/gen/javadsl/Serializer.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/javadsl/Serializer.scala
@@ -4,14 +4,20 @@
 
 package akka.grpc.gen.javadsl
 
-import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.{ Descriptor, MethodDescriptor }
 
 final case class Serializer(name: String, init: String, messageType: String)
 
 object Serializer {
-  def apply(messageType: Descriptor): Serializer =
+  def apply(method: MethodDescriptor, messageType: Descriptor): Serializer = {
+    val name = if (method.getFile.getPackage == messageType.getFile.getPackage) {
+      messageType.getName + "Serializer"
+    } else {
+      messageType.getFile.getPackage.replace('.', '_') + "_" + messageType.getName + "Serializer"
+    }
     Serializer(
-      messageType.getName + "Serializer",
+      name,
       s"new GoogleProtobufSerializer<>(${Method.getMessageType(messageType)}.parser())",
       Method.getMessageType(messageType))
+  }
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -16,11 +16,12 @@ case class Method(
     outputType: Descriptor,
     outputStreaming: Boolean,
     options: com.google.protobuf.DescriptorProtos.MethodOptions,
-    comment: Option[String] = None)(implicit ops: DescriptorImplicits) {
+    comment: Option[String] = None,
+    methodDescriptor: MethodDescriptor)(implicit ops: DescriptorImplicits) {
   import Method._
 
-  def deserializer = Serializer(inputType)
-  def serializer = Serializer(outputType)
+  def deserializer = Serializer(methodDescriptor, inputType)
+  def serializer = Serializer(methodDescriptor, outputType)
 
   def unmarshal =
     if (inputStreaming) "GrpcMarshalling.unmarshalStream"
@@ -67,7 +68,8 @@ object Method {
       descriptor.getOutputType,
       descriptor.toProto.getServerStreaming,
       descriptor.getOptions,
-      descriptor.comment)
+      descriptor.comment,
+      descriptor)
   }
 
   private def methodName(name: String) =

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Serializer.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Serializer.scala
@@ -4,14 +4,18 @@
 
 package akka.grpc.gen.scaladsl
 
-import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.{ Descriptor, MethodDescriptor }
 import scalapb.compiler.DescriptorImplicits
 
 case class Serializer(name: String, init: String)
 
 object Serializer {
-  def apply(messageType: Descriptor)(implicit ops: DescriptorImplicits): Serializer =
-    Serializer(
-      messageType.getName + "Serializer",
-      s"new ScalapbProtobufSerializer(${Method.messageType(messageType)}.messageCompanion)")
+  def apply(method: MethodDescriptor, messageType: Descriptor)(implicit ops: DescriptorImplicits): Serializer = {
+    val name = if (method.getFile.getPackage == messageType.getFile.getPackage) {
+      messageType.getName + "Serializer"
+    } else {
+      messageType.getFile.getPackage.replace('.', '_') + "_" + messageType.getName + "Serializer"
+    }
+    Serializer(name, s"new ScalapbProtobufSerializer(${Method.messageType(messageType)}.messageCompanion)")
+  }
 }

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
@@ -1,0 +1,9 @@
+// Can be removed when we move to 2.12.14
+// https://github.com/akka/akka-grpc/pull/1279
+scalaVersion := "2.12.16"
+
+resolvers += Resolver.sonatypeRepo("staging")
+
+enablePlugins(AkkaGrpcPlugin)
+
+akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/java/helloworld/GreeterServiceImpl.java
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/java/helloworld/GreeterServiceImpl.java
@@ -1,0 +1,18 @@
+package helloworld;
+
+import java.util.concurrent.CompletionStage;
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
+import helloworld.Helloworld.*;
+
+class GreeterServiceImpl implements GreeterService {
+  public CompletionStage<HelloReply> sayHello(HelloRequest request) {
+    throw new UnsupportedOperationException();
+  }
+  public CompletionStage<HelloReply> sayHelloA(a.Other.HelloRequest request) {
+    throw new UnsupportedOperationException();
+  }
+  public CompletionStage<HelloReply> sayHelloB(b.Other.HelloRequest request) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/a/other.proto
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/a/other.proto
@@ -1,0 +1,3 @@
+package a;
+
+message HelloRequest {}

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/b/other.proto
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/b/other.proto
@@ -1,0 +1,3 @@
+package b;
+
+message HelloRequest {}

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/src/main/protobuf/helloworld.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package helloworld;
+
+import "a/other.proto";
+import "b/other.proto";
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+    rpc SayHelloA (a.HelloRequest) returns (HelloReply) {}
+    rpc SayHelloB (b.HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/test
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/test
@@ -1,0 +1,3 @@
+> compile
+
+$ exists target/scala-2.12/akka-grpc/main/helloworld/Helloworld.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
@@ -1,0 +1,7 @@
+// Can be removed when we move to 2.12.14
+// https://github.com/akka/akka-grpc/pull/1279
+scalaVersion := "2.12.16"
+
+resolvers += Resolver.sonatypeRepo("staging")
+
+enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/a/other.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/a/other.proto
@@ -1,0 +1,3 @@
+package a;
+
+message HelloRequest {}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/b/other.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/b/other.proto
@@ -1,0 +1,3 @@
+package b;
+
+message HelloRequest {}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/helloworld.proto
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/protobuf/helloworld.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package helloworld;
+
+import "a/other.proto";
+import "b/other.proto";
+
+// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+    rpc SayHelloA (a.HelloRequest) returns (HelloReply) {}
+    rpc SayHelloB (b.HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/scala/helloworld/GreeterServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/src/main/scala/helloworld/GreeterServiceImpl.scala
@@ -1,0 +1,12 @@
+package helloworld
+
+import scala.concurrent.Future
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+
+class GreeterServiceImpl extends GreeterService {
+  override def sayHello(in: HelloRequest): Future[HelloReply] = ???
+  override def sayHelloA(in: a.HelloRequest): Future[HelloReply] = ???
+  override def sayHelloB(in: b.HelloRequest): Future[HelloReply] = ???
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/test
@@ -1,0 +1,6 @@
+> compile
+
+$ exists target/scala-2.12/akka-grpc
+$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloRequest.scala
+$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloworldProto.scala
+$ exists target/scala-2.12/akka-grpc/main/helloworld/GreeterService.scala


### PR DESCRIPTION
Fixes #1625

This allows messages with the same name but different packages to be used by the same service by prefixing the messages generated serializer names with the underscore separated package name if they came from if they come frome a different package to the package the service is declared in.