### PR TITLE
fix: Java API for rich errors was not usable from Java

### DIFF
--- a/docs/src/main/paradox/client/details.md
+++ b/docs/src/main/paradox/client/details.md
@@ -84,6 +84,6 @@ Scala
 :  @@snip [GreeterClient.scala](/interop-tests/src/test/scala/akka/grpc/scaladsl/RichErrorModelNativeSpec.scala) { #client_request }
 
 Java
-:  @@snip[RichErrorModelSpec](/interop-tests/src/test/java/example/myapp/helloworld/grpc/RichErrorModelNativeTest.java) { #client_request }
+:  @@snip[RichErrorModelSpec](/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorModelNativeTest.java) { #client_request }
 
 Please look @ref[here](../server/details.md) how to create errors with such details on the server side.

--- a/docs/src/main/paradox/server/details.md
+++ b/docs/src/main/paradox/server/details.md
@@ -52,6 +52,6 @@ Scala
 :    @@snip[RichErrorModelSpec](/interop-tests/src/test/scala/akka/grpc/scaladsl/RichErrorModelNativeSpec.scala) { #rich_error_model_unary }
 
 Java
-:    @@snip[RichErrorModelTest](/interop-tests/src/test/java/example/myapp/helloworld/grpc/RichErrorNativeImpl.java) { #rich_error_model_unary }
+:    @@snip[RichErrorModelTest](/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorNativeImpl.java) { #rich_error_model_unary }
 
 Please look @ref[here](../client/details.md) how to handle this on the client.

--- a/docs/src/main/paradox/server/details.md
+++ b/docs/src/main/paradox/server/details.md
@@ -46,7 +46,8 @@ Java
 ## Rich error model
 Beyond status codes you can also use the [Rich error model](https://www.grpc.io/docs/guides/error/#richer-error-model).  
 
-This example uses an error model taken from [common protobuf](https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto) but every class that is based on `scalapb.GeneratedMessage` can be used. Build and return the error as an `AkkaGrpcException`:
+This example uses an error model taken from [common protobuf](https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto) but every class that is based on @scala[`scalapb.GeneratedMessage`]@java[`com.google.protobuf.Message`] can be used. 
+Build and return the error as an `AkkaGrpcException`:
 
 Scala
 :    @@snip[RichErrorModelSpec](/interop-tests/src/test/scala/akka/grpc/scaladsl/RichErrorModelNativeSpec.scala) { #rich_error_model_unary }

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorModelNativeTest.java
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorModelNativeTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2018-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package example.myapp.helloworld.grpc;
+package example.myapp.helloworld;
 
 import akka.actor.ActorSystem;
 import akka.grpc.GrpcClientSettings;
@@ -12,9 +12,10 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import com.google.rpc.error_details.LocalizedMessage;
+import com.google.rpc.LocalizedMessage;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import example.myapp.helloworld.grpc.*;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.Assert;
@@ -71,9 +72,9 @@ public class RichErrorModelNativeTest extends JUnitSuite {
             assertEquals(Status.INVALID_ARGUMENT.getCode().value(), meta.getCode());
             assertEquals("What is wrong?", meta.getMessage());
 
-            LocalizedMessage details = meta.getParsedDetails(LocalizedMessage.messageCompanion()).get(0);
-            assertEquals("The password!", details.message());
-            assertEquals("EN", details.locale());
+            LocalizedMessage details = meta.getParsedDetails(LocalizedMessage.getDefaultInstance()).get(0);
+            Assert.assertEquals("The password!", details.getMessage());
+            Assert.assertEquals("EN", details.getLocale());
             // #client_request
 
         } catch (Exception e) {

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorNativeImpl.java
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/RichErrorNativeImpl.java
@@ -2,13 +2,18 @@
  * Copyright (C) 2018-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package example.myapp.helloworld.grpc;
+package example.myapp.helloworld;
 
 import akka.NotUsed;
 import akka.grpc.GrpcServiceException;
 import akka.stream.javadsl.Source;
+import com.google.api.HttpBody;
+import com.google.protobuf.Message;
 import com.google.rpc.Code;
-import com.google.rpc.error_details.LocalizedMessage;
+import com.google.rpc.LocalizedMessage;
+import example.myapp.helloworld.grpc.GreeterService;
+import example.myapp.helloworld.grpc.HelloReply;
+import example.myapp.helloworld.grpc.HelloRequest;
 
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
@@ -20,8 +25,8 @@ public class RichErrorNativeImpl implements GreeterService {
     @Override
     public CompletionStage<HelloReply> sayHello(HelloRequest in) {
 
-        ArrayList<scalapb.GeneratedMessage> ar = new ArrayList<>();
-        ar.add(LocalizedMessage.of("EN", "The password!"));
+        ArrayList<Message> ar = new ArrayList<>();
+        ar.add(LocalizedMessage.newBuilder().setLocale("EN").setMessage("The password!").build());
 
         GrpcServiceException exception = GrpcServiceException.create(
                 Code.INVALID_ARGUMENT,
@@ -34,6 +39,12 @@ public class RichErrorNativeImpl implements GreeterService {
         return future;
     }
     // #rich_error_model_unary
+
+
+    @Override
+    public CompletionStage<HttpBody> sayHelloHttp(HelloRequest in) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 
     @Override
     public CompletionStage<HelloReply> itKeepsTalking(Source<HelloRequest, NotUsed> in) {

--- a/runtime/src/main/mima-filters/2.4.1.backwards.excludes/java-rich-errors.excludes
+++ b/runtime/src/main/mima-filters/2.4.1.backwards.excludes/java-rich-errors.excludes
@@ -1,0 +1,4 @@
+# This breaks compatibility but Java users could likely never use it anyway (scalpb message type as parameter)
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.grpc.GrpcServiceException.create")
+# not for user extension
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.javadsl.MetadataStatus.getParsedDetails")

--- a/runtime/src/main/scala/akka/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/MetadataImpl.scala
@@ -246,6 +246,15 @@ class JavaMetadataImpl(val delegate: Metadata) extends javadsl.Metadata with jav
 
   def getParsedDetails[K <: GeneratedMessage](companion: GeneratedMessageCompanion[K]): jList[K] =
     richDelegate.getParsedDetails(companion).asJava
+
+  def getParsedDetails[K <: com.google.protobuf.GeneratedMessageV3](messageType: K): jList[K] = {
+    val parser = messageType.getParserForType
+    val messageTypeUrl = s"type.googleapis.com/${messageType.getDescriptorForType.getFullName}"
+    richDelegate.details.collect {
+      case scalaPbAny if scalaPbAny.typeUrl == messageTypeUrl =>
+        parser.parseFrom(scalaPbAny.value).asInstanceOf[K]
+    }.asJava
+  }
 }
 
 class RichGrpcMetadataImpl(delegate: io.grpc.Status, meta: io.grpc.Metadata)

--- a/runtime/src/main/scala/akka/grpc/javadsl/Metadata.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/Metadata.scala
@@ -4,7 +4,7 @@
 
 package akka.grpc.javadsl
 
-import java.util.{ List, Map, Optional }
+import java.util.{ List => JList, Map => JMap, Optional }
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.util.ByteString
 import akka.japi.Pair
@@ -35,13 +35,13 @@ trait Metadata {
    * @return A map from keys to a list of metadata entries. Entries with the same key will be ordered based on
    *         when they were added or received.
    */
-  def asMap(): Map[String, List[MetadataEntry]]
+  def asMap(): JMap[String, JList[MetadataEntry]]
 
   /**
    * @return A list of (key, entry) pairs. Pairs with the same key will be ordered based on when they were added
    *         or received.
    */
-  def asList(): List[Pair[String, MetadataEntry]]
+  def asList(): JList[Pair[String, MetadataEntry]]
 
   /**
    * @return Returns the scaladsl.Metadata interface for this instance.
@@ -61,6 +61,9 @@ trait MetadataStatus extends Metadata {
   def getStatus(): com.google.rpc.Status
   def getCode(): Int
   def getMessage(): String
-  def getDetails(): List[com.google.protobuf.any.Any]
-  def getParsedDetails[K <: scalapb.GeneratedMessage](companion: scalapb.GeneratedMessageCompanion[K]): List[K]
+  def getDetails(): JList[com.google.protobuf.any.Any]
+  @deprecated(message = "Use the new getParsedDetails overload taking a Java protobuf message type instead")
+  def getParsedDetails[K <: scalapb.GeneratedMessage](companion: scalapb.GeneratedMessageCompanion[K]): JList[K]
+
+  def getParsedDetails[K <: com.google.protobuf.GeneratedMessageV3](defaultMessage: K): JList[K]
 }


### PR DESCRIPTION
We were accepting the ScalaPB generated top message type in the Java API which likely means no Java project could ever use the detailed errors. 

This breaks binary and source compatibility but since it is unlikely that anyone could really make use of the API I think that is fine.