### PR TITLE
build: Disable unidoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,10 +177,8 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
   .settings(
     name := "Akka gRPC",
     publish / skip := true,
-    makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     previewPath := (Paradox / siteSubdirName).value,
     Preprocess / siteSubdirName := s"api/akka-grpc/${projectInfoVersion.value}",
-    Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Paradox / siteSubdirName := s"docs/akka-grpc/${projectInfoVersion.value}",
     // Make sure code generation is ran before paradox:
     (Compile / paradox) := (Compile / paradox).dependsOn(Compile / compile).value,
@@ -236,7 +234,6 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
   .pluginTestingSettings
 
 lazy val root = Project(id = "akka-grpc", base = file("."))
-  .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(SitePlugin, MimaPlugin)
   .aggregate(
     runtime,
@@ -252,13 +249,6 @@ lazy val root = Project(id = "akka-grpc", base = file("."))
   .settings(
     (publish / skip) := true,
     (Compile / headerCreate / unmanagedSources) := (baseDirectory.value / "project").**("*.scala").get,
-    // unidoc combines sources and jars from all subprojects and that
-    // might include some incompatible ones. Depending on the
-    // classpath order that might lead to scaladoc compilation errors.
-    // the scalapb compilerplugin has a scalapb/package$.class that conflicts
-    // with the one from the scalapb runtime, so for that reason we don't produce
-    // unidoc for the codegen projects:
-    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(runtime),
     // https://github.com/sbt/sbt/issues/3465
     // Libs and plugins must share a version. The root project must use that
     // version (and set the crossScalaVersions as empty list) so each sub-project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.51")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
-addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 
 // For RawText


### PR DESCRIPTION
Disabling for now, unidoc expects 2.12 artifacts for some reason, didn't manage to force it onto 2.13 with `scalaVersion`. Can see that it lists 2.12 as `compilers` but didn't get further than that.