### PR TITLE
Drop direct scala-collection-compat dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,6 @@ object Dependencies {
     val protocJar = "com.github.os72" % "protoc-jar" % "3.11.4"
 
     val plexusBuildApi = "org.sonatype.plexus" % "plexus-build-api" % "0.0.7" % "optional" // Apache v2
-    val collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0"
   }
 
   object Test {
@@ -90,10 +89,6 @@ object Dependencies {
 
   val codegen = l ++= Seq(
     Compile.scalapbCompilerPlugin,
-    // Temporarily added: this is a transitive
-    // dependency, but we want to pull it up to
-    // at least version 2.5.0
-    Compile.collectionCompat,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Test.scalaTest)
 
@@ -108,11 +103,6 @@ object Dependencies {
     Compile.akkaHttp,
     Compile.akkaDiscovery,
     Compile.akkaHttpCors % "provided",
-    // Temporarily added: this is a transitive
-    // dependency, but we want to pull it up to
-    // at least version 2.5.0
-    Compile.collectionCompat,
-    Test.akkaDiscoveryConfig,
     Test.akkaTestkit,
     Test.scalaTest,
     Test.scalaTestPlusJunit)


### PR DESCRIPTION
Upstream is now at version 0.7.0, so we don't need
to override it anymore.

Replaces #1639