### PR TITLE
bump: Maven dependency plugin 3.7.1

### DIFF
--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
-    <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <akka.http.cors.version>1.1.0</akka.http.cors.version>
     <akka.version>2.10.0</akka.version>

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -161,7 +161,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>getClasspathFilenames</id>

--- a/samples/akka-grpc-quickstart-java/pom.xml
+++ b/samples/akka-grpc-quickstart-java/pom.xml
@@ -116,7 +116,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>getClasspathFilenames</id>

--- a/samples/akka-grpc-quickstart-scala/pom.xml
+++ b/samples/akka-grpc-quickstart-scala/pom.xml
@@ -152,7 +152,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>getClasspathFilenames</id>


### PR DESCRIPTION
Was accidentally bumped to nonexistent 2.5.3 in a previous PR, this aligns and bumps all usage to 3.7.1 across the repo.

Fixes broken CI https://github.com/akka/akka-grpc/actions/runs/13792116796