### PR TITLE
perf: Trailers only support

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/AkkaNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/AkkaNettyGrpcClientGraphStage.scala
@@ -102,6 +102,10 @@ private final class AkkaNettyGrpcClientGraphStage[I, O](
         override def onMessage(message: O): Unit =
           callback.invoke(message)
         override def onClose(status: Status, trailers: Metadata): Unit = {
+          if (!matVal.isCompleted) {
+            // Trailers only response, first invoke onHeaders to setup the materialized value
+            onHeaders(trailers)
+          }
           trailerPromise.success(trailers)
           callback.invoke(Closed(status, trailers))
         }


### PR DESCRIPTION
An optimisation exists in the gRPC spec that allows responses that immediately return an error to return it as a "Trailers-Only" response. This is where the response has no body, rather, the `grpc-status`, `grpc-message` and `grpc-status-details-bin` trailers are placed in the response headers frame.

When adding support for this, I found a bug in the Akka gRPC client where trailers only responses were not correctly handled in streamed requests (the error returned to the client code was an `AbruptStageTerminationException`).