### PR TITLE
fix: protoPaths as import params to protoc (Maven)

### DIFF
--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -18,6 +18,9 @@
     <akka.http.cors.version>1.1.0</akka.http.cors.version>
     <grpc.version>1.48.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
+    <build-helper-maven-plugin>3.3.0</build-helper-maven-plugin>
+    <protobuf-java.version>3.22.2</protobuf-java.version>
+    <proto-google-common-protos.version>2.15.0</proto-google-common-protos.version>
   </properties>
 
   <dependencies>
@@ -41,6 +44,56 @@
   </dependencies>
   <build>
     <plugins>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>getClasspathFilenames</id>
+            <goals>
+              <!-- provides the jars of the classpath as properties inside of maven
+                   so that we can refer to one of the jars in the exec plugin config below -->
+              <goal>properties</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <!-- to use protobuf java types -->
+                <artifactItem>
+                  <groupId>com.google.protobuf</groupId>
+                  <artifactId>protobuf-java</artifactId>
+                  <version>${protobuf-java.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/proto</outputDirectory>
+                  <includes>**/*.proto</includes>
+                </artifactItem>
+
+                <!-- to use protobuf common types -->
+                <artifactItem>
+                  <groupId>com.google.api.grpc</groupId>
+                  <artifactId>proto-google-common-protos</artifactId>
+                  <version>${proto-google-common-protos.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/proto</outputDirectory>
+                  <includes>**/*.proto</includes>
+                </artifactItem>
+              </artifactItems>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>com.lightbend.akka.grpc</groupId>
         <artifactId>akka-grpc-maven-plugin</artifactId>
@@ -57,23 +110,35 @@
             <serverPowerApis>true</serverPowerApis>
           </generatorSettings>
           <includeStdTypes>true</includeStdTypes>
+          <language>Java</language>
+          <protoPaths>
+            <protoPath>target/proto</protoPath>
+            <protoPath>src/main/proto</protoPath>
+            <protoPath>src/main/protobuf</protoPath>
+          </protoPaths>
         </configuration>
       </plugin>
 
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin}</version>
         <executions>
           <execution>
-            <id>getClasspathFilenames</id>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
             <goals>
-              <!-- provides the jars of the classpath as properties inside of maven
-                   so that we can refer to one of the jars in the exec plugin config below -->
-              <goal>properties</goal>
+              <goal>add-source</goal>
             </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/akka-grpc-java/</source>
+              </sources>
+            </configuration>
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -87,6 +152,7 @@
           </arguments>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
 

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
@@ -14,7 +14,8 @@ import akka.NotUsed;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
-
+import com.google.api.HttpBody;
+import com.google.protobuf.BytesValue;
 import com.google.protobuf.Timestamp;
 import example.myapp.helloworld.grpc.*;
 
@@ -32,6 +33,16 @@ public class GreeterServiceImpl implements GreeterService {
       .setMessage("Hello, " + in.getName())
       .setTimestamp(Timestamp.newBuilder().setSeconds(1234567890).setNanos(12345).build())
       .build();
+    return CompletableFuture.completedFuture(reply);
+  }
+
+  @Override
+  public CompletionStage<HttpBody> sayHelloHttp(HelloRequest in) {
+    System.out.println("sayHelloHttp to " + in.getName());
+    HttpBody reply = HttpBody.newBuilder().setData(
+      com.google.protobuf.ByteString.copyFrom("test".getBytes())
+    ).build();
+
     return CompletableFuture.completedFuture(reply);
   }
 

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServicePowerApiImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServicePowerApiImpl.java
@@ -10,6 +10,8 @@ import akka.grpc.javadsl.Metadata;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import com.google.api.HttpBody;
+import com.google.protobuf.ByteString;
 import example.myapp.helloworld.grpc.GreeterServicePowerApi;
 import example.myapp.helloworld.grpc.HelloReply;
 import example.myapp.helloworld.grpc.HelloRequest;
@@ -31,6 +33,16 @@ public class GreeterServicePowerApiImpl implements GreeterServicePowerApi {
     String greetee = authTaggedName(in, metadata);
     System.out.println("sayHello to " + greetee);
     HelloReply reply = HelloReply.newBuilder().setMessage("Hello, " + greetee).build();
+    return CompletableFuture.completedFuture(reply);
+  }
+
+  @Override
+  public CompletionStage<HttpBody> sayHelloHttp(HelloRequest in, Metadata metadata) {
+    System.out.println("sayHelloHttp to " + in.getName());
+    HttpBody reply = HttpBody.newBuilder().setData(
+      com.google.protobuf.ByteString.copyFrom("test".getBytes())
+    ).build();
+
     return CompletableFuture.completedFuture(reply);
   }
 

--- a/plugin-tester-java/src/main/protobuf/helloworld.proto
+++ b/plugin-tester-java/src/main/protobuf/helloworld.proto
@@ -8,6 +8,9 @@ option java_outer_classname = "HelloWorldProto";
 
 package helloworld;
 
+import "google/api/annotations.proto";
+import "google/api/httpbody.proto";
+
 ////////////////////////////////////// The greeting service definition.
 service GreeterService {
     //////////////////////
@@ -16,6 +19,8 @@ service GreeterService {
     //      HELLO       //
     ////////*****/////////
     rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloHttp (HelloRequest) returns (google.api.HttpBody) {}
 
     // Comment spanning
     // on several lines


### PR DESCRIPTION
Pass all items listed in `<protoPath>` individually as `-I` to `protoc`.

Fixes:
- https://github.com/akka/akka-grpc/issues/1300
- https://github.com/akka/akka-grpc/issues/152 (examples taken from here)
- https://github.com/akka/akka-grpc/issues/686