### PR TITLE
Update scala reserved words, handle already defined method names like `close`

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -80,7 +80,7 @@ object Method {
     messageType.scalaType.fullName
   }
 
-  // https://github.com/scalapb/ScalaPB/blob/master/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala#L1038
+  // https://github.com/scalapb/ScalaPB/blob/38845c0cf21173a2242a5d14ed48a7c33b981bae/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala#L1115
   private val ReservedWords = Set(
     "abstract",
     "case",
@@ -90,21 +90,28 @@ object Method {
     "do",
     "else",
     "enum",
+    "export",
     "extends",
     "false",
     "final",
     "finally",
     "for",
     "forSome",
+    "given",
     "if",
     "implicit",
     "import",
+    "infix",
+    "inline",
     "lazy",
     "macro",
     "match",
+    "ne",
     "new",
     "null",
     "object",
+    "opaque",
+    "open",
     "override",
     "package",
     "private",
@@ -116,6 +123,7 @@ object Method {
     "this",
     "throw",
     "trait",
+    "transparent",
     "try",
     "true",
     "type",
@@ -123,6 +131,5 @@ object Method {
     "var",
     "while",
     "with",
-    "yield",
-    "ne")
+    "yield")
 }

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Method.scala
@@ -52,7 +52,8 @@ case class Method(
   }
 
   val nameSafe: String =
-    if (ReservedWords.contains(name)) s"""`$name`"""
+    if (ReservedScalaWords.contains(name)) s"""`$name`"""
+    else if (ReservedMethodNames.contains(name)) s"$name$ReservedMethodNameSuffix"
     else name
 
 }
@@ -81,7 +82,7 @@ object Method {
   }
 
   // https://github.com/scalapb/ScalaPB/blob/38845c0cf21173a2242a5d14ed48a7c33b981bae/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala#L1115
-  private val ReservedWords = Set(
+  private val ReservedScalaWords = Set(
     "abstract",
     "case",
     "catch",
@@ -132,4 +133,27 @@ object Method {
     "while",
     "with",
     "yield")
+
+  private val ReservedMethodNameSuffix = "Method"
+
+  private val ReservedMethodNames =
+    Set(
+      "close",
+      "closed",
+      "clone",
+      "clone",
+      "hashCode",
+      "toString",
+      "isInstanceOf",
+      "asInstanceOf",
+      "equals",
+      "eq",
+      "notify",
+      "notifyAll",
+      "wait",
+      "finalize",
+      "synchronized",
+      "ensuring",
+      "wait",
+      "formatted")
 }


### PR DESCRIPTION
References: #1667

1st commit:
Updates the lists to the latest of reserved words for scala, also fixes the comment so it is pointed to a commit so the exact line isn't wrong if they change the file

2nd commit:
Adds `Method` suffix to a method's name if is a method that will already be defined by scala/akka
