### PR TITLE
remove isGrpcRequest check from the java api to align with scala api

### DIFF
--- a/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
@@ -41,9 +41,7 @@ object ServiceHandler {
   /**
    * Creates a `HttpRequest` to `HttpResponse` handler for gRPC services that can be used in
    * for example `Http().bindAndHandleAsync` for the generated partial function handlers:
-   *  - The generated handler supports the `application/grpc` media type.
-   *  - If the request is for an invalid media type, then a _415: Unsupported Media Type_ response is produced.
-   *  - Otherwise if the request is not handled by one of the provided handlers, a _404: Not Found_ response is produced.
+   *  - If the request is not handled by one of the provided handlers, a _404: Not Found_ response is produced.
    */
   @varargs
   def handler(handlers: JFunction[HttpRequest, CompletionStage[HttpResponse]]*)

--- a/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/ServiceHandler.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
-import akka.grpc.scaladsl.{ ServiceHandler => sServiceHandler }
 import akka.http.javadsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.japi.function.{ Function => JFunction }
 
@@ -50,7 +49,7 @@ object ServiceHandler {
   def handler(handlers: JFunction[HttpRequest, CompletionStage[HttpResponse]]*)
       : JFunction[HttpRequest, CompletionStage[HttpResponse]] = {
     val servicesHandler = concat(handlers: _*)
-    (req: HttpRequest) => if (sServiceHandler.isGrpcRequest(req)) servicesHandler(req) else unsupportedMediaType
+    (req: HttpRequest) => servicesHandler(req)
   }
 
   private[javadsl] def concat(handlers: JFunction[HttpRequest, CompletionStage[HttpResponse]]*)

--- a/runtime/src/main/scala/akka/grpc/scaladsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ServiceHandler.scala
@@ -6,7 +6,7 @@ package akka.grpc.scaladsl
 
 import akka.annotation.ApiMayChange
 import akka.grpc.GrpcProtocol
-import akka.grpc.internal.{ GrpcProtocolNative, GrpcProtocolWeb, GrpcProtocolWebText }
+import akka.grpc.internal.{ GrpcProtocolWeb, GrpcProtocolWebText }
 import akka.http.javadsl.{ model => jmodel }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 
@@ -23,7 +23,6 @@ object ServiceHandler {
   private def matchesVariant(variants: Set[GrpcProtocol])(request: jmodel.HttpRequest) =
     variants.exists(_.mediaTypes.contains(request.entity.getContentType.mediaType))
 
-  private[grpc] val isGrpcRequest: jmodel.HttpRequest => Boolean = matchesVariant(Set(GrpcProtocolNative))
   private[grpc] val isGrpcWebRequest: jmodel.HttpRequest => Boolean = matchesVariant(
     Set(GrpcProtocolWeb, GrpcProtocolWebText))
 


### PR DESCRIPTION
Fixes https://github.com/akka/akka-grpc/issues/1668 and https://github.com/akka/akka-grpc/issues/1574
