### PR TITLE
fix: Avoid NPE in GrpcMetadataImpl #1854

### DIFF
--- a/runtime/src/main/scala/akka/grpc/GrpcServiceException.scala
+++ b/runtime/src/main/scala/akka/grpc/GrpcServiceException.scala
@@ -39,7 +39,11 @@ object GrpcServiceException {
 
     val statusRuntimeException = StatusProto.toStatusRuntimeException(status.build)
 
-    new GrpcServiceException(statusRuntimeException.getStatus, new GrpcMetadataImpl(statusRuntimeException.getTrailers))
+    new GrpcServiceException(
+      statusRuntimeException.getStatus,
+      new GrpcMetadataImpl(
+        // might not be present
+        Option(statusRuntimeException.getTrailers).getOrElse(new io.grpc.Metadata())))
   }
 
   private def toJavaProto(scalaPbSource: com.google.protobuf.any.Any): com.google.protobuf.Any = {
@@ -50,7 +54,12 @@ object GrpcServiceException {
   }
 
   def apply(ex: StatusRuntimeException): GrpcServiceException = {
-    new GrpcServiceException(ex.getStatus, new RichGrpcMetadataImpl(ex.getStatus, ex.getTrailers))
+    new GrpcServiceException(
+      ex.getStatus,
+      new RichGrpcMetadataImpl(
+        ex.getStatus,
+        // might not be present
+        Option(ex.getTrailers).getOrElse(new io.grpc.Metadata())))
   }
 }
 

--- a/runtime/src/main/scala/akka/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/MetadataImpl.scala
@@ -91,6 +91,7 @@ import scalapb.{ GeneratedMessage, GeneratedMessageCompanion }
  */
 @InternalApi
 class GrpcMetadataImpl(delegate: io.grpc.Metadata) extends Metadata {
+  require(delegate != null, "Metadata delegate must be present")
   private lazy val map = delegate.keys.iterator.asScala.map(key => key -> getEntries(key)).toMap
 
   override def getText(key: String): Option[String] =


### PR DESCRIPTION
Exception may not have any trailers. Also, fail fast if created with null delegate in some place we don't expected.

References #1854
