### PR TITLE
Pin logback to 1.2.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -27,4 +27,7 @@ updates.pin = [
 
   # https://github.com/akka/akka-grpc/issues/1661
   { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1." }
+  # logback 1.3 and 1.4 would bump sfl4j to 2.0.0
+  # http://mailman.qos.ch/pipermail/announce/2022/000177.html
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." }
 ]


### PR DESCRIPTION
Since we don't want to update to slf4j 2.x yet
(#1661, http://mailman.qos.ch/pipermail/announce/2022/000177.html)