### PR TITLE
fix: Fail queued requests on connection failure

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientSpec.scala
@@ -1,0 +1,55 @@
+package akka.grpc.scaladsl
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.model.HttpResponse
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import example.myapp.helloworld.grpc.helloworld.{ GreeterServiceClient, HelloRequest }
+import org.scalatest.Inspectors.forAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.util.{ Failure, Success }
+
+class AkkaHttpClientSpec
+    extends TestKit(
+      ActorSystem(
+        "GrpcExceptionHandlerSpec",
+        ConfigFactory
+          .parseString("""
+           akka.grpc.client."*".backend = "akka-http"
+          akka.http.client.http2.max-persistent-attempts = 2
+        """.stripMargin)
+          .withFallback(ConfigFactory.load())))
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures {
+
+  "The Akka HTTP client backend" should {
+    "fail queued requests when connection fails" in {
+
+      // Note that the Akka HTTP client does not strictly adhere to the gRPC backoff protocol but has its own
+      // backoff algorithm
+      val client = GreeterServiceClient(GrpcClientSettings.connectToServiceAt("127.0.0.1", 5).withTls(false))
+
+      val futures = (1 to 10).map { _ =>
+        client.sayHello(HelloRequest())
+      }
+      // all should be failed
+      import system.dispatcher
+      // FIXME the one in the pipe is still not failed :/
+      val lifted = Future.sequence(futures.tail.map(_.map(Success(_)).recover {
+        case th: Throwable => Failure[HttpResponse](th)
+      }))
+      val results = lifted.futureValue(timeout(5.seconds))
+      forAll(results) { it =>
+        it.isFailure should be(true)
+      }
+    }
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
     // We don't force Akka updates because downstream projects can upgrade
     // themselves. For more information see
     // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-    val akka = "2.7.0"
-    val akkaBinary = "2.7"
+    val akka = "2.9.0-M1+3-09367f8c-SNAPSHOT"
+    val akkaBinary = "2.9"
     val akkaHttp = "10.5.0"
     val akkaHttpBinary = "10.5"
 
@@ -42,6 +42,9 @@ object Dependencies {
     val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % Versions.akkaHttp
     val akkaDiscovery = "com.typesafe.akka" %% "akka-discovery" % Versions.akka
     val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % Versions.akka
+
+    // FIXME remove when updating to AKka HTTP version without dependency to ssl-config-core
+    val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.1"
 
     val akkaHttpCors = ("ch.megard" %% "akka-http-cors" % "1.2.0") // Apache v2
       .excludeAll(ExclusionRule(organization = "com.typesafe.akka")) // needed to not pull in 2.13 deps for Scala 3
@@ -77,6 +80,8 @@ object Dependencies {
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test"
     val akkaTestkitTyped = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka % "test"
     val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka % "test"
+    val grpcStub = Compile.grpcStub % Test
+    val scalapbRuntime = Compile.scalapbRuntime % Test
   }
 
   object Runtime {
@@ -117,6 +122,7 @@ object Dependencies {
     Compile.akkaHttp,
     Compile.akkaDiscovery,
     Compile.akkaHttpCors % "provided",
+    Compile.sslConfig,
     Test.akkaTestkit,
     Test.akkaStreamTestkit,
     Test.scalaTest,


### PR DESCRIPTION
Refs #1423

Trying out the change in https://github.com/akka/akka/pull/32062

Works except the initial request triggering the connection, which is not failed, so an additional fix in Akka HTTP is likely needed.