### PR TITLE
TLS related settings should force useTls=true

### DIFF
--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -212,15 +212,17 @@ final class GrpcClientSettings private (
   def withCallCredentials(value: CallCredentials): GrpcClientSettings = copy(callCredentials = Option(value))
   def withOverrideAuthority(value: String): GrpcClientSettings = copy(overrideAuthority = Option(value))
   def withSslProvider(sslProvider: SslProvider): GrpcClientSettings =
-    copy(useTls = true, sslProvider = Option(sslProvider))
+    Option(sslProvider).fold(this)(sslProvider => copy(useTls = true, sslProvider = Some(sslProvider)))
 
   /**
    * Prefer using `withContextManager`: withSslContext forces the ssl-provider 'jdk', which is known
    * not to work on JDK 1.8.0_252.
    */
-  def withSslContext(sslContext: SSLContext): GrpcClientSettings = copy(useTls = true, sslContext = Option(sslContext))
+  def withSslContext(sslContext: SSLContext): GrpcClientSettings =
+    Option(sslContext).fold(this)(sslContext => copy(useTls = true, sslContext = Option(sslContext)))
   def withTrustManager(trustManager: TrustManager): GrpcClientSettings =
-    copy(useTls = true, trustManager = Option(trustManager))
+    Option(trustManager).fold(this)(trustManager => copy(useTls = true, trustManager = Option(trustManager)))
+
   def withResolveTimeout(value: FiniteDuration): GrpcClientSettings = copy(resolveTimeout = value)
 
   /**

--- a/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcClientSettings.scala
@@ -211,14 +211,16 @@ final class GrpcClientSettings private (
   def withDefaultPort(value: Int): GrpcClientSettings = copy(defaultPort = value)
   def withCallCredentials(value: CallCredentials): GrpcClientSettings = copy(callCredentials = Option(value))
   def withOverrideAuthority(value: String): GrpcClientSettings = copy(overrideAuthority = Option(value))
-  def withSslProvider(sslProvider: SslProvider): GrpcClientSettings = copy(sslProvider = Option(sslProvider))
+  def withSslProvider(sslProvider: SslProvider): GrpcClientSettings =
+    copy(useTls = true, sslProvider = Option(sslProvider))
 
   /**
    * Prefer using `withContextManager`: withSslContext forces the ssl-provider 'jdk', which is known
    * not to work on JDK 1.8.0_252.
    */
-  def withSslContext(sslContext: SSLContext): GrpcClientSettings = copy(sslContext = Option(sslContext))
-  def withTrustManager(trustManager: TrustManager): GrpcClientSettings = copy(trustManager = Option(trustManager))
+  def withSslContext(sslContext: SSLContext): GrpcClientSettings = copy(useTls = true, sslContext = Option(sslContext))
+  def withTrustManager(trustManager: TrustManager): GrpcClientSettings =
+    copy(useTls = true, trustManager = Option(trustManager))
   def withResolveTimeout(value: FiniteDuration): GrpcClientSettings = copy(resolveTimeout = value)
 
   /**


### PR DESCRIPTION
rather than
```scala
settings.withTls(true).withSslContext(context)
```
instead,
```scala
settings.withSslContext(context)
```
should suffice
