### PR TITLE
Groundwork to support telemetry for Akka gRPC responses

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -11,6 +11,8 @@ import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import io.grpc.Status;
+
 import akka.japi.function.Function;
 import akka.actor.ActorSystem;
 import akka.actor.ClassicActorSystemProvider;
@@ -141,7 +143,18 @@ public class @{serviceName}HandlerFactory {
           String method = segments.next();
           if (segments.hasNext()) return notFound; // we don't allow any random `/prefix/Method/anything/here
           else {
-            return handle(spi.onRequest(prefix, method, req), method, implementation, mat, eHandler, system);
+            final akka.japi.Function<ActorSystem, akka.japi.Function<Throwable, Trailers>> instrumentedEHandler = s -> {
+              return t -> {
+                final Trailers ts = eHandler.apply(s).apply(t);
+                spi.onResponse(prefix, method, ts);
+
+                return ts;
+              };
+            };
+            return handle(spi.onRequest(prefix, method, req), method, implementation, mat, instrumentedEHandler, system)
+              .whenComplete((resp, e) -> {
+                if (resp != null && e == null) spi.onResponse(prefix, method, new Trailers(Status.OK));
+              });
           }
         } else {
           return notFound;

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -8,6 +8,9 @@
 package @service.packageName
 
 import scala.concurrent.ExecutionContext
+import scala.util.Success
+
+import io.grpc.Status
 
 import akka.grpc.scaladsl.{ GrpcExceptionHandler, GrpcMarshalling }
 import akka.grpc.Trailers
@@ -114,7 +117,13 @@ object @{serviceName}Handler {
 
       import @{service.name}.Serializers._
 
-      def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] =
+      def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] = {
+        val instrumentedEHandler: ActorSystem => PartialFunction[Throwable, Trailers] = { system =>
+          eHandler(system).andThen { trailer =>
+            spi.onResponse(prefix, method, trailer)
+            trailer
+          }
+        }
         GrpcMarshalling.negotiated(request, (reader, writer) =>
           (method match {
             @for(method <- service.methods) {
@@ -122,12 +131,16 @@ object @{serviceName}Handler {
                 @{if(powerApis) { "val metadata = MetadataBuilder.fromHttpMessage(request)" } else { "" }}
                 @{method.unmarshal}(request.entity)(@method.deserializer.name, mat, reader)
                   .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
-                  .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
+                  .map(e => @{method.marshal}(e, instrumentedEHandler)(@method.serializer.name, writer, system))
             }
             case m => scala.concurrent.Future.failed(new NotImplementedError(s"Not implemented: $m"))
           })
-          .recoverWith(GrpcExceptionHandler.from(eHandler(system.classicSystem))(system, writer))
+          .andThen {
+            case Success(_) => spi.onResponse(prefix, method, Trailers(Status.OK))
+          }
+          .recoverWith(GrpcExceptionHandler.from(instrumentedEHandler(system.classicSystem))(system, writer))
       ).getOrElse(unsupportedMediaType)
+      }
 
       def isThisService(path: model.Uri.Path): Boolean =
         path match {

--- a/runtime/src/main/scala/akka/grpc/internal/TelemetrySpi.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/TelemetrySpi.scala
@@ -13,6 +13,7 @@ import akka.actor.{
   ExtensionIdProvider
 }
 import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.grpc.Trailers
 import akka.http.javadsl.model.HttpRequest
 
 import scala.annotation.nowarn
@@ -61,6 +62,7 @@ private[internal] object TelemetrySpi {
 trait TelemetrySpi {
   @nowarn
   def onRequest[T <: HttpRequest](prefix: String, method: String, request: T): T = request
+  def onResponse(prefix: String, method: String, trailers: Trailers): Unit = ()
 }
 
 @InternalApi


### PR DESCRIPTION
Lays the groundwork to be able to start gathering gRPC response metrics in Cinnamon.

References #2034
