### PR TITLE
chore: Drop Scala 2.12

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaVersion: [2.12, 2.13, 3.3]
+        scalaVersion: [2.13, 3.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -98,9 +98,9 @@ jobs:
       matrix:
         include:
           - test-set: gen-scala-server
-            scala-version: 2.12
+            scala-version: 2.13
           - test-set: gen-java
-            scala-version: 2.12
+            scala-version: 2.13
           - test-set: scala-2_13
             scala-version: 2.13
           - test-set: scala3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Code style check and binary-compatibility check
         run: |-
           cp .jvmopts-ghactions .jvmopts
-          sbt scalafmtCheckAll scalafmtSbtCheck headerCheckAll grpcVersionSyncCheck googleProtobufVersionSyncCheck +mimaReportBinaryIssues
+          sbt scalafmtCheckAll scalafmtSbtCheck headerCheckAll grpcVersionSyncCheck googleProtobufVersionSyncCheck mimaReportBinaryIssues
 
   compile-benchmarks:
     name: Compile Benchmarks

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,10 +18,6 @@ jobs:
       matrix:
         include:
           # leaving out combinations covered in `build-test.yml`
-          - { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
-
           - { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
           # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }

--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 enablePlugins(AkkaGrpcPlugin)
 
 run / javaOptions ++= List("-Xms1g", "-Xmx1g", "-XX:+PrintGCDetails", "-XX:+PrintGCTimeStamps")

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val codegen = Project(id = akkaGrpcCodegenId, base = file("codegen"))
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
       Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
-    scalaVersion := scala212)
+    scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head)
   .settings(addArtifact((Compile / assembly / artifact), assembly))
   .settings(addArtifact(Artifact(akkaGrpcCodegenId, "bat", "bat", "bat"), mkBatAssemblyTask))
 
@@ -48,6 +48,7 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
   .settings(VersionGenerator.settings)
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
+    scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     mimaFailOnNoPrevious := true,
     mimaPreviousArtifacts :=
       (if (scalaVersion.value.startsWith("2"))
@@ -218,7 +219,7 @@ lazy val pluginTesterScala = Project(id = "akka-grpc-plugin-tester-scala", base 
     (publish / skip) := true,
     fork := true,
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
-    scalaVersion := scala212,
+    scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
   .pluginTestingSettings
 
@@ -230,7 +231,7 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
     fork := true,
     ReflectiveCodeGen.generatedLanguages := Seq("Java"),
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
-    scalaVersion := scala212,
+    scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"))
   .pluginTestingSettings
 

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -28,7 +28,7 @@ Variables to be expanded in this template:
 
 - [ ] Check [API](https://doc.akka.io/api/akka-grpc/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/docs/akka-grpc/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release on [Maven central](https://repo1.maven.org/maven2/com/lightbend/akka/grpc/akka-grpc-scalapb-protoc-plugin_2.12/$VERSION$/)
+- [ ] Check the release on [Maven central](https://repo1.maven.org/maven2/com/lightbend/akka/grpc/akka-grpc-scalapb-protoc-plugin_2.13/$VERSION$/)
 
 ### When everything is on maven central
   - [ ] Log into `gustav.akka.io` as `akkarepo` 

--- a/docs/src/main/paradox/client/walkthrough.md
+++ b/docs/src/main/paradox/client/walkthrough.md
@@ -58,7 +58,7 @@ Maven
   <dependencies>
     <dependency>
       <groupId>com.lightbend.akka.grpc</groupId>
-      <artifactId>akka-grpc-runtime_2.12</artifactId>
+      <artifactId>akka-grpc-runtime_2.13</artifactId>
       <version>${akka.grpc.version}</version>
     </dependency>
     <!-- for loading of cert, issue #89 -->
@@ -113,10 +113,10 @@ For example, this is the definition of a Hello World service:
 From this definition, Akka gRPC generates interfaces that look like this:
 
 Scala
-:  @@snip [helloworld.proto](/plugin-tester-scala/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala)
+:  @@snip [helloworld.proto](/plugin-tester-scala/target/scala-2.13/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala)
 
 Java
-:  @@snip [helloworld.proto](/plugin-tester-java/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java)
+:  @@snip [helloworld.proto](/plugin-tester-java/target/scala-2.13/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java)
 
 and model @scala[case ]classes for `HelloRequest` and `HelloResponse`.
 

--- a/docs/src/main/paradox/server/grpc-web.md
+++ b/docs/src/main/paradox/server/grpc-web.md
@@ -48,7 +48,7 @@ Additionally, add the dependency as below.
 
 @@dependency[sbt,Maven,Gradle] {
   group="ch.megard"
-  artifact="akka-http-cors_2.12"
+  artifact="akka-http-cors_2.13"
   version="0.4.2"
 }
 

--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -64,7 +64,7 @@ Maven
       <dependencies>
         <dependency>
           <groupId>com.lightbend.akka.grpc</groupId>
-          <artifactId>akka-grpc-runtime_2.12</artifactId>
+          <artifactId>akka-grpc-runtime_2.13</artifactId>
           <version>${akka.grpc.version}</version>
         </dependency>
       </dependencies>
@@ -129,10 +129,10 @@ mvn akka-grpc:generate
 From the above definition, Akka gRPC generates interfaces that look like this:
 
 Scala
-:  @@snip [helloworld.proto](/plugin-tester-scala/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala)
+:  @@snip [helloworld.proto](/plugin-tester-scala/target/scala-2.13/src_managed/main/example/myapp/helloworld/grpc/GreeterService.scala)
 
 Java
-:  @@snip [helloworld.proto](/plugin-tester-java/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java)
+:  @@snip [helloworld.proto](/plugin-tester-java/target/scala-2.13/src_managed/main/example/myapp/helloworld/grpc/GreeterService.java)
 
 and model @scala[case ]classes for `HelloRequest` and `HelloResponse`.
 

--- a/gradle-plugin/src/test/groovy/helper/BaseSpec.groovy
+++ b/gradle-plugin/src/test/groovy/helper/BaseSpec.groovy
@@ -30,7 +30,7 @@ plugins {
   id '$PLUGIN_CODE'
 }
 project.dependencies {
-    implementation "com.typesafe.scala-logging:scala-logging_2.12:3.9.2"
+    implementation "com.typesafe.scala-logging:scala-logging_2.13:3.9.2"
 }
 """
     }

--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -15,7 +15,7 @@ repositories {
   mavenLocal()
 }
 
-def scalaVersion = org.gradle.util.VersionNumber.parse(System.getenv("TRAVIS_SCALA_VERSION") ?: "2.12")
+def scalaVersion = org.gradle.util.VersionNumber.parse(System.getenv("TRAVIS_SCALA_VERSION") ?: "2.13")
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 def akkaVersion = "2.7.0"
 

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -27,17 +27,17 @@
   <dependencies>
     <dependency>
       <groupId>com.lightbend.akka.grpc</groupId>
-      <artifactId>akka-grpc-runtime_2.12</artifactId>
+      <artifactId>akka-grpc-runtime_2.13</artifactId>
       <version>${akka.grpc.project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-pki_2.12</artifactId>
+      <artifactId>akka-pki_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.megard</groupId>
-      <artifactId>akka-http-cors_2.12</artifactId>
+      <artifactId>akka-http-cors_2.13</artifactId>
       <version>${akka.http.cors.version}</version>
     </dependency>
 

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -10,7 +10,7 @@ repositories {
   mavenLocal()
 }
 
-def scalaVersion = org.gradle.util.VersionNumber.parse(System.getenv("TRAVIS_SCALA_VERSION") ?: "2.12")
+def scalaVersion = org.gradle.util.VersionNumber.parse(System.getenv("TRAVIS_SCALA_VERSION") ?: "2.13")
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 def akkaVersion = "2.7.0"
 

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -22,37 +22,37 @@
   <dependencies>
     <dependency>
       <groupId>com.lightbend.akka.grpc</groupId>
-      <artifactId>akka-grpc-runtime_2.12</artifactId>
+      <artifactId>akka-grpc-runtime_2.13</artifactId>
       <version>${akka.grpc.project.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.megard</groupId>
-      <artifactId>akka-http-cors_2.12</artifactId>
+      <artifactId>akka-http-cors_2.13</artifactId>
       <version>${akka.http.cors.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream-testkit_2.12</artifactId>
+      <artifactId>akka-stream-testkit_2.13</artifactId>
       <version>${akka.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-actor-testkit-typed_2.12</artifactId>
+      <artifactId>akka-actor-testkit-typed_2.13</artifactId>
       <version>${akka.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-pki_2.12</artifactId>
+      <artifactId>akka-pki_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.12</artifactId>
+      <artifactId>scalatest_2.13</artifactId>
       <version>3.0.5</version>
       <scope>test</scope>
     </dependency>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val scala3 = "3.3.1"
 
     // the order in the list is important because the head will be considered the default.
-    val CrossScalaForLib = Seq(scala212, scala213, scala3)
+    val CrossScalaForLib = Seq(scala213, scala3)
     val CrossScalaForPlugin = Seq(scala212)
 
     // We don't force Akka updates because downstream projects can upgrade

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -1,6 +1,4 @@
-// Can be removed when we move to 2.12.14
-// https://github.com/akka/akka-grpc/pull/1279
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.11"
 
 resolvers += Resolver.sonatypeRepo("staging")
 

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/test
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/test
@@ -1,9 +1,9 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java
+$ exists target/scala-2.13/akka-grpc
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java
 
 > doc

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
@@ -1,6 +1,4 @@
-// Can be removed when we move to 2.12.14
-// https://github.com/akka/akka-grpc/pull/1279
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.11"
 
 resolvers += Resolver.sonatypeRepo("staging")
 

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/test
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/test
@@ -1,7 +1,7 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java
+$ exists target/scala-2.13/akka-grpc
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloReply.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.java
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceClient.java

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
@@ -1,6 +1,4 @@
-// Can be removed when we move to 2.12.14
-// https://github.com/akka/akka-grpc/pull/1279
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.11"
 
 resolvers += Resolver.sonatypeRepo("staging")
 

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/test
@@ -1,3 +1,3 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc/main/helloworld/Helloworld.java
+$ exists target/scala-2.13/akka-grpc/main/helloworld/Helloworld.java

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -1,6 +1,4 @@
-// Can be removed when we move to 2.12.14
-// https://github.com/akka/akka-grpc/pull/1279
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.11"
 
 resolvers += Resolver.sonatypeRepo("staging")
 

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
@@ -1,6 +1,4 @@
-// Can be removed when we move to 2.12.14
-// https://github.com/akka/akka-grpc/pull/1279
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.11"
 
 resolvers += Resolver.sonatypeRepo("staging")
 

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/test
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/test
@@ -1,3 +1,3 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc/main/helloworld/Helloworld.java
+$ exists target/scala-2.13/akka-grpc/main/helloworld/Helloworld.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 organization := "com.lightbend.akka.grpc"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/scala/akka/grpc/TestServiceImpl.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/scala/akka/grpc/TestServiceImpl.scala
@@ -68,7 +68,7 @@ class TestServiceImpl(implicit sys: ActorSystem) extends TestService {
           Status.fromCodeValue(reqStatus.code).withDescription(reqStatus.message)))
       req
     }).mapConcat(
-      _.responseParameters.to[immutable.Seq]).via(parametersToResponseFlow)
+      _.responseParameters.toList).via(parametersToResponseFlow)
 
   override def halfDuplexCall(in: Source[StreamingOutputCallRequest, NotUsed]): Source[StreamingOutputCallResponse, NotUsed] = ???
 
@@ -82,7 +82,7 @@ class TestServiceImpl(implicit sys: ActorSystem) extends TestService {
   }
 
   override def streamingOutputCall(in: StreamingOutputCallRequest): Source[StreamingOutputCallResponse, NotUsed] =
-    Source(in.responseParameters.to[immutable.Seq]).via(parametersToResponseFlow)
+    Source(in.responseParameters.toList).via(parametersToResponseFlow)
 
   override def unimplementedCall(in: Empty): Future[Empty] = ???
 }

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 scalacOptions += "-Xfatal-warnings"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/test
@@ -1,9 +1,9 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
+$ exists target/scala-2.13/akka-grpc
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
 
 # This will for example detect when we publish generated code that is
 # already in scalapb-runtime

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/test
@@ -1,15 +1,15 @@
 > test:compile
 
 # the Scala server was generated in Compile
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
 
 # only the Scala client was generated in Test
--$ exists target/scala-2.12/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
-$ exists target/scala-2.12/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+-$ exists target/scala-2.13/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+$ exists target/scala-2.13/akka-grpc/test/example/myapp/helloworld/grpc/GreeterServiceClient.scala
 
 > it:protocGenerate
 
 # only the Java server was generated in IntegrationTest
--$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
--$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceClient.scala
-$ exists target/scala-2.12/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandlerFactory.java
+-$ exists target/scala-2.13/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandler.scala
+-$ exists target/scala-2.13/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceClient.scala
+$ exists target/scala-2.13/akka-grpc/it/example/myapp/helloworld/grpc/GreeterServiceHandlerFactory.java

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
@@ -64,7 +64,7 @@ object Main extends App {
       ServiceHandler.concatOrNotFound(
         greeterPartial,
         echoPartial,
-        reflection),
+        reflection)
     //#server-reflection-manual-concat
 
 }

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/test
@@ -1,6 +1,6 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc/main
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
+$ exists target/scala-2.13/akka-grpc/main
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/test
@@ -1,6 +1,6 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc
-$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloRequest.scala
-$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloworldProto.scala
-$ exists target/scala-2.12/akka-grpc/main/helloworld/GreeterService.scala
+$ exists target/scala-2.13/akka-grpc
+$ exists target/scala-2.13/akka-grpc/main/helloworld/HelloRequest.scala
+$ exists target/scala-2.13/akka-grpc/main/helloworld/HelloworldProto.scala
+$ exists target/scala-2.13/akka-grpc/main/helloworld/GreeterService.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 // Disable for now because of: https://github.com/protocolbuffers/protobuf-javascript/issues/127

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/test
@@ -1,10 +1,10 @@
 > compile
 
 # Disabled for now because of: https://github.com/protocolbuffers/protobuf-javascript/issues/127
-# $ exists target/scala-2.12/resource_managed/main/js/hellorequest.js
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+# $ exists target/scala-2.13/resource_managed/main/js/hellorequest.js
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
 
 > test:compile
 # Disabled for now because of: https://github.com/protocolbuffers/protobuf-javascript/issues/127
-# $ exists target/scala-2.12/resource_managed/test/js/echomessage.js
-$ exists target/scala-2.12/akka-grpc/test/example/myapp/echo/grpc/EchoMessage.scala
+# $ exists target/scala-2.13/resource_managed/test/js/echomessage.js
+$ exists target/scala-2.13/akka-grpc/test/example/myapp/echo/grpc/EchoMessage.scala

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-27/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-akka-27/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/test
@@ -1,5 +1,5 @@
 > protocGenerate
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
-$ exists target/scala-2.12/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloRequest.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/HelloworldProto.scala
+$ exists target/scala-2.13/akka-grpc/main/example/myapp/helloworld/grpc/GreeterService.scala
 > compile

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 //#setup

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.13.11"
+
 resolvers += Resolver.sonatypeRepo("staging")
 
 enablePlugins(AkkaGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/test
@@ -1,6 +1,6 @@
 > compile
 
-$ exists target/scala-2.12/akka-grpc
-$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloRequest.scala
-$ exists target/scala-2.12/akka-grpc/main/helloworld/HelloworldProto.scala
-$ exists target/scala-2.12/akka-grpc/main/helloworld/GreeterService.scala
+$ exists target/scala-2.13/akka-grpc
+$ exists target/scala-2.13/akka-grpc/main/helloworld/HelloRequest.scala
+$ exists target/scala-2.13/akka-grpc/main/helloworld/HelloworldProto.scala
+$ exists target/scala-2.13/akka-grpc/main/helloworld/GreeterService.scala


### PR DESCRIPTION
* build plugins are still on 2.12

See https://github.com/akka/akka/pull/32125
