### PR TITLE
Fix binary trailer decoding

### DIFF
--- a/runtime/src/test/scala/akka/grpc/internal/AkkaHttpClientUtilsSpec.scala
+++ b/runtime/src/test/scala/akka/grpc/internal/AkkaHttpClientUtilsSpec.scala
@@ -34,26 +34,35 @@ class AkkaHttpClientUtilsSpec extends TestKit(ActorSystem()) with AnyWordSpecLik
       val source = AkkaHttpClientUtils.responseToSource(requestUri, response, null, false)
 
       val failure = source.run().failed.futureValue
+      failure shouldBe a[StatusRuntimeException]
       // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
       failure.asInstanceOf[StatusRuntimeException].getStatus.getCode should be(Status.Code.UNIMPLEMENTED)
     }
 
     "map a strict 200 response with non-0 gRPC error code to a failed stream" in {
       val requestUri = Uri("https://example.com/GuestExeSample/GrpcHello")
-      val responseHeaders = List(RawHeader("grpc-status", "9"), RawHeader("custom-key", "custom-value-in-header"))
+      val responseHeaders = RawHeader("grpc-status", "9") ::
+        RawHeader("custom-key", "custom-value-in-header") ::
+        RawHeader("custom-key-bin", ByteString("custom-trailer-value").encodeBase64.utf8String) ::
+        Nil
       val response =
         Future.successful(HttpResponse(OK, responseHeaders, Strict(GrpcProtocolNative.contentType, ByteString.empty)))
       val source = AkkaHttpClientUtils.responseToSource(requestUri, response, null, false)
 
       val failure = source.run().failed.futureValue
+      failure shouldBe a[StatusRuntimeException]
       failure.asInstanceOf[StatusRuntimeException].getStatus.getCode should be(Status.Code.FAILED_PRECONDITION)
       failure.asInstanceOf[StatusRuntimeException].getTrailers.get(key) should be("custom-value-in-header")
+      failure.asInstanceOf[StatusRuntimeException].getTrailers.get(keyBin) should be(ByteString("custom-trailer-value"))
     }
 
     "map a strict 200 response with non-0 gRPC error code with a trailer to a failed stream with trailer metadata" in {
       val requestUri = Uri("https://example.com/GuestExeSample/GrpcHello")
       val responseHeaders = List(RawHeader("grpc-status", "9"))
-      val responseTrailers = Trailer(RawHeader("custom-key", "custom-trailer-value") :: Nil)
+      val responseTrailers = Trailer(
+        RawHeader("custom-key", "custom-trailer-value") ::
+        RawHeader("custom-key-bin", ByteString("custom-trailer-value").encodeBase64.utf8String) ::
+        Nil)
       val response = Future.successful(
         new HttpResponse(
           OK,
@@ -64,11 +73,14 @@ class AkkaHttpClientUtilsSpec extends TestKit(ActorSystem()) with AnyWordSpecLik
       val source = AkkaHttpClientUtils.responseToSource(requestUri, response, null, false)
 
       val failure = source.run().failed.futureValue
+      failure shouldBe a[StatusRuntimeException]
       failure.asInstanceOf[StatusRuntimeException].getStatus.getCode should be(Status.Code.FAILED_PRECONDITION)
       failure.asInstanceOf[StatusRuntimeException].getTrailers should not be null
       failure.asInstanceOf[StatusRuntimeException].getTrailers.get(key) should be("custom-trailer-value")
+      failure.asInstanceOf[StatusRuntimeException].getTrailers.get(keyBin) should be(ByteString("custom-trailer-value"))
     }
 
     lazy val key = Metadata.Key.of("custom-key", Metadata.ASCII_STRING_MARSHALLER)
+    lazy val keyBin = Metadata.Key.of("custom-key-bin", Metadata.BINARY_BYTE_MARSHALLER)
   }
 }


### PR DESCRIPTION
In https://github.com/akka/akka-grpc/pull/1906 I introduced a bug in the trailer decoding where I didn't take into consideration that there are "ASCII headers" and "binary headers"

This PR adds a failure test and the fix in separate commits