### PR TITLE
chore: fix fossa excludes using paths

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,14 +1,10 @@
 version: 3
 # https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
 
-targets:
+paths:
   # exclude non-distributed projects from dependency scanning
   exclude:
-    - type: scala
-      path: benchmarks
-    - type: scala
-      path: interop-tests
-    - type: scala
-      path: plugin-tester-java
-    - type: scala
-      path: plugin-tester-scala
+    - benchmarks
+    - interop-tests
+    - plugin-tester-java
+    - plugin-tester-scala


### PR DESCRIPTION
Fossa was not skipping the excluded targets. Couldn't figure out why or how to make target excludes work here. Switch to path excludes (as we're using for akka).

`fossa analyze --output` before:

```
12 projects scanned;  0 skipped,  12 succeeded,  0 failed,  18 analysis warnings

* maven project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-java/": succeeded with 4 warnings
* maven project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-scala/": succeeded with 4 warnings
* scala project in "/Users/peter/dev/akka/akka-grpc/benchmarks/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/codegen/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/interop-tests/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/maven-plugin/target/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-java/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-scala/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/runtime/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/sbt-plugin/target/scala-2.12/sbt-1.0/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/scalapb-protoc-plugin/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/target/scala-2.12/": succeeded with 1 warning
```

With path excludes it skips the excluded projects:

```
12 projects scanned;  6 skipped,  6 succeeded,  0 failed,  6 analysis warnings

* scala project in "/Users/peter/dev/akka/akka-grpc/codegen/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/maven-plugin/target/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/runtime/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/sbt-plugin/target/scala-2.12/sbt-1.0/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/scalapb-protoc-plugin/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/target/scala-2.12/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-grpc/benchmarks/target/scala-2.12/": skipped (exclusion filters)
* scala project in "/Users/peter/dev/akka/akka-grpc/interop-tests/target/scala-2.12/": skipped (exclusion filters)
* maven project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-java/": skipped (exclusion filters)
* scala project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-java/target/scala-2.12/": skipped (exclusion filters)
* maven project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-scala/": skipped (exclusion filters)
* scala project in "/Users/peter/dev/akka/akka-grpc/plugin-tester-scala/target/scala-2.12/": skipped (exclusion filters)
```
