### PR TITLE
fix: do not publish sbt-akka-gprc jar twice (under two different names)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,8 +125,7 @@ lazy val sbtPlugin = Project(id = "sbt-akka-grpc", base = file("sbt-plugin"))
     scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head,
     publishConfiguration := publishConfiguration.value.withArtifacts(
       // avoid publishing the plugin jar twice
-      publishConfiguration.value.artifacts.filter(_._1.name.contains("2.12_1.0"))
-    ))
+      publishConfiguration.value.artifacts.filter(_._1.name.contains("2.12_1.0"))))
   .dependsOn(codegen)
 
 lazy val interopTests = Project(id = "akka-grpc-interop-tests", base = file("interop-tests"))

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,11 @@ lazy val sbtPlugin = Project(id = "sbt-akka-grpc", base = file("sbt-plugin"))
     },
     scriptedBufferLog := false,
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
-    scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head)
+    scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head,
+    publishConfiguration := publishConfiguration.value.withArtifacts(
+      // avoid publishing the plugin jar twice
+      publishConfiguration.value.artifacts.filter(_._1.name.contains("2.12_1.0"))
+    ))
   .dependsOn(codegen)
 
 lazy val interopTests = Project(id = "akka-grpc-interop-tests", base = file("interop-tests"))


### PR DESCRIPTION
Before this PR, it seems that for the `sbt-akka-grpc` submodule, a `publish` does publish the plugin jar twice as follows:
- `sbt-akka-grpc_2.12_1.0-2.4.1.jar` and
- `sbt-akka-grpc-2.4.1.jar`.

Both files are identical, just carry a different name.

This has caused some issues on the hosting side of things, so this PR removes one of the two artifacts during `publish`.