### PR TITLE
Update to Akka 2.7.0-M5, Akka HTTP 10.4.0-M2

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcMarshallingSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/GrpcMarshallingSpec.scala
@@ -51,12 +51,10 @@ class GrpcMarshallingSpec extends AnyWordSpec with Matchers {
         headers = immutable.Seq(`Message-Encoding`("gzip")),
         entity = HttpEntity.Chunked(
           GrpcProtocolNative.contentType,
-          TestSource
-            .probe[ChunkStreamPart]
-            .mapMaterializedValue((p: TestPublisher.Probe[ChunkStreamPart]) => {
-              sourceProbe.success(p)
-              NotUsed
-            })))
+          TestSource[ChunkStreamPart]().mapMaterializedValue((p: TestPublisher.Probe[ChunkStreamPart]) => {
+            sourceProbe.success(p)
+            NotUsed
+          })))
 
       val marshalledRequest = GrpcMarshalling.unmarshal(request)
 

--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -20,7 +20,7 @@ def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
   implementation group: 'ch.megard', name: "akka-http-cors_${scalaBinaryVersion}", version: '1.1.3'
-  testImplementation "com.typesafe.akka:akka-stream-testkit_${scalaBinaryVersion}:2.7.0-M1"
+  testImplementation "com.typesafe.akka:akka-stream-testkit_${scalaBinaryVersion}:2.7.0-M5"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.12"
   testImplementation "org.scalatestplus:junit-4-12_${scalaBinaryVersion}:3.2.2.0"
 }

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -15,7 +15,7 @@ def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
   implementation group: 'ch.megard', name: "akka-http-cors_${scalaBinaryVersion}", version: '1.1.3'
-  testImplementation "com.typesafe.akka:akka-stream-testkit_${scalaBinaryVersion}:2.7.0-M1"
+  testImplementation "com.typesafe.akka:akka-stream-testkit_${scalaBinaryVersion}:2.7.0-M5"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.12"
   testImplementation "org.scalatestplus:junit-4-12_${scalaBinaryVersion}:3.2.2.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,9 +16,9 @@ object Dependencies {
     // We don't force Akka updates because downstream projects can upgrade
     // themselves. For more information see
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-    val akka = "2.7.0-M1"
+    val akka = "2.7.0-M5"
     val akkaBinary = "2.7"
-    val akkaHttp = "10.4.0-M1"
+    val akkaHttp = "10.4.0-M2"
     val akkaHttpBinary = "10.4"
 
     val grpc = "1.48.1" // checked synced by VersionSyncCheckPlugin

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-27/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-27/build.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)
 
-dependencyOverrides += "com.typesafe.akka" %% "akka-stream" % "2.7.0-M1"
+dependencyOverrides += "com.typesafe.akka" %% "akka-stream" % "2.7.0-M5"
 
 assembly / assemblyMergeStrategy := {
   // https://github.com/akka/akka/issues/29456


### PR DESCRIPTION
* probe deprecation
* and Scala 2.12.17, 2.13.10