### PR TITLE
chore: missing interpolator

### DIFF
--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -139,7 +139,7 @@ object @{serviceName}Handler {
         case request if isThisService(request.uri.path) =>
           request.uri.path.tail.tail match {
             case model.Uri.Path.Slash(model.Uri.Path.Segment(method, model.Uri.Path.Empty)) => handle(spi.onRequest(prefix, method, request), method)
-            case _ => scala.concurrent.Future.failed(new akka.grpc.GrpcServiceException(io.grpc.Status.INVALID_ARGUMENT.withDescription("Invalid gRPC request path [${request.uri.path}]")))
+            case _ => scala.concurrent.Future.failed(new akka.grpc.GrpcServiceException(io.grpc.Status.INVALID_ARGUMENT.withDescription(s"Invalid gRPC request path [${request.uri.path}]")))
           }
       }
     }


### PR DESCRIPTION
Noticed in Akka Projections when updating to 2.4.4

```
[error] /home/runner/work/akka-projection/akka-projection/akka-projection-grpc/target/scala-2.13/akka-grpc/main/akka/projection/grpc/internal/proto/EventConsumerServiceHandler.scala:137:137: possible missing interpolator: detected an interpolated expression
[error]             case _ => scala.concurrent.Future.failed(new akka.grpc.GrpcServiceException(io.grpc.Status.INVALID_ARGUMENT.withDescription("Invalid gRPC request path [${request.uri.path}]")))
```