### PR TITLE
fix link validator on tags

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -32,4 +32,7 @@ jobs:
         run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
 
       - name: Run Link Validator
-        run: ./cs launch net.runne::site-link-validator:0.2.0 -- scripts/link-validator.conf
+        run: |
+          VERSION=$(ls docs/target/site/docs/akka-grpc)
+          sed -e "s/snapshot/$VERSION/" scripts/link-validator.conf > /tmp/link-validator.conf
+          ./cs launch net.runne::site-link-validator:0.2.0 -- /tmp/link-validator.conf


### PR DESCRIPTION
The link validator would not work when the current HEAD is a tag
(i.e. https://github.com/akka/akka-grpc/runs/7946004526?check_suite_focus=true)
auto-detect the version in that case