### PR TITLE
ci: renovate GH workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Compile benchmarks
         run: |-
           cd benchmark-java
+          cp .jvmopts-ghactions .jvmopts
           sbt Test/compile
 
 
@@ -68,8 +69,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12, 2.13, 3.1]
-        JDK_VERSION: [1.8.0, 1.11]
+        SCALA_VERSION: [2.13, 2.13, 3.1]
+        JDK_VERSION: [1.8.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -85,7 +86,9 @@ jobs:
           jvm: temurin:${{ matrix.JDK_VERSION }}
 
       - name: Compile and test for JDK ${{ matrix.JDK_VERSION }}, Scala ${{ matrix.SCALA_VERSION }}
-        run: sbt ++${{ matrix.SCALA_VERSION }}.* test
+        run: |-
+          cp .jvmopts-ghactions .jvmopts
+          sbt ++${{ matrix.SCALA_VERSION }}.* test
 
 
   test-sbt:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Compile benchmarks
         run: |-
-          cd benchmark-java
           cp .jvmopts-ghactions .jvmopts
+          cd benchmark-java
           sbt Test/compile
 
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main ]
     tags-ignore: [ v* ]
 
+permissions:
+  contents: read
+
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
   group: ci-${{ github.ref }}
@@ -14,29 +17,21 @@ concurrency:
 jobs:
   check-code-style:
     name: Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
-      - name: FOSSA policy check
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'akka/akka-grpc' }}
-        run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
-          fossa analyze && fossa test
-        env:
-          FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Code style check and binary-compatibility check
         run: |-
@@ -45,56 +40,57 @@ jobs:
 
   compile-benchmarks:
     name: Compile Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
+
       - name: Compile benchmarks
         run: |-
           cd benchmark-java
-          sbt test:compile
+          sbt Test/compile
 
 
   compile-and-test:
     name: Compile and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3.1]
-        # use 1.8 when https://github.com/akka/akka-grpc/issues/1332 is fixed
-        JABBA_JDK: [1.8.0-275, 1.11]
+        JDK_VERSION: [1.8.0, 1.11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.JABBA_JDK }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@${{ matrix.JABBA_JDK }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Compile and test for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
+      - name: Set up JDK ${{ matrix.JDK_VERSION }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:${{ matrix.JDK_VERSION }}
+
+      - name: Compile and test for JDK ${{ matrix.JDK_VERSION }}, Scala ${{ matrix.SCALA_VERSION }}
         run: sbt ++${{ matrix.SCALA_VERSION }}.* test
 
 
   test-sbt:
     name: sbt scripted tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -107,37 +103,39 @@ jobs:
             scala-version: 3.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8
 
       - name: Scripted ${{ matrix.test-set }}
-        run: cp .jvmopts-ghactions .jvmopts && sbt ++${{ matrix.scala-version }}.* "sbt-akka-grpc/scripted ${{ matrix.test-set }}/*"
+        run: |-
+          cp .jvmopts-ghactions .jvmopts
+          sbt ++${{ matrix.scala-version }}.* "sbt-akka-grpc/scripted ${{ matrix.test-set }}/*"
 
   test-gradle:
     name: Gradle tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8
 
       - name: Gather version
         run: |-
@@ -145,7 +143,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Gradle repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: |
             ~/.gradle/caches
@@ -179,20 +177,20 @@ jobs:
 
   test-maven:
     name: Maven tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8
 
       - name: Gather version
         run: |-
@@ -200,7 +198,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('plugin-tester-*/pom.xml') }}
@@ -224,19 +222,21 @@ jobs:
 
   test-docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
+
       - name: Test Maven Java
         run: |-
           cp .jvmopts-ghactions .jvmopts

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,29 +5,32 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-grpc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.17
 
       - name: FOSSA policy check
         run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
           fossa analyze && fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -31,6 +31,8 @@ jobs:
       - name: FOSSA policy check
         run: |-
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          cp .jvmopts-ghactions .jvmopts
+          sbt "compile; makePom"
           fossa analyze && fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -5,34 +5,33 @@ on:
   schedule:
     - cron:  '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   validate-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
-          # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
-          ref: ${{ github.event.pull_request.head.sha }}
           # fetch everything https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
+          apps: cs
 
       - name: sbt site
         run: sbt akka-grpc-docs/makeSite
-
-      - name: Install Coursier command line tool
-        run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
 
       - name: Run Link Validator
         run: |
           VERSION=$(ls docs/target/site/docs/akka-grpc)
           sed -e "s/snapshot/$VERSION/" scripts/link-validator.conf > /tmp/link-validator.conf
-          ./cs launch net.runne::site-link-validator:0.2.0 -- /tmp/link-validator.conf
+          cs launch net.runne::site-link-validator:0.2.3 -- /tmp/link-validator.conf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,15 +19,15 @@ jobs:
         include:
           # leaving out combinations covered in `build-test.yml`
           # { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
 
           # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
 
           # { scalaVersion: "3.1",  jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "3.1",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "3.1",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,66 @@
+name: Nightly Builds
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-postgres:
+    name: Run test with Postgres
+    runs-on: ubuntu-22.04
+    if: github.repository == 'akka/akka-grpc'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # leaving out combinations covered in `build-test.yml`
+          # { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
+          # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
+          # { scalaVersion: "3.1",  jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "3.1",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: sbt test
+        run: |-
+          cp .jvmopts-ghactions .jvmopts
+          sbt ++${{ matrix.scalaVersion }} \
+            test ${{ matrix.extraOpts }}
+
+#      - name: Email on failure
+#        if: ${{ failure() }}
+#        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
+#        with:
+#          server_address: smtp.gmail.com
+#          server_port: 465
+#          username: ${{secrets.MAIL_USERNAME}}
+#          password: ${{secrets.MAIL_PASSWORD}}
+#          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+#          to: ${{secrets.MAIL_SEND_TO}}
+#          from: Akka gRPC CI
+#          body: |
+#            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+#            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+#

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,8 +5,13 @@ on:
 
 jobs:
   pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # https://github.com/TimonVS/pr-labeler-action/releases
+      # v4.1.1
+      - uses: TimonVS/pr-labeler-action@8b99f404a073744885d8021d1de4e40c6eaf38e2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,22 +9,22 @@ on:
 jobs:
   sbt:
     name: sbt publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-grpc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8
 
       - name: Publish
         run: |-
@@ -39,41 +39,41 @@ jobs:
 
   gradle-plugin:
     name: Release gradle plugin
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-grpc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
+        uses: coursier/setup-action@v1.3.0
         with:
-          java-version: adopt@1.8
+          jvm: temurin:1.8
 
       - name: Publish Plugin to Gradle Plugin Repository
         run: cd gradle-plugin && ./gradlew publishPlugins -Pgradle.publish.key='${{ secrets.GRADLE_PUBLISH_KEY }}' -Pgradle.publish.secret='${{ secrets.GRADLE_SECRET }}'
 
   documentation:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-grpc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Publish
         run: |-

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,15 +5,20 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    if: github.repository == 'akka/akka-grpc'
+    permissions:
+      contents: write
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-          # config-name: my-config.yml
+      # Drafts your next Release notes as Pull Requests are merged
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.jvmopts-ghactions
+++ b/.jvmopts-ghactions
@@ -1,4 +1,4 @@
-# This is used to configure the sbt instance that Travis launches
+# This is used to configure the sbt instance that GH workflows launch
 
 -Dfile.encoding=UTF8
 -Dsbt.color=always


### PR DESCRIPTION
* limit workflow permissions
* current versions of actions
* switch to coursier/setup-action
* run more Scala/JDK combinations in a nightly job