### PR TITLE
Provide access to akka-http request/response attributes

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -156,7 +156,7 @@ public class @{serviceName}HandlerFactory {
     private static CompletionStage<akka.http.javadsl.model.HttpResponse> handle(akka.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, akka.japi.Function<ActorSystem, akka.japi.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
       return GrpcMarshalling.negotiated(request, (reader, writer) -> {
         final CompletionStage<akka.http.javadsl.model.HttpResponse> response;
-        @{if(powerApis) { "Metadata metadata = MetadataBuilder.fromHeaders(request.getHeaders());" } else { "" }}
+        @{if(powerApis) { "Metadata metadata = MetadataBuilder.fromHttpMessage(request);" } else { "" }}
         switch(method) {
           @for(method <- service.methods) {
           case "@method.grpcName":

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -119,7 +119,7 @@ object @{serviceName}Handler {
           (method match {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
-                @{if(powerApis) { "val metadata = MetadataBuilder.fromHeaders(request.headers)" } else { "" }}
+                @{if(powerApis) { "val metadata = MetadataBuilder.fromHttpMessage(request)" } else { "" }}
                 @{method.unmarshal}(request.entity)(@method.deserializer.name, mat, reader)
                   .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
                   .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))

--- a/runtime/src/main/mima-filters/2.4.3.backwards.excludes/metadata-attributes.excludes
+++ b/runtime/src/main/mima-filters/2.4.3.backwards.excludes/metadata-attributes.excludes
@@ -1,0 +1,5 @@
+# not for user extension
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.javadsl.Metadata.getAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.scaladsl.Metadata.akka$grpc$scaladsl$Metadata$_setter_$rawHttpMessage_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.scaladsl.Metadata.rawHttpMessage")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.grpc.scaladsl.Metadata.attribute")

--- a/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaHttpClientUtils.scala
@@ -303,10 +303,10 @@ object AkkaHttpClientUtils {
                   .mapMaterializedValue(_ =>
                     Future.successful(new GrpcResponseMetadata() {
                       override def headers: akka.grpc.scaladsl.Metadata =
-                        new HeaderMetadataImpl(response.headers)
+                        new HttpMessageMetadataImpl(response)
 
                       override def getHeaders(): akka.grpc.javadsl.Metadata =
-                        new JavaMetadataImpl(new HeaderMetadataImpl(response.headers))
+                        new JavaMetadataImpl(new HttpMessageMetadataImpl(response))
 
                       override def trailers: Future[akka.grpc.scaladsl.Metadata] =
                         trailerPromise.future.map(new HeaderMetadataImpl(_))

--- a/runtime/src/main/scala/akka/grpc/javadsl/Metadata.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/Metadata.scala
@@ -4,11 +4,12 @@
 
 package akka.grpc.javadsl
 
-import java.util.{ List => JList, Map => JMap, Optional }
+import java.util.{ Optional, List => JList, Map => JMap }
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.util.ByteString
 import akka.japi.Pair
 import akka.grpc.scaladsl
+import akka.http.javadsl.model.AttributeKey
 
 /**
  * Immutable representation of the metadata in a call
@@ -47,6 +48,14 @@ trait Metadata {
    * @return Returns the scaladsl.Metadata interface for this instance.
    */
   def asScala: scaladsl.Metadata
+
+  /**
+   * Get an attribute from the underlying akka-http message associated with this metadata.
+   *
+   * Will return `None` if this metadata is not associated with an akka-http request or response, for example,
+   * if using the netty client support.
+   */
+  def getAttribute[T](key: AttributeKey[T]): Optional[T]
 }
 
 /**

--- a/runtime/src/main/scala/akka/grpc/javadsl/MetadataBuilder.scala
+++ b/runtime/src/main/scala/akka/grpc/javadsl/MetadataBuilder.scala
@@ -5,12 +5,11 @@
 package akka.grpc.javadsl
 
 import java.lang.{ Iterable => jIterable }
-
 import akka.annotation.ApiMayChange
 
 import scala.collection.JavaConverters._
-import akka.http.javadsl.model.HttpHeader
-import akka.http.scaladsl.model.{ HttpHeader => sHttpHeader }
+import akka.http.javadsl.model.{ HttpHeader, HttpMessage }
+import akka.http.scaladsl.model.{ HttpHeader => sHttpHeader, HttpMessage => sHttpMessage }
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.util.ByteString
 import akka.grpc.scaladsl
@@ -68,6 +67,22 @@ object MetadataBuilder {
    */
   def fromHeaders(headers: jIterable[HttpHeader]): Metadata =
     new JavaMetadataImpl(scaladsl.MetadataBuilder.fromHeaders(headers.asScala.map(asScala).toList))
+
+  /**
+   * Constructs a Metadata instance from an HTTP message.
+   *
+   * @param message The HTTP message.
+   * @return The metadata instance.
+   */
+  def fromHttpMessage(message: HttpMessage): Metadata = {
+    message match {
+      // All HTTP messages should be scaladsl HttpMessages
+      case s: sHttpMessage => new JavaMetadataImpl(scaladsl.MetadataBuilder.fromHttpMessage(s))
+      // If not, just pass the headers
+      case _ => fromHeaders(message.getHeaders)
+    }
+
+  }
 
   /**
    * Converts from a javadsl.HttpHeader to a scaladsl.HttpHeader.

--- a/runtime/src/main/scala/akka/grpc/scaladsl/Metadata.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/Metadata.scala
@@ -5,6 +5,7 @@
 package akka.grpc.scaladsl
 
 import akka.annotation.{ ApiMayChange, DoNotInherit, InternalApi }
+import akka.http.scaladsl.model.{ AttributeKey, HttpMessage }
 import akka.util.ByteString
 import com.google.protobuf.any
 
@@ -21,6 +22,7 @@ import com.google.protobuf.any
    */
   @InternalApi
   private[grpc] val raw: Option[io.grpc.Metadata] = None
+  private[grpc] val rawHttpMessage: Option[HttpMessage] = None
 
   /**
    * @return The text header value for `key` if one exists, if the same key has multiple values the last occurrence
@@ -45,6 +47,14 @@ import com.google.protobuf.any
    */
   @ApiMayChange
   def asList: List[(String, MetadataEntry)]
+
+  /**
+   * Get an attribute from the underlying akka-http message associated with this metadata.
+   *
+   * Will return `None` if this metadata is not associated with an akka-http request or response, for example,
+   * if using the netty client support.
+   */
+  def attribute[T](key: AttributeKey[T]): Option[T]
 }
 
 /**

--- a/runtime/src/main/scala/akka/grpc/scaladsl/MetadataBuilder.scala
+++ b/runtime/src/main/scala/akka/grpc/scaladsl/MetadataBuilder.scala
@@ -6,9 +6,9 @@ package akka.grpc.scaladsl
 
 import scala.collection.immutable
 import akka.annotation.{ ApiMayChange, DoNotInherit }
-import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.{ HttpHeader, HttpMessage }
 import akka.util.ByteString
-import akka.grpc.internal.{ EntryMetadataImpl, HeaderMetadataImpl, MetadataImpl }
+import akka.grpc.internal.{ EntryMetadataImpl, HeaderMetadataImpl, HttpMessageMetadataImpl, MetadataImpl }
 
 /**
  * This class provides an interface for constructing immutable Metadata instances.
@@ -78,4 +78,14 @@ object MetadataBuilder {
    */
   def fromHeaders(headers: immutable.Seq[HttpHeader]): Metadata =
     new HeaderMetadataImpl(headers)
+
+  /**
+   * Creates a Metadata instance from an HTTP message.
+   *
+   * @param message The message
+   * @return The new Metadata instance.
+   */
+  def fromHttpMessage(message: HttpMessage): Metadata =
+    new HttpMessageMetadataImpl(message)
+
 }


### PR DESCRIPTION
Fixes #859

This adds an `attribute`/`getAttribute` method to `Metadata`, and connects it to the underlying request/response that the metadata has been sourced from.

I haven't implemented passing attributes on from user created metadata, I'm not sure if there's a use case for that.