### PR TITLE
perf: Thread local thread buffer for unmarshalling

### DIFF
--- a/benchmarks/src/main/scala/akka/grpc/GrpcUnmarshallingBenchmark.scala
+++ b/benchmarks/src/main/scala/akka/grpc/GrpcUnmarshallingBenchmark.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.grpc
+
+import akka.actor.ActorSystem
+import akka.grpc.internal.{ GrpcProtocolNative, GrpcRequestHelpers, Identity }
+import akka.grpc.scaladsl.{ GrpcMarshalling, ScalapbProtobufSerializer }
+import akka.http.scaladsl.model.Uri
+import akka.stream.scaladsl.Source
+import grpc.reflection.v1alpha.reflection._
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class GrpcUnmarshallingBenchmark extends CommonBenchmark {
+  implicit val system: ActorSystem = ActorSystem("bench")
+  implicit val writer: GrpcProtocol.GrpcProtocolWriter = GrpcProtocolNative.newWriter(Identity)
+  implicit val reader: GrpcProtocol.GrpcProtocolReader = GrpcProtocolNative.newReader(Identity)
+  implicit val serializer: ScalapbProtobufSerializer[ServerReflectionRequest] =
+    ServerReflection.Serializers.ServerReflectionRequestSerializer
+
+  val request = GrpcRequestHelpers(
+    Uri("https://unused.example/" + ServerReflection.name + "/ServerReflectionInfo"),
+    Nil,
+    Source.single(ServerReflectionRequest()))
+
+  @Benchmark
+  def unmarshall(): ServerReflectionRequest = {
+    Await.result(GrpcMarshalling.unmarshal(request), 3.seconds)
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    system.terminate()
+  }
+}

--- a/runtime/src/main/scala/akka/grpc/ProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/ProtobufSerializer.scala
@@ -8,9 +8,11 @@ import akka.grpc.internal.ByteStringUtils
 import akka.util.ByteString
 
 import java.io.InputStream
+import java.nio.ByteBuffer
 
 trait ProtobufSerializer[T] {
   def serialize(t: T): ByteString
   def deserialize(bytes: ByteString): T
   def deserialize(stream: InputStream): T = deserialize(ByteStringUtils.fromInputStream(stream))
+  def deserialize(buffer: ByteBuffer): T
 }

--- a/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/GoogleProtobufSerializer.scala
@@ -10,6 +10,7 @@ import akka.util.ByteString
 import com.google.protobuf.Parser
 
 import java.io.InputStream
+import java.nio.ByteBuffer
 
 @ApiMayChange
 class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[T]) extends ProtobufSerializer[T] {
@@ -24,4 +25,6 @@ class GoogleProtobufSerializer[T <: com.google.protobuf.Message](parser: Parser[
     parser.parseFrom(bytes.toArray)
   override def deserialize(data: InputStream): T =
     parser.parseFrom(data)
+  override def deserialize(buffer: ByteBuffer): T =
+    parser.parseFrom(buffer)
 }

--- a/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/ScalapbProtobufSerializer.scala
@@ -11,6 +11,7 @@ import com.google.protobuf.CodedInputStream
 import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
 
 import java.io.InputStream
+import java.nio.ByteBuffer
 
 @ApiMayChange
 class ScalapbProtobufSerializer[T <: GeneratedMessage](companion: GeneratedMessageCompanion[T])
@@ -18,7 +19,10 @@ class ScalapbProtobufSerializer[T <: GeneratedMessage](companion: GeneratedMessa
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
   override def deserialize(bytes: ByteString): T =
-    companion.parseFrom(CodedInputStream.newInstance(bytes.asByteBuffer))
+    deserialize(bytes.asByteBuffer)
+
   override def deserialize(data: InputStream): T =
     companion.parseFrom(data)
+  override def deserialize(buffer: ByteBuffer): T =
+    companion.parseFrom(CodedInputStream.newInstance(buffer))
 }


### PR DESCRIPTION
Last optimisation from #1391

Trying to optimise deserialisation by going via byte buffer.
Couldn't see a perf improvement on aarch64 in a microbench, so needs further investigation.


