### PR TITLE
Don't send content length with gRPC responses

### DIFF
--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolNative.scala
@@ -6,16 +6,9 @@ package akka.grpc.internal
 
 import akka.grpc.GrpcProtocol._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart, LastChunk }
-import akka.http.scaladsl.model.{
-  AttributeKey,
-  AttributeKeys,
-  HttpEntity,
-  HttpHeader,
-  HttpProtocols,
-  HttpResponse,
-  StatusCodes,
-  Trailer
-}
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocols, HttpResponse, StatusCodes, Trailer }
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
 import scala.collection.immutable
@@ -45,18 +38,29 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
   @inline
   private def encodeFrame(codec: Codec, frame: Frame): ChunkStreamPart =
     frame match {
-      case DataFrame(data) =>
-        Chunk(AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false))
+      case DataFrame(data)       => Chunk(encodeDataToFrameBytes(codec, data))
       case TrailerFrame(headers) => LastChunk(trailer = headers)
     }
+
   private def encodeDataToResponse(
       codec: Codec)(data: ByteString, headers: immutable.Seq[HttpHeader], trailer: Trailer): HttpResponse =
-    new HttpResponse(
+    HttpResponse(
       status = StatusCodes.OK,
       headers = headers,
-      entity = HttpEntity(contentType, encodeDataToFrameBytes(codec, data)),
-      protocol = HttpProtocols.`HTTP/1.1`,
-      attributes = Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, trailer))
+      // We pass the entity as a chunked response. This forces akka-http to send it without a Content-Length header in
+      // HTTP/2. While the wire encoding doesn't explicitly forbid a content-length header, it doesn't say there should
+      // be one. It appears most, if not all implementations don't send a content length header, so it's probably best
+      // not to send one. Clients that are not expecting one, such as envoy's grpc-web filter, can have problems like
+      // this: https://github.com/envoyproxy/envoy/issues/40097
+      entity = HttpEntity.Chunked(
+        contentType,
+        Source(
+          Seq(
+            Chunk(encodeDataToFrameBytes(codec, data)),
+            LastChunk(trailer = trailer.headers.map {
+              case (header, value) => RawHeader(header, value)
+            })))),
+      protocol = HttpProtocols.`HTTP/1.1`)
 
   private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString =
     AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false)


### PR DESCRIPTION
This avoids sending a content length header with gRPC unary responses.

The gRPC spec specifies require a content length to be sent, though it also doesn't expressly forbid it. It seems server implementations probably don't usually send one. There are some clients that don't expect one, most notably, the envoy gRPC web transcoder doesn't expect one, and fails to strip it out before modifying the response body, causing protocol errors:

https://github.com/envoyproxy/envoy/issues/40097

One downside of this change is that it is probably a performance regression for unary requests, as sending a `Strict` entity I believe is more performant than sending a `Chunked` entity - no substream needs to be materialised when sending a strict entity. I'm not sure exactly how much more performant it is though, and the difference is likely negligable for services that actually do something like access a database.