### PR TITLE
fix: Don't send content length header for unary gRPC responses

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     // https://doc.akka.io/libraries/akka-core/current/project/downstream-upgrade-strategy.html
     val akka = "2.10.5"
     val akkaBinary = VersionNumber(akka).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
-    val akkaHttp = "10.7.1"
+    val akkaHttp = "10.7.1+8-d2adcf6a"
     val akkaHttpBinary = VersionNumber(akkaHttp).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
 
     val grpc = "1.72.0" // checked synced by VersionSyncCheckPlugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     // https://doc.akka.io/libraries/akka-core/current/project/downstream-upgrade-strategy.html
     val akka = "2.10.5"
     val akkaBinary = VersionNumber(akka).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
-    val akkaHttp = "10.7.1+8-d2adcf6a"
+    val akkaHttp = "10.7.2"
     val akkaHttpBinary = VersionNumber(akkaHttp).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
 
     val grpc = "1.72.0" // checked synced by VersionSyncCheckPlugin

--- a/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/akka/grpc/internal/GrpcProtocolWeb.scala
@@ -32,7 +32,8 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
     HttpResponse(
       status = StatusCodes.OK,
       headers = headers,
-      entity = HttpEntity(contentType, encodeDataToFrameBytes(codec, data, trailer)),
+      entity =
+        HttpEntity.Strict(contentType, encodeDataToFrameBytes(codec, data, trailer), reportContentLength = false),
       protocol = HttpProtocols.`HTTP/1.1`)
 
   private def encodeDataToFrameBytes(codec: Codec, data: ByteString, trailer: Trailer): ByteString = {


### PR DESCRIPTION
Motivation in #2071 depends on upstream Akka HTTP change https://github.com/akka/akka-http/pull/4504