### PR TITLE
feat: Include information about called service in StatusRuntimeException

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/interop/AkkaGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/AkkaGrpcScalaClientTester.scala
@@ -270,6 +270,7 @@ class AkkaGrpcScalaClientTester(val settings: Settings, backend: String)(implici
     throwable shouldBe a[StatusRuntimeException]
     val e = throwable.asInstanceOf[StatusRuntimeException]
     assertEquals(expectedStatus.getCode, e.getStatus.getCode)
-    assertEquals(expectedMessage, e.getStatus.getDescription)
+    // Note: message also includes what service was called
+    assertTrue(e.getStatus.getDescription.startsWith(expectedMessage))
   }
 }

--- a/runtime/src/main/mima-filters/2.3.x.backwards.excludes/1747-status-runtime-details.excludes
+++ b/runtime/src/main/mima-filters/2.3.x.backwards.excludes/1747-status-runtime-details.excludes
@@ -1,0 +1,2 @@
+# Internal changes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.grpc.internal.AkkaHttpClientUtils.responseToSource")


### PR DESCRIPTION
References #1747 

Is this a potential leak of internal details, should it be opt in through config? Otoh, if a service built with Akka gRPC just passes thrown exceptions with details and all to a calling client they already are likely leaking that kind of details to clients?
