### PR TITLE
bump: Akka HTTP 2.5.0

### DIFF
--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/driver/LoadWorker.java
@@ -128,7 +128,7 @@ public class LoadWorker {
 
 
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
     ActorSystem system = ActorSystem.create("LoadWorker", conf);
     new LoadWorker(system, driverPort, serverPort).start();

--- a/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmark-java/src/main/java/akka/grpc/benchmarks/qps/AsyncServer.java
@@ -67,7 +67,7 @@ public class AsyncServer {
   public void run(InetSocketAddress address, boolean useTls) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
 
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
 
     system = ActorSystem.create("AsyncServer", conf);

--- a/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmark-java/src/test/java/akka/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -69,7 +69,7 @@ public class LoadWorkerTest extends JUnitSuite {
   @Before
   public void setup() throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
     system = ActorSystem.create("LoadWorkerTest", conf);
     mat = SystemMaterializer.get(system).materializer();

--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -195,7 +195,7 @@ Java
 It's important to enable HTTP/2 in Akka HTTP in the configuration of the `ActorSystem` by setting
 
 ```
-akka.http.server.preview.enable-http2 = on
+akka.http.server.enable-http2 = on
 ```
 
 In the example this was done from the `main` method, but you could also do this from within your `application.conf`.

--- a/docs/src/main/paradox/troubleshooting.md
+++ b/docs/src/main/paradox/troubleshooting.md
@@ -15,5 +15,5 @@ gRPC server with a client that is configured with TLS enabled.
 java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: UNAVAILABLE: Failed ALPN negotiation: Unable to find compatible protocol
 ```
 
-This may happen when `akka.http.server.preview.enable-http2` is not enabled in
+This may happen when `akka.http.server.enable-http2` is not enabled in
 the configuration.

--- a/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcServerJava.java
+++ b/interop-tests/src/main/java/akka/grpc/interop/AkkaGrpcServerJava.java
@@ -53,7 +53,7 @@ public class AkkaGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBin
   public Tuple2<ActorSystem, ServerBinding> start(String[] args) throws Exception {
     ActorSystem sys = ActorSystem.create(
       "akka-grpc-server-java",
-      ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on"));
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on"));
     Materializer mat = SystemMaterializer.get(sys).materializer();
 
     Function<HttpRequest, CompletionStage<HttpResponse>> testService = handlerFactory.apply(mat, sys);

--- a/interop-tests/src/test/resources/application.conf
+++ b/interop-tests/src/test/resources/application.conf
@@ -4,7 +4,7 @@ akka.http {
     }
     server {
         default-host-header = "localhost.com"
-        preview.enable-http2 = on
+        enable-http2 = on
         remote-address-attribute = on
     }
 }

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -35,7 +35,7 @@ import example.myapp.echo.grpc.*;
 class CombinedServer {
   public static void main(String[] args) {
       // important to enable HTTP/2 in ActorSystem's config
-      Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+      Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
       ActorSystem sys = ActorSystem.create("HelloWorld", conf);
       Materializer mat = SystemMaterializer.get(sys).materializer();

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/AuthenticatedGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/AuthenticatedGreeterServer.java
@@ -28,7 +28,7 @@ import static akka.http.javadsl.server.Directives.*;
 class AuthenticatedGreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // Akka ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
 class GreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // Akka ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
@@ -33,7 +33,7 @@ import static akka.http.javadsl.server.Directives.*;
 public class LoggingErrorHandlingGreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication());
 
     // Akka ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionStage;
 class PowerGreeterServer {
   public static void main(String[] args) throws Exception {
       // important to enable HTTP/2 in ActorSystem's config
-      Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+      Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
               .withFallback(ConfigFactory.defaultApplication());
 
       // Akka ActorSystem Boot

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
@@ -26,9 +26,8 @@ class JGreeterServiceSpec extends Matchers with AnyWordSpecLike with BeforeAndAf
 
   implicit val serverSystem: ActorSystem = {
     // important to enable HTTP/2 in server ActorSystem's config
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     val sys = ActorSystem("GreeterServer", conf)
     // make sure servers are bound before using client
     GreeterServer.run(sys).toCompletableFuture.get

--- a/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
@@ -30,9 +30,8 @@ import akka.grpc.scaladsl.WebHandler
 object CombinedServer {
   def main(args: Array[String]): Unit = {
     // important to enable HTTP/2 in ActorSystem's config
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     implicit val sys: ActorSystem = ActorSystem("HelloWorld", conf)
     implicit val ec: ExecutionContext = sys.dispatcher
 

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
@@ -18,9 +18,8 @@ object AuthenticatedGreeterServer {
   def main(args: Array[String]): Unit = {
     // Important: enable HTTP/2 in ActorSystem's config
     // We do it here programmatically, but you can also set it in the application.conf
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("HelloWorld", conf)
     new AuthenticatedGreeterServer(system).run()
     // ActorSystem threads will keep the app alive until `system.terminate()` is called

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
@@ -17,9 +17,8 @@ object GreeterServer {
   def main(args: Array[String]): Unit = {
     // Important: enable HTTP/2 in ActorSystem's config
     // We do it here programmatically, but you can also set it in the application.conf
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("HelloWorld", conf)
     new GreeterServer(system).run()
     // ActorSystem threads will keep the app alive until `system.terminate()` is called

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.scala
@@ -23,9 +23,8 @@ import scala.util.control.NonFatal
 
 object LoggingErrorHandlingGreeterServer {
   def main(args: Array[String]): Unit = {
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("Server", conf)
     new LoggingErrorHandlingGreeterServer(system).run()
   }

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -28,9 +28,8 @@ class GreeterSpec extends Matchers with AnyWordSpecLike with BeforeAndAfterAll w
 
   implicit val serverSystem: ActorSystem = {
     // important to enable HTTP/2 in server ActorSystem's config
-    val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
-      .withFallback(ConfigFactory.defaultApplication())
+    val conf =
+      ConfigFactory.parseString("akka.http.server.enable-http2 = on").withFallback(ConfigFactory.defaultApplication())
     val sys = ActorSystem("GreeterServer", conf)
     // make sure servers are bound before using client
     new GreeterServer(sys).run().futureValue

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val akka = "2.7.0"
     val akkaBinary = "2.7"
     val akkaHttp = "10.5.0"
-    val akkaHttpBinary = "10.4"
+    val akkaHttpBinary = "10.5"
 
     val grpc = "1.54.1" // checked synced by VersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
     val akka = "2.7.0"
     val akkaBinary = "2.7"
-    val akkaHttp = "10.5.0-M1"
+    val akkaHttp = "10.5.0"
     val akkaHttpBinary = "10.4"
 
     val grpc = "1.54.1" // checked synced by VersionSyncCheckPlugin

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
@@ -25,7 +25,7 @@ import example.myapp.helloworld.grpc.*;
 public class Main {
     public static void main(String[] args) throws Exception {
         // important to enable HTTP/2 in ActorSystem's config
-        Config conf = ConfigFactory.parseString("akka.http.server.preview.enable-http2 = on")
+        Config conf = ConfigFactory.parseString("akka.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
         // Akka ActorSystem Boot
         ActorSystem sys = ActorSystem.create("HelloWorld", conf);

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/resources/application.conf
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-akka.http.server.preview.enable-http2 = on
+akka.http.server.enable-http2 = on

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
@@ -21,7 +21,7 @@ import example.myapp.helloworld.grpc._
 
 object Main extends App {
     val conf = ConfigFactory
-      .parseString("akka.http.server.preview.enable-http2 = on")
+      .parseString("akka.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     implicit val sys = ActorSystem("HelloWorld", conf)
 

--- a/sbt-plugin/src/sbt-test/scala-2_13/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala-2_13/01-basic-client-server/build.sbt
@@ -8,6 +8,6 @@ enablePlugins(AkkaGrpcPlugin)
 
 libraryDependencies ++= Seq(
   // just to make sure it works with Scala 3 artifacts
-  "com.typesafe.akka" %% "akka-http" % "10.5.0-M1",
+  "com.typesafe.akka" %% "akka-http" % "10.5.0",
   "org.scalatest" %% "scalatest" % "3.2.12" % "test"
 )

--- a/sbt-plugin/src/sbt-test/scala-2_13/01-basic-client-server/src/main/resources/application.conf
+++ b/sbt-plugin/src/sbt-test/scala-2_13/01-basic-client-server/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-akka.http.server.preview.enable-http2 = on
+akka.http.server.enable-http2 = on
 
 akka.grpc.client."*" {
   backend = "akka-http"

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
@@ -8,5 +8,5 @@ enablePlugins(AkkaGrpcPlugin)
 
 libraryDependencies ++= Seq(
   // just to make sure it works with Scala 3 artifacts
-  "com.typesafe.akka" %% "akka-http" % "10.5.0-M1",
+  "com.typesafe.akka" %% "akka-http" % "10.5.0",
   "org.scalatest" %% "scalatest" % "3.2.12" % "test")

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/src/main/resources/application.conf
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-akka.http.server.preview.enable-http2 = on
+akka.http.server.enable-http2 = on
 
 akka.grpc.client."*" {
   backend = "akka-http"


### PR DESCRIPTION
Something was missed for the last two releases and we had a milestone dependency on Akka HTTP

Failure is unrelated (link validator)