### PR TITLE
nowarn for never used different for 2.12 vs 2.13

### DIFF
--- a/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/CodeGenerator.scala
@@ -4,7 +4,6 @@
 
 package akka.grpc.gen
 
-import scala.annotation.nowarn
 import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
@@ -24,7 +23,7 @@ trait CodeGenerator {
   /** Takes Scala binary version and returns suggested dependency Seq */
   def suggestedDependencies: ScalaBinaryVersion => Seq[Artifact]
 
-  def registerExtensions(@nowarn("cat=unused-params") registry: ExtensionRegistry): Unit = {}
+  def registerExtensions(registry: ExtensionRegistry): Unit = {}
 
   final def run(request: Array[Byte], logger: Logger): Array[Byte] = {
     val registry = ExtensionRegistry.newInstance

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -53,6 +53,7 @@ object Common extends AutoPlugin {
       // deprecated in 2.13, but used as long as we support 2.12
       "-Wconf:msg=Use `scala.jdk.CollectionConverters` instead:silent",
       "-Wconf:msg=Use LazyList instead of Stream:silent",
+      "-Wconf:msg=never used:silent",
       // ignore imports in templates (FIXME why is that trailig .* needed?)
       "-Wconf:src=.*.txt.*:silent"),
     Compile / console / scalacOptions ~= (_.filterNot(consoleDisabledOptions.contains)),


### PR DESCRIPTION
Fails for 2.13.10 https://github.com/akka/akka-grpc/actions/runs/3280415938/jobs/5401160093#step:5:976

The whole setup for codegen publish is strange, but that is another story.