### PR TITLE
feat: Eager connect flag for Netty based client

### DIFF
--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -58,6 +58,17 @@ class GreeterSpec extends Matchers with AnyWordSpecLike with BeforeAndAfterAll w
       val reply = clients.head.sayHello(HelloRequest("Alice"))
       reply.futureValue should ===(HelloReply("Hello, Alice", Some(Timestamp.apply(123456, 123))))
     }
+
+    "reply to single request (eager connect client)" in {
+      val eagerClient = GreeterServiceClient(
+        GrpcClientSettings
+          .connectToServiceAt("127.0.0.1", 8080)(clientSystem.asInstanceOf[ClassicActorSystemProvider])
+          .withEagerConnection(true)
+          .withTls(false))(clientSystem.asInstanceOf[ClassicActorSystemProvider])
+      // no clear way to test it actually connected eagerly, but at least cover that it works
+      val reply = eagerClient.sayHello(HelloRequest("Alice"))
+      reply.futureValue should ===(HelloReply("Hello, Alice", Some(Timestamp.apply(123456, 123))))
+    }
   }
 
   "GreeterServicePowerApi" should {

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -6,6 +6,10 @@ akka.grpc.client."*" {
   # Host to use if service-discovery-mechanism is set to static or grpc-dns
   host = ""
 
+  # Service discovery mechamism to use. The default is to use a static host
+  # and port that will be resolved via DNS.
+  # Any of the mechanisms described in https://doc.akka.io/docs/akka-management/current/discovery/index.html can be used
+  # including Kubernetes, Consul, AWS API
   service-discovery {
     mechanism = "static"
     # Service name to use if a service-discovery.mechanism other than static or grpc-dns
@@ -54,9 +58,9 @@ akka.grpc.client."*" {
   # interpreted as retrying 'indefinitely'.
   connection-attempts = 20
 
-  # Service discovery mechamism to use. The default is to use a static host
-  # and port that will be resolved via DNS.
-  # Any of the mechanisms described in https://doc.akka.io/docs/akka-management/current/discovery/index.html can be used
-  # including Kubernetes, Consul, AWS API
+  # Request that the client try to connect the service immediately when the client is created
+  # rather than on the first request. Only supported for the Netty client backend, the akka-http client backend
+  # is always eager.
+  eager-connection = off
 }
 //#defaults

--- a/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/NettyClientUtils.scala
@@ -125,6 +125,9 @@ object NettyClientUtils {
         channelClosedPromise.tryFailure(e)
     }
 
+    if (settings.eagerConnection)
+      channel.getState(true)
+
     new InternalChannel {
       override def shutdown() = channel.shutdown()
       override def done = channelClosedPromise.future


### PR DESCRIPTION
Will casue the client creation to trigger connection to server rather than first on initial request, can help avoiding latency for the first requests caused by waiting for connection to complete.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #1930
