### PR TITLE
Send transitive dependencies in server reflection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,8 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
-    PB.protocVersion := Dependencies.Versions.googleProtobuf)
+    PB.protocVersion := Dependencies.Versions.googleProtobuf,
+    Test / PB.targets += (scalapb.gen() -> (Test / sourceManaged).value))
   .enablePlugins(akka.grpc.build.ReflectiveCodeGen)
   .enablePlugins(ReproducibleBuildsPlugin)
 

--- a/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_1.proto
+++ b/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_1.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package akka.grpc.internal;
+
+import "akka/grpc/internal/reflection_test_2.proto";
+import "akka/grpc/internal/reflection_test_3.proto";
+
+message MyMessage1 {
+  MyMessage2 field1 = 1;
+  MyMessage3 field2 = 2;
+}

--- a/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_2.proto
+++ b/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_2.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package akka.grpc.internal;
+
+import "akka/grpc/internal/reflection_test_3.proto";
+
+message MyMessage2 {
+  MyMessage3 field1 = 2;
+}

--- a/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_3.proto
+++ b/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_3.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package akka.grpc.internal;
+
+import "akka/grpc/internal/reflection_test_4.proto";
+
+message MyMessage3 {
+  MyMessage4 field1 = 1;
+}

--- a/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_4.proto
+++ b/runtime/src/test/protobuf/akka/grpc/internal/reflection_test_4.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package akka.grpc.internal;
+
+message MyMessage4 {
+}

--- a/runtime/src/test/scala/akka/grpc/internal/ServerReflectionImplSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/ServerReflectionImplSpec.scala
@@ -5,10 +5,15 @@
 package akka.grpc.internal
 
 import akka.actor.ActorSystem
+import akka.grpc.internal.reflection_test_1.ReflectionTest1Proto
+import akka.grpc.internal.reflection_test_2.ReflectionTest2Proto
+import akka.grpc.internal.reflection_test_3.ReflectionTest3Proto
+import akka.grpc.internal.reflection_test_4.ReflectionTest4Proto
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.testkit.TestKit
+import com.google.protobuf.descriptor.FileDescriptorProto
 import grpc.reflection.v1alpha.reflection.ServerReflectionRequest.MessageRequest
-import grpc.reflection.v1alpha.reflection.{ ServerReflection, ServerReflectionRequest }
+import grpc.reflection.v1alpha.reflection.{ ServerReflection, ServerReflectionRequest, ServerReflectionResponse }
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -34,14 +39,22 @@ class ServerReflectionImplSpec
   }
 
   "The Server Reflection implementation" should {
+    val serverReflection =
+      ServerReflectionImpl(
+        Seq(
+          ServerReflection.descriptor,
+          ReflectionTest1Proto.javaDescriptor,
+          ReflectionTest2Proto.javaDescriptor,
+          ReflectionTest3Proto.javaDescriptor,
+          ReflectionTest4Proto.javaDescriptor),
+        List.empty[String])
+
     "retrieve server reflection info" in {
       val serverReflectionRequest = ServerReflectionRequest(messageRequest =
         MessageRequest.FileByFilename("grpc/reflection/v1alpha/reflection.proto"))
 
-      val serverReflectionResponse = ServerReflectionImpl(Seq(ServerReflection.descriptor), List.empty[String])
-        .serverReflectionInfo(Source.single(serverReflectionRequest))
-        .runWith(Sink.head)
-        .futureValue
+      val serverReflectionResponse =
+        serverReflection.serverReflectionInfo(Source.single(serverReflectionRequest)).runWith(Sink.head).futureValue
 
       serverReflectionResponse.messageResponse.listServicesResponse should be(empty)
 
@@ -53,13 +66,65 @@ class ServerReflectionImplSpec
       val serverReflectionRequest =
         ServerReflectionRequest(messageRequest = MessageRequest.FileByFilename("grpc/reflection/v1alpha/unknown.proto"))
 
-      val serverReflectionResponse = ServerReflectionImpl(Seq(ServerReflection.descriptor), List.empty[String])
-        .serverReflectionInfo(Source.single(serverReflectionRequest))
-        .runWith(Sink.head)
-        .futureValue
+      val serverReflectionResponse =
+        serverReflection.serverReflectionInfo(Source.single(serverReflectionRequest)).runWith(Sink.head).futureValue
 
       serverReflectionResponse.messageResponse.listServicesResponse should be(empty)
       serverReflectionResponse.messageResponse.fileDescriptorResponse.value.fileDescriptorProto should be(empty)
     }
+
+    "return transitive dependencies" in {
+      val serverReflectionRequest = ServerReflectionRequest(messageRequest =
+        MessageRequest.FileByFilename("akka/grpc/internal/reflection_test_1.proto"))
+
+      val serverReflectionResponse =
+        serverReflection.serverReflectionInfo(Source.single(serverReflectionRequest)).runWith(Sink.head).futureValue
+
+      val protos = decodeFileResponseToNames(serverReflectionResponse)
+      protos should have size 4
+      (protos should contain).allOf(
+        "akka/grpc/internal/reflection_test_1.proto",
+        "akka/grpc/internal/reflection_test_2.proto",
+        "akka/grpc/internal/reflection_test_3.proto",
+        "akka/grpc/internal/reflection_test_4.proto")
+    }
+
+    "not return transitive dependencies already sent" in {
+      val req1 = ServerReflectionRequest(messageRequest =
+        MessageRequest.FileByFilename("akka/grpc/internal/reflection_test_4.proto"))
+      val req2 = ServerReflectionRequest(messageRequest =
+        MessageRequest.FileByFilename("akka/grpc/internal/reflection_test_1.proto"))
+      val req3 = ServerReflectionRequest(messageRequest =
+        MessageRequest.FileByFilename("akka/grpc/internal/reflection_test_2.proto"))
+
+      val responses =
+        serverReflection.serverReflectionInfo(Source(List(req1, req2, req3))).runWith(Sink.seq).futureValue
+
+      (responses should have).length(3)
+
+      val protos1 = decodeFileResponseToNames(responses.head)
+      protos1 should have size 1
+      protos1.head shouldBe "akka/grpc/internal/reflection_test_4.proto"
+
+      val protos2 = decodeFileResponseToNames(responses(1))
+      // all except 4, because 4 has already been sent
+      protos2 should have size 3
+      (protos2 should contain).allOf(
+        "akka/grpc/internal/reflection_test_1.proto",
+        "akka/grpc/internal/reflection_test_2.proto",
+        "akka/grpc/internal/reflection_test_3.proto")
+
+      val protos3 = decodeFileResponseToNames(responses(2))
+      // should still include 2, because 2 was explicitly requested, but should not include anything else
+      // because everything has already been sent
+      protos3 should have size 1
+      protos3.head shouldBe "akka/grpc/internal/reflection_test_2.proto"
+
+    }
+
   }
+
+  private def decodeFileResponseToNames(response: ServerReflectionResponse): Seq[String] =
+    response.messageResponse.fileDescriptorResponse.value.fileDescriptorProto.map(bs =>
+      FileDescriptorProto.parseFrom(bs.newCodedInput()).name.getOrElse(""))
 }


### PR DESCRIPTION
Fixes #1718

Not only has sending of transitive dependencies been implemented, but also filtering out ones already sent by the server on a given stream, as allowed by the server reflection spec.