### PR TITLE
build: Build and publish scaladocs for runtime module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import akka.grpc.Dependencies
 import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
-import akka.grpc.ProjectExtensions.*
+import akka.grpc.ProjectExtensions._
 import akka.grpc.build.ReflectiveCodeGen
 import sbt.Keys.scalaVersion
 import com.geirsson.CiReleasePlugin

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 import akka.grpc.Dependencies
 import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
-import akka.grpc.ProjectExtensions._
+import akka.grpc.ProjectExtensions.*
 import akka.grpc.build.ReflectiveCodeGen
-import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.*
 import sbt.Keys.scalaVersion
 import com.geirsson.CiReleasePlugin
+import com.typesafe.sbt.site.util.SiteHelpers
 
 val akkaGrpcRuntimeName = "akka-grpc-runtime"
 
@@ -176,11 +177,20 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     (publish / skip) := true)
 
+// Config to allow only building scaladocs for runtime module but in/from the docs module
+val Runtime = config("runtime")
+
 lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
 // Make sure code generation is ran:
   .dependsOn(pluginTesterScala)
   .dependsOn(pluginTesterJava)
-  .enablePlugins(SitePreviewPlugin, AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
+  .enablePlugins(
+    SitePreviewPlugin,
+    AkkaParadoxPlugin,
+    ParadoxSitePlugin,
+    PreprocessPlugin,
+    PublishRsyncPlugin,
+    SiteScaladocPlugin)
   .disablePlugins(MimaPlugin, CiReleasePlugin)
   .settings(
     name := "Akka gRPC",
@@ -219,6 +229,14 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head)
+  .settings(
+    // only the publish API docs for the runtime, inlined instead of using SiteScaladocPlugin.scaladocSettings
+    // to be able to reference the `projectInfoVersion` in the sub dir path
+    inConfig(Runtime)(
+      Seq(
+        siteSubdirName := s"api/akka-grpc/${projectInfoVersion.value}",
+        mappings := (runtime / Compile / packageDoc / mappings).value)) ++
+    SiteHelpers.addMappingsToSiteDir(Runtime / mappings, Runtime / siteSubdirName))
 
 lazy val pluginTesterScala = Project(id = "akka-grpc-plugin-tester-scala", base = file("plugin-tester-scala"))
   .disablePlugins(MimaPlugin, CiReleasePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import akka.grpc.Dependencies
 import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
 import akka.grpc.ProjectExtensions.*
 import akka.grpc.build.ReflectiveCodeGen
-import com.typesafe.tools.mima.core.*
 import sbt.Keys.scalaVersion
 import com.geirsson.CiReleasePlugin
 import com.typesafe.sbt.site.util.SiteHelpers
@@ -178,7 +177,7 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
     (publish / skip) := true)
 
 // Config to allow only building scaladocs for runtime module but in/from the docs module
-val Runtime = config("runtime")
+val AkkaGrpcRuntime = config("akkaGrpcRuntime")
 
 lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
 // Make sure code generation is ran:
@@ -232,11 +231,11 @@ lazy val docs = Project(id = "akka-grpc-docs", base = file("docs"))
   .settings(
     // only the publish API docs for the runtime, inlined instead of using SiteScaladocPlugin.scaladocSettings
     // to be able to reference the `projectInfoVersion` in the sub dir path
-    inConfig(Runtime)(
+    inConfig(AkkaGrpcRuntime)(
       Seq(
         siteSubdirName := s"api/akka-grpc/${projectInfoVersion.value}",
         mappings := (runtime / Compile / packageDoc / mappings).value)) ++
-    SiteHelpers.addMappingsToSiteDir(Runtime / mappings, Runtime / siteSubdirName))
+    SiteHelpers.addMappingsToSiteDir(AkkaGrpcRuntime / mappings, AkkaGrpcRuntime / siteSubdirName))
 
 lazy val pluginTesterScala = Project(id = "akka-grpc-plugin-tester-scala", base = file("plugin-tester-scala"))
   .disablePlugins(MimaPlugin, CiReleasePlugin)


### PR DESCRIPTION
We previously had to disable unidoc in #1847 because of the tricky build with 2.12 for plugins but 2.13 only for the runtime. This re-introduces at least scaladoc for the runtime module, published under akka-grpc/api/[version].