### PR TITLE
ci: JDK 8 for Fossa

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: temurin:1.17
+          jvm: temurin:1.8
 
       - name: FOSSA policy check
         run: |-


### PR DESCRIPTION
The target release flags for Scala and Java are missing. That mixes class file versions up when Fossa tries to run Gradle, AFAIU.
Trying this to see if it solves part of the problem before introducing flags into the sbt build.

Sample CI problem in https://github.com/akka/akka-grpc/actions/runs/3564968871/jobs/5989562205#step:5:486