### PR TITLE
fix: Don't log peer closing connection at error

### DIFF
--- a/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GrpcExceptionHandler.scala
@@ -18,6 +18,7 @@ import io.grpc.{ Status, StatusRuntimeException }
 
 import scala.concurrent.ExecutionException
 import akka.event.Logging
+import akka.http.scaladsl.model.http2.PeerClosedStreamException
 
 @ApiMayChange
 object GrpcExceptionHandler {
@@ -32,7 +33,9 @@ object GrpcExceptionHandler {
 
   /** INTERNAL API */
   @InternalApi
-  private def default(system: ActorSystem): jFunction[Throwable, Trailers] =
+  private def default(system: ActorSystem): jFunction[Throwable, Trailers] = {
+    val log = Logging(system, "akka.grpc.javadsl.GrpcExceptionHandler")
+
     new jFunction[Throwable, Trailers] {
       override def apply(param: Throwable): Trailers =
         param match {
@@ -47,12 +50,15 @@ object GrpcExceptionHandler {
           case e: NotImplementedError              => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
           case e: UnsupportedOperationException    => Trailers(Status.UNIMPLEMENTED.withDescription(e.getMessage))
           case e: StatusRuntimeException           => Trailers(e.getStatus, new GrpcMetadataImpl(e.getTrailers))
+          case ex: PeerClosedStreamException =>
+            log.warning("Peer closed stream unexpectedly: {}", ex.getMessage)
+            INTERNAL // nobody will receive it anyway
           case other =>
-            val log = Logging(system, "akka.grpc.javadsl.GrpcExceptionHandler")
             log.error(other, "Unhandled error: [{}]", other.getMessage)
             INTERNAL
         }
     }
+  }
 
   def standard(t: Throwable, writer: GrpcProtocolWriter, system: ClassicActorSystemProvider): HttpResponse =
     standard(t, default, writer, system)


### PR DESCRIPTION
Downstream fix for https://github.com/akka/akka-http/issues/4041

As we don't have information about how to reproduce, matching the logged error message is the best I could do and I think this is where the exception is logged at error.