### PR TITLE
build: Scaladoc JDK links handling breaking build

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -100,7 +100,7 @@ object Common extends AutoPlugin {
       (if (scalaBinaryVersion.value.startsWith("3")) {
          Seq(
            s"-external-mappings:https://docs.oracle.com/en/java/javase/${Dependencies.JavaDocLinkVersion}/docs/api/java.base/")
-       } else if (isJdk17orHigher) {
+       } else if (isJdk17orHigher && scalaBinaryVersion.value.startsWith("2.13")) {
          Seq(
            "-jdk-api-doc-base",
            s"https://docs.oracle.com/en/java/javase/${Dependencies.JavaDocLinkVersion}/docs/api/java.base/",


### PR DESCRIPTION
We cross build for 2.12 because of sbt, and the `-jdk-api-doc-base` setting does not exist in 2.12

This only shows in ["check samples" CI build](https://github.com/akka/akka-grpc/actions/workflows/check-samples.yml), and that doesn't have workflow_dispatch, so we have to merge this to see that it works.