### PR TITLE
akka-grpc-codegen published twice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: |-
           cp .jvmopts-ghactions .jvmopts
           sbt ci-release
-          CI_RELEASE=akka-grpc-codegen/publishSigned CI_SNAPSHOT_RELEASE=akka-grpc-codegen/publish sbt ++2.13.x ci-release
+          CI_RELEASE=akka-grpc-codegen/publishSigned CI_SNAPSHOT_RELEASE=akka-grpc-codegen/publish sbt ++2.13.10\! ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Seems like the `++2.13.x` doesn't work for akka-grpc-codegen in the release workflow. Reverting to the fixed `++2.13.10!`

Compare logs from M1: https://github.com/akka/akka-grpc/actions/runs/3126167835/jobs/5071356163
with M2: https://github.com/akka/akka-grpc/actions/runs/3264590565/jobs/5365495186

and sbt session:
```
sbt:akka-grpc-codegen> show scalaVersion
[info] 2.12.17
sbt:akka-grpc-codegen> ++2.13.x
[info] Setting Scala version to 2.13.10 on 6 projects.
[info] Excluded 5 projects, run ++ 2.13.x -v for more details.
[info] Reapplying settings...
[info] set current project to akka-grpc-codegen (in build file:/Users/patrik/dev/akka-grpc/)
sbt:akka-grpc-codegen> show scalaVersion
[info] 2.12.17
sbt:akka-grpc-codegen> ++2.13.10!
[info] Forcing Scala version to 2.13.10 on all projects.
[info] Reapplying settings...
[info] set current project to akka-grpc-codegen (in build file:/Users/patrik/dev/akka-grpc/)
sbt:akka-grpc-codegen> show scalaVersion
[info] 2.13.10
```

