### PR TITLE
docs: Build tool with resolver config in more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ The Akka family of projects is managed by teams at [Lightbend](https://lightbend
 
 ## Project Status
 
-This library is ready to be used in production, but API's and build system plugins are still expected to be improved and [may change](https://doc.akka.io/docs/akka/current/common/may-change.html).
+This library is ready to be used in production
 
 The API on both sides (Client and Server) is a simple Akka Streams-based one.
 
-The client side is
-currently implemented on top of [io.grpc:grpc-netty-shaded](https://mvnrepository.com/artifact/io.grpc/grpc-netty-shaded),
-we plan to replace this by just [io.grpc:grpc-core](https://mvnrepository.com/artifact/io.grpc/grpc-core) and [Akka HTTP](https://doc.akka.io/docs/akka-http/current).
+The client side is currently implemented on top of [io.grpc:grpc-netty-shaded](https://mvnrepository.com/artifact/io.grpc/grpc-netty-shaded) with an [Akka HTTP](https://doc.akka.io/docs/akka-http/current) client 
+backend alternative available.
 
 As for performance, we are currently relying on the JVM TLS implementation,
 which is sufficient for many use cases, but is planned to be replaced with

--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -13,7 +13,32 @@ By default both client and server are generated and Java or Scala is autodetecte
 
 ### Installation
 
-Follow the initial instructions in @ref[client walkthrough](../client/walkthrough.md) or @ref[server walkthrough](../server/walkthrough.md) to set the plugin up.
+To add the Akka gRPC gradle plugin to a project:
+
+```gradle
+buildscript {
+  repositories {
+    gradlePluginPortal()
+    maven {
+      url "https://repo.akka.io/maven"
+    }
+  }
+}
+plugins {
+  id 'java'
+  id 'application'
+  id 'com.lightbend.akka.grpc.gradle' version '$project.version$'
+}
+repositories {
+  mavenCentral()
+  maven {
+    url "https://repo.akka.io/maven"
+  }
+}
+```
+
+
+For a step by step getting started with Akka gRPC read the @ref[client](../client/index.md) or @ref[server](../server/index.md) introductions.
 
 ### Available plugin options
 

--- a/docs/src/main/paradox/buildtools/maven.md
+++ b/docs/src/main/paradox/buildtools/maven.md
@@ -1,11 +1,71 @@
 # Maven
 
-To get started with Akka gRPC read the @ref[client](../client/index.md) or @ref[server](../server/index.md) introductions.
+```xml
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Project name</name>
+  <groupId>com.example</groupId>
+  <artifactId>my-grpc-app</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <properties>
+    <akka.grpc.version>$project.version$</akka.grpc.version>
+    <grpc.version>$grpc.version$</grpc.version>
+    <project.encoding>UTF-8</project.encoding>
+  </properties>
+  <repositories>
+    <repository>
+      <id>akka-repository</id>
+      <name>Akka library repository</name>
+      <url>https://repo.akka.io/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>akka-repository</id>
+      <name>Akka library repository</name>
+      <url>https://repo.akka.io/maven</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.lightbend.akka.grpc</groupId>
+      <artifactId>akka-grpc-runtime_2.13</artifactId>
+      <version>${akka.grpc.version}</version>
+    </dependency>
+    <!-- for loading of cert, issue #89 -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.lightbend.akka.grpc</groupId>
+        <artifactId>akka-grpc-maven-plugin</artifactId>
+        <version>${akka.grpc.version}</version>
+        <!-- Hook the generate goal into the lifecycle,
+             automatically tied to generate-sources -->
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+For a step by step getting started with Akka gRPC read the @ref[client](../client/index.md) or @ref[server](../server/index.md) introductions.
 
 ## Configuring what to generate
 
 The plugin can be configured to generate either Java or Scala classes, and then server and or client for the chosen language.
-By default both client and server in Java are generated.
+By default, both client and server in Java are generated.
 
 Java
 :   ```xml

--- a/docs/src/main/paradox/buildtools/sbt.md
+++ b/docs/src/main/paradox/buildtools/sbt.md
@@ -1,6 +1,18 @@
 # sbt
 
-To get started with Akka gRPC read the @ref[client](../client/index.md) or @ref[server](../server/index.md) introductions.
+To add the sbt plugin and Akka gRPC dependencies to a project:
+
+```scala
+// in project/plugins.sbt:
+resolvers += "Akka library repository".at("https://repo.akka.io/maven")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "$project.version$")
+//
+// in build.sbt:
+resolvers += "Akka library repository".at("https://repo.akka.io/maven")
+enablePlugins(AkkaGrpcPlugin)
+```
+
+For a step by step getting started with Akka gRPC read the @ref[client](../client/index.md) or @ref[server](../server/index.md) introductions.
 
 ## Configuring what to generate
 

--- a/docs/src/main/paradox/client/walkthrough.md
+++ b/docs/src/main/paradox/client/walkthrough.md
@@ -50,7 +50,7 @@ repositories {
 
 Maven
 :   @@@vars
-```
+```xml
 <project>
   <modelVersion>4.0.0</modelVersion>
   <name>Project name</name>


### PR DESCRIPTION
Backed out on @octonato s suggestion to add it also to the README, with the three different build tools it just becomes a pages long scroll unless you happened to like the first build tool best.