### PR TITLE
bump: grpc 1.58.0

### DIFF
--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -9,7 +9,7 @@ run / javaOptions ++= List("-Xms1g", "-Xmx1g", "-XX:+PrintGCDetails", "-XX:+Prin
 // generate both client and server (default) in Java
 akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java)
 
-val grpcVersion = "1.54.2" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.58.0" // checked synced by VersionSyncCheckPlugin
 
 val runtimeProject = ProjectRef(file("../"), "akka-grpc-runtime")
 

--- a/build.sbt
+++ b/build.sbt
@@ -234,6 +234,7 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
   .settings(
     (publish / skip) := true,
     fork := true,
+    PB.protocVersion := Dependencies.Versions.googleProtobuf,
     ReflectiveCodeGen.generatedLanguages := Seq("Java"),
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
@@ -5,11 +5,11 @@ import org.gradle.api.Project
 
 class AkkaGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "3.21.12" // checked synced by VersionSyncCheckPlugin
+    static final String PROTOC_VERSION = "3.22.3" // checked synced by VersionSyncCheckPlugin
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 
-    static final String GRPC_VERSION = "1.54.2" // checked synced by VersionSyncCheckPlugin
+    static final String GRPC_VERSION = "1.58.0" // checked synced by VersionSyncCheckPlugin
 
     static final String PLUGIN_CODE = 'com.lightbend.akka.grpc.gradle'
 

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -94,7 +94,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${akka-grpc.outputDirectory}</outputDirectory>
-	<protocVersion implementation="java.lang.String" default-value="-v3.21.12">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+	<protocVersion implementation="java.lang.String" default-value="-v3.22.3">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>
@@ -185,7 +185,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${akka-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v3.21.12">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v3.22.3">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -16,7 +16,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <akka.http.cors.version>1.1.0</akka.http.cors.version>
     <akka.version>2.9.0-M3</akka.version>
-    <grpc.version>1.54.2</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.58.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
     <build-helper-maven-plugin>3.3.0</build-helper-maven-plugin>
     <protobuf-java.version>3.22.2</protobuf-java.version>

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <akka.version>2.9.0-M3</akka.version>
     <akka.http.cors.version>0.4.2</akka.http.cors.version>
-    <grpc.version>1.54.2</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.58.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,11 +22,11 @@ object Dependencies {
     val akkaHttp = "10.6.0-M2"
     val akkaHttpBinary = "10.6"
 
-    val grpc = "1.54.2" // checked synced by VersionSyncCheckPlugin
+    val grpc = "1.58.0" // checked synced by VersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and akka.grpc.sbt.AkkaGrpcPlugin
-    val googleProtobuf = "3.21.12" // checked synced by VersionSyncCheckPlugin
+    val googleProtobuf = "3.22.3" // checked synced by VersionSyncCheckPlugin
     val googleApi = "2.23.0"
 
     val scalaTest = "3.2.12"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -4,7 +4,7 @@ resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
 organization := "com.lightbend.akka.grpc"
 
-val grpcVersion = "1.54.2" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.58.0" // checked synced by VersionSyncCheckPlugin
 
 libraryDependencies ++= Seq(
   "io.grpc" % "grpc-interop-testing" % grpcVersion % "protobuf-src",


### PR DESCRIPTION
* guava dependency to 32.0.1 to address CVE-2023-2976
* protobuf-java 3.22.3 to align with grpc 1.58.0
* plugin-tester-java wasn't setting protoc version when inside sbt

See release notes https://github.com/grpc/grpc-java/releases

Still some problem in interop-tests...