### PR TITLE
chore: Exclude samples from FOSSA scan

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -9,3 +9,4 @@ paths:
     - native-image-tests
     - plugin-tester-java
     - plugin-tester-scala
+    - samples


### PR DESCRIPTION
Exclude the samples directory from the FOSSA scanning during analysis. lightbend/akka-meta#488

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
