### PR TITLE
build: Bump plugins to only fetch from maven central

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -7,7 +7,6 @@ import akka.grpc.Dependencies.Versions.{ scala212, scala213, scala3 }
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import com.typesafe.tools.mima.plugin.MimaKeys._
-import sbtprotoc.ProtocPlugin.autoImport.PB
 import xerial.sbt.Sonatype
 
 object Common extends AutoPlugin {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,9 +18,9 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 // docs
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.54")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.4")
-addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
+addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.3")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 
 // For RawText


### PR DESCRIPTION
As the other repos are unstable/going away: https://contributors.scala-lang.org/t/roadmap-for-the-sbt-community-repository/6195