### PR TITLE
bump: Scala 3.2.2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaVersion: [2.12, 2.13, 3.1]
+        scalaVersion: [2.12, 2.13, 3.2]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -104,7 +104,7 @@ jobs:
           - test-set: scala-2_13
             scala-version: 2.13
           - test-set: scala3
-            scala-version: 3.1
+            scala-version: 3.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,9 +26,9 @@ jobs:
           # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
 
-          - { scalaVersion: "3.1",  jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "3.1",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          - { scalaVersion: "3.2",  jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "3.2",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "3.2",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0

--- a/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcServerScala.scala
+++ b/interop-tests/src/main/scala/akka/grpc/interop/AkkaGrpcServerScala.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ Await, Future }
  */
 case class AkkaGrpcServerScala(serverHandlerFactory: ActorSystem => HttpRequest => Future[HttpResponse])
     extends GrpcServer[(ActorSystem, ServerBinding)] {
-  override def start(args: Array[String]) = {
+  override def start(args: Array[String]): (ActorSystem, ServerBinding) = {
     implicit val sys = ActorSystem()
 
     val testService = serverHandlerFactory(sys)

--- a/interop-tests/src/test/scala/akka/grpc/interop/AkkaHttpServerProviderScala.scala
+++ b/interop-tests/src/test/scala/akka/grpc/interop/AkkaHttpServerProviderScala.scala
@@ -24,7 +24,7 @@ object AkkaHttpServerProviderScala extends AkkaHttpServerProvider with Directive
   val pendingCases =
     Set()
 
-  val server = AkkaGrpcServerScala(implicit sys => {
+  val server: AkkaGrpcServerScala = AkkaGrpcServerScala(implicit sys => {
     val testServiceImpl = new TestServiceImpl()
     val testServiceHandler = TestServiceHandler(testServiceImpl)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.17"
     val scala213 = "2.13.10"
-    val scala3 = "3.1.3"
+    val scala3 = "3.2.2"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala212, scala213, scala3)

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.1.3"
+scalaVersion := "3.2.2"
 
 resolvers += Resolver.sonatypeRepo("staging")
 
@@ -9,5 +9,4 @@ enablePlugins(AkkaGrpcPlugin)
 libraryDependencies ++= Seq(
   // just to make sure it works with Scala 3 artifacts
   "com.typesafe.akka" %% "akka-http" % "10.5.0-M1",
-  "org.scalatest" %% "scalatest" % "3.2.12" % "test"
-)
+  "org.scalatest" %% "scalatest" % "3.2.12" % "test")


### PR DESCRIPTION
We decided to bump and stop supporting Scala 3.1 (https://github.com/akka/alpakka-kafka/pull/1622#discussion_r1168674439)

Should let us tag along with upstream releases of Scala PB again.