### PR TITLE
fix: Fail queued requests on connection failure #1423

### DIFF
--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientConnectionFailSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientConnectionFailSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.grpc.scaladsl
 
 import akka.actor.ActorSystem

--- a/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientConnectionFailSpec.scala
+++ b/interop-tests/src/test/scala/akka/grpc/scaladsl/AkkaHttpClientConnectionFailSpec.scala
@@ -1,0 +1,55 @@
+package akka.grpc.scaladsl
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.model.HttpResponse
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import example.myapp.helloworld.grpc.helloworld.{ GreeterServiceClient, HelloRequest }
+import org.scalatest.Inspectors.forAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.util.{ Failure, Success }
+
+class AkkaHttpClientConnectionFailSpec
+    extends TestKit(
+      ActorSystem(
+        "GrpcExceptionHandlerSpec",
+        ConfigFactory
+          .parseString("""
+           akka.grpc.client."*".backend = "akka-http"
+          akka.http.client.http2.max-persistent-attempts = 2
+        """.stripMargin)
+          .withFallback(ConfigFactory.load())))
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures {
+
+  "The Akka HTTP client backend" should {
+    "fail queued requests when connection fails" in {
+
+      // Note that the Akka HTTP client does not strictly adhere to the gRPC backoff protocol but has its own
+      // backoff algorithm
+      val client = GreeterServiceClient(GrpcClientSettings.connectToServiceAt("127.0.0.1", 5).withTls(false))
+
+      val futures = (1 to 10).map { _ =>
+        client.sayHello(HelloRequest())
+      }
+      // all should be failed
+      import system.dispatcher
+      // FIXME the first one in the pipe is still not failed :/ needs a fix in Akka HTTP
+      val lifted = Future.sequence(futures.tail.map(_.map(Success(_)).recover {
+        case th: Throwable => Failure[HttpResponse](th)
+      }))
+      val results = lifted.futureValue(timeout(5.seconds))
+      forAll(results) { it =>
+        it.isFailure should be(true)
+      }
+    }
+  }
+
+}

--- a/runtime/src/main/scala/akka/grpc/internal/SwitchOnCancel.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/SwitchOnCancel.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.grpc.internal
 
 import akka.stream.Attributes

--- a/runtime/src/main/scala/akka/grpc/internal/SwitchOnCancel.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/SwitchOnCancel.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.grpc.internal
+
+import akka.stream.Attributes
+import akka.stream.FanOutShape2
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import akka.util.OptionVal
+
+/**
+ * Identity stage that feeds all incoming events to output 1 until it cancels, then switches over to output 2, after
+ * completing the materialized value future.
+ *
+ * INTERNAL API
+ * @tparam T
+ */
+final private[akka] class SwitchOnCancel[T] extends GraphStage[FanOutShape2[T, T, (Throwable, T)]] {
+
+  val in = Inlet[T]("in")
+  val mainOut = Outlet[T]("mainOut")
+  val failoverOut = Outlet[(Throwable, T)]("failoverOut")
+
+  override def shape: FanOutShape2[T, T, (Throwable, T)] = new FanOutShape2(in, mainOut, failoverOut)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    var failedOver: OptionVal[Throwable] = OptionVal.None
+
+    setHandler(
+      in,
+      new InHandler {
+        override def onPush(): Unit = {
+          val elem = grab(in)
+          failedOver match {
+            case OptionVal.Some(error) => push(failoverOut, (error, elem))
+            case _                     => push(mainOut, elem)
+          }
+
+        }
+      })
+
+    setHandler(
+      mainOut,
+      new OutHandler {
+        override def onPull(): Unit =
+          pull(in)
+
+        override def onDownstreamFinish(cause: Throwable): Unit = {
+          // on downstream cancel or failure switch to second out
+          failedOver = OptionVal.Some(cause)
+          if (isAvailable(failoverOut) && !hasBeenPulled(in)) {
+            pull(in)
+          }
+        }
+      })
+
+    setHandler(
+      failoverOut,
+      new OutHandler {
+        override def onPull(): Unit = {
+          // may have been pulled and then failed over
+          if (!hasBeenPulled(in)) pull(in)
+        }
+      })
+
+  }
+
+}


### PR DESCRIPTION
Without any stuff introduced in Akka streams, a switch over operator that will drain/continue to fail requests put in the buffer. Still doesn't fail the first request triggering the connection fail inside Akka HTTP/2 infra.

References #1423

Superseedes #1831

Related fix for failing the triggering request in Akka HTTP: https://github.com/akka/akka-http/pull/4322
