### PR TITLE
Fix base64 request decoding for grpc-web-text

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,6 +114,7 @@ object Dependencies {
     Compile.collectionCompat,
     Test.akkaDiscoveryConfig,
     Test.akkaTestkit,
+    Test.akkaStreamTestkit,
     Test.scalaTest,
     Test.scalaTestPlusJunit)
 

--- a/runtime/src/main/mima-filters/2.1.5.backwards.excludes/base64-decoding.excludes
+++ b/runtime/src/main/mima-filters/2.1.5.backwards.excludes/base64-decoding.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[Problem]("akka.grpc.internal.AbstractGrpcProtocol.*")
+ProblemFilters.exclude[Problem]("akka.grpc.internal.GrpcProtocolWeb*")

--- a/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AbstractGrpcProtocol.scala
@@ -110,11 +110,12 @@ object AbstractGrpcProtocol {
   def reader(
       codec: Codec,
       decodeFrame: (Int, ByteString) => Frame,
-      flowAdapter: ByteString => ByteString = null): GrpcProtocolReader = {
-    val strictAdapter: ByteString => ByteString = if (flowAdapter eq null) identity else flowAdapter
+      preDecodeStrict: ByteString => ByteString = null,
+      preDecodeFlow: Flow[ByteString, ByteString, NotUsed] = null): GrpcProtocolReader = {
+    val strictAdapter: ByteString => ByteString = if (preDecodeStrict eq null) identity else preDecodeStrict
     val adapter: Flow[ByteString, Frame, NotUsed] => Flow[ByteString, Frame, NotUsed] =
-      if (flowAdapter eq null) identity
-      else x => Flow[ByteString].map(flowAdapter).via(x)
+      if (preDecodeFlow eq null) identity
+      else x => Flow[ByteString].via(preDecodeFlow).via(x)
 
     // strict decoder
     def decoder(bs: ByteString): ByteString = try {

--- a/runtime/src/main/scala/akka/grpc/internal/DecodeBase64.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/DecodeBase64.scala
@@ -1,0 +1,72 @@
+package akka.grpc.internal
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.stream.scaladsl.Flow
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.util.ByteString
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object DecodeBase64 {
+  def apply(): Flow[ByteString, ByteString, NotUsed] =
+    Flow[ByteString].via(new DecodeBase64)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class DecodeBase64 extends GraphStage[FlowShape[ByteString, ByteString]] {
+  private val in = Inlet[ByteString]("DecodeBase64.in")
+  private val out = Outlet[ByteString]("DecodeBase64.out")
+
+  override def initialAttributes = Attributes.name("DecodeBase64")
+
+  final override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var buffer: ByteString = ByteString.empty
+
+      override def onPush(): Unit = {
+        buffer ++= grab(in)
+
+        val length = buffer.length
+        val decodeLength = length - length % 4
+
+        if (decodeLength > 0) {
+          val (decodeBytes, remaining) = buffer.splitAt(decodeLength)
+          push(out, decodeBytes.decodeBase64)
+          buffer = remaining
+        } else {
+          pull(in)
+        }
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (buffer.nonEmpty) {
+          if (isAvailable(out)) {
+            push(out, buffer.decodeBase64)
+            buffer = ByteString.empty
+          }
+        } else {
+          completeStage()
+        }
+      }
+
+      override def onPull(): Unit = {
+        if (isClosed(in)) {
+          if (buffer.nonEmpty) {
+            push(out, buffer.decodeBase64)
+            buffer = ByteString.empty
+          } else {
+            completeStage()
+          }
+        } else pull(in)
+      }
+
+      setHandlers(in, out, this)
+    }
+}

--- a/runtime/src/main/scala/akka/grpc/internal/DecodeBase64.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/DecodeBase64.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import akka.NotUsed

--- a/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
@@ -1,0 +1,51 @@
+package akka.grpc.internal
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class DecodeBase64Spec extends TestKit(ActorSystem()) with AnyWordSpecLike {
+
+  private val data = ByteString(Range(-128, 128).map(_.toByte).toArray)
+
+  "DecodeBase64" should {
+    "handle a single element" in {
+      Source
+        .single(data.encodeBase64)
+        .via(DecodeBase64())
+        .runWith(TestSink[ByteString]())
+        .request(1)
+        .expectNext(data)
+        .expectComplete()
+    }
+
+    "handle a chunked stream" in {
+      val encodedData = data.encodeBase64
+      for (i <- Range(1, 12)) {
+        val chunks = encodedData.grouped(i).to[scala.collection.immutable.Seq]
+        Source(chunks)
+          .via(DecodeBase64())
+          .fold(ByteString.empty)(_.concat(_))
+          .runWith(TestSink[ByteString]())
+          .request(1)
+          .expectNext(data)
+          .expectComplete()
+      }
+    }
+
+    "handle a chunked stream with mid-stream flushes" in {
+      for (i <- Range(1, 9)) {
+        val chunks = data.grouped(i).to[scala.collection.immutable.Seq]
+        Source(chunks.map(_.encodeBase64))
+          .via(DecodeBase64())
+          .runWith(TestSink[ByteString]())
+          .request(chunks.length)
+          .expectNextN(chunks)
+          .expectComplete()
+      }
+    }
+  }
+}

--- a/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
@@ -29,7 +29,7 @@ class DecodeBase64Spec extends TestKit(ActorSystem()) with AnyWordSpecLike {
     "handle a chunked stream" in {
       val encodedData = data.encodeBase64
       for (i <- Range(1, 12)) {
-        val chunks = encodedData.grouped(i).to[scala.collection.immutable.Seq]
+        val chunks = encodedData.grouped(i).toList
         Source(chunks)
           .via(DecodeBase64())
           .fold(ByteString.empty)(_.concat(_))
@@ -42,7 +42,7 @@ class DecodeBase64Spec extends TestKit(ActorSystem()) with AnyWordSpecLike {
 
     "handle a chunked stream with mid-stream flushes" in {
       for (i <- Range(1, 9)) {
-        val chunks = data.grouped(i).to[scala.collection.immutable.Seq]
+        val chunks = data.grouped(i).toList
         Source(chunks.map(_.encodeBase64))
           .via(DecodeBase64())
           .runWith(TestSink[ByteString]())

--- a/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/DecodeBase64Spec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import akka.actor.ActorSystem

--- a/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
@@ -34,7 +34,7 @@ class GrpcProtocolWebTextSpec extends TestKit(ActorSystem()) with AnyWordSpecLik
 
     "decode a fragmented frame" in {
       for (i <- Range(1, 8)) {
-        Source(chunk.data.grouped(i).to[scala.collection.immutable.Iterable])
+        Source(chunk.data.grouped(i).toList)
           .via(reader.frameDecoder)
           .runWith(TestSink[Frame]())
           .request(1)

--- a/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
@@ -1,0 +1,42 @@
+package akka.grpc.internal
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcProtocol.{ DataFrame, Frame }
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class GrpcProtocolWebTextSpec extends TestKit(ActorSystem()) with AnyWordSpecLike {
+
+  "GrpcProtocolWebText" should {
+    val reader = GrpcProtocolWebText.newReader(Identity)
+    val writer = GrpcProtocolWebText.newWriter(Identity)
+
+    val data = ByteString(Range(-128, 128).map(_.toByte).toArray)
+    val frame = DataFrame(data)
+    val chunk = writer.encodeFrame(frame)
+
+    "decode a full frame" in {
+      Source
+        .single(chunk.data)
+        .via(reader.frameDecoder)
+        .runWith(TestSink[Frame]())
+        .request(1)
+        .expectNext(frame)
+        .expectComplete()
+    }
+
+    "decode a fragmented frame" in {
+      for (i <- Range(1, 8)) {
+        Source(chunk.data.grouped(i).to[scala.collection.immutable.Iterable])
+          .via(reader.frameDecoder)
+          .runWith(TestSink[Frame]())
+          .request(1)
+          .expectNext(frame)
+          .expectComplete()
+      }
+    }
+  }
+}

--- a/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/GrpcProtocolWebTextSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.internal
 
 import akka.actor.ActorSystem


### PR DESCRIPTION
Added DecodeBase64 flow that enforces 4-byte alignment.
Added preDecodeFlow parameter to AbstractGrpcProtocol.
Added tests.

References #1650 
