### PR TITLE
docs: remove protoc version from gradle docs

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -51,7 +51,6 @@ To additionally generate server "power APIs" that have access to request metadat
 
 ## Protoc version
 
-Default version of `protoc` compiler is 3.4.0.
 The version and the location of `protoc` can be changed using `protobuf-gradle-plugin` [settings](https://github.com/google/protobuf-gradle-plugin#locate-external-executables).
 
 ## Proto source directory


### PR DESCRIPTION
as it depends on the system path by default
https://github.com/google/protobuf-gradle-plugin#locate-external-executables

replaces #1614