### PR TITLE
bump: gh actions cache plugin 4.2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -177,7 +177,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Gradle repository
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4.2.0
         with:
           path: |
             ~/.gradle/caches
@@ -238,7 +238,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Maven repository
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('plugin-tester-*/pom.xml') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -177,7 +177,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Gradle repository
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4.0.0
         with:
           path: |
             ~/.gradle/caches
@@ -238,7 +238,7 @@ jobs:
           cat ~/.version
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4.0.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('plugin-tester-*/pom.xml') }}


### PR DESCRIPTION
v3 deprecated and no longer working