### PR TITLE
chore: remove references to Play gRPC

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -95,7 +95,3 @@ Then, the server can then be started from the command line with:
 ```
 ./gradlew runServer
 ```
-
-## Play Framework support
-
-See the [Play gRPC documentation](https://developer.lightbend.com/docs/play-grpc/current/play/gradle-support.html) for details.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -22,8 +22,7 @@ It features:
  * gRPC Runtime implementation that uses 
     - @extref[Akka HTTP/2 support](akka-http:server-side/http2.html) for the server side and 
     - `grpc-netty-shaded` for the client side.
- * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), @ref[Maven](buildtools/maven.md),
-   and the [Play Framework](https://developer.lightbend.com/docs/play-grpc/current/).
+ * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), and @ref[Maven](buildtools/maven.md).
 
 ## Project Information
 
@@ -32,7 +31,7 @@ It features:
 ## Project Status
 
 Akka gRPC is [Supported](https://developer.lightbend.com/docs/introduction/getting-help/support-terminology.html)
-as part of a [Lightbend Subscription](https://www.lightbend.com/lightbend-subscription).
+for users with an [Akka license](https://www.lightbend.com/akka#pricing).
 
 Both client- and server-side APIs are based on Akka Streams.
 


### PR DESCRIPTION
Lightbend does not maintain Play gRPC anymore.
Play gRPC documentation is currently not published anywhere.