### PR TITLE
build: Binary compatibilty check of runtime for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,12 +62,9 @@ lazy val runtime = Project(id = akkaGrpcRuntimeName, base = file("runtime"))
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     mimaFailOnNoPrevious := true,
-    mimaPreviousArtifacts :=
-      (if (scalaVersion.value.startsWith("2"))
-         previousStableVersion.value.map(v => Set(organization.value %% "akka-grpc-runtime" % v)).getOrElse(Set.empty)
-       else
-         Set.empty // FIXME no released Scala 3 artifacts yet, re-enable when there is
-      ),
+    mimaPreviousArtifacts := previousStableVersion.value
+      .map(v => Set(organization.value %% "akka-grpc-runtime" % v))
+      .getOrElse(Set.empty),
     AutomaticModuleName.settings("akka.grpc.runtime"),
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),


### PR DESCRIPTION
We had missed to re-enable after we did the first release with Scala 3 support