### PR TITLE
build: filter out 2.12_1.0 artifacs to fix publishing of sbt-akka-grpc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ lazy val sbtPlugin = Project(id = "sbt-akka-grpc", base = file("sbt-plugin"))
     scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head,
     publishSignedConfiguration := publishSignedConfiguration.value.withArtifacts(
       // avoid publishing the plugin jar twice
-      publishSignedConfiguration.value.artifacts.filter(_._1.name.contains("2.12_1.0"))))
+      publishSignedConfiguration.value.artifacts.filter(!_._1.name.contains("2.12_1.0"))))
   .dependsOn(codegen)
 
 lazy val interopTests = Project(id = "akka-grpc-interop-tests", base = file("interop-tests"))


### PR DESCRIPTION
Only after https://github.com/akka/akka-grpc/pull/1911 got merged and released, it showed that the wrong artifacts were filtered out.