### PR TITLE
spike: bump to scalaPB v1.0.0-alpha.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -253,7 +253,10 @@ lazy val pluginTesterScala = Project(id = "akka-grpc-plugin-tester-scala", base 
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     Test / parallelExecution := false,
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"),
+    // descriptor.proto excluded: generated DescriptorProtos conflicts with protobuf-java runtime
+    PB.generate / excludeFilter := new SimpleFileFilter((f: File) =>
+      f.getAbsolutePath.endsWith("google/protobuf/descriptor.proto")))
   .pluginTestingSettings
 
 lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = file("plugin-tester-java"))

--- a/build.sbt
+++ b/build.sbt
@@ -267,7 +267,10 @@ lazy val pluginTesterJava = Project(id = "akka-grpc-plugin-tester-java", base = 
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     Test / parallelExecution := false,
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"))
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"),
+    // descriptor.proto excluded: generated DescriptorProtos.java conflicts with protobuf-java runtime
+    PB.generate / excludeFilter := new SimpleFileFilter((f: File) =>
+      f.getAbsolutePath.endsWith("google/protobuf/descriptor.proto")))
   .pluginTestingSettings
 
 lazy val pluginTesterSdkHandler =
@@ -282,7 +285,10 @@ lazy val pluginTesterSdkHandler =
       crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
       scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
       Test / parallelExecution := false,
-      ReflectiveCodeGen.codeGeneratorSettings ++= Seq("generate_scala_handler_factory"))
+      ReflectiveCodeGen.codeGeneratorSettings ++= Seq("generate_scala_handler_factory"),
+      // descriptor.proto excluded: generated DescriptorProtos.java conflicts with protobuf-java runtime
+      PB.generate / excludeFilter := new SimpleFileFilter((f: File) =>
+        f.getAbsolutePath.endsWith("google/protobuf/descriptor.proto")))
     .pluginTestingSettings
 
 lazy val root = Project(id = "akka-grpc", base = file("."))

--- a/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/akka/grpc/gen/scaladsl/Service.scala
@@ -40,7 +40,7 @@ object Service {
 
     Service(
       fileDesc.fileDescriptorObject.fullName + ".javaDescriptor",
-      fileDesc.scalaPackage.fullName,
+      fileDesc.scalaPackage.fullName.stripPrefix("_root_."),
       serviceClassName,
       (if (fileDesc.getPackage.isEmpty) "" else fileDesc.getPackage + ".") + serviceDescriptor.getName,
       serviceDescriptor.getMethods.asScala.map(method => Method(method)).toList,

--- a/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/akka/grpc/gradle/AkkaGrpcPluginExtension.groovy
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 
 class AkkaGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "4.34.0" // checked synced by VersionSyncCheckPlugin
+    static final String PROTOC_VERSION = "4.35.0" // checked synced by VersionSyncCheckPlugin
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -94,7 +94,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${akka-grpc.outputDirectory}</outputDirectory>
-	<protocVersion implementation="java.lang.String" default-value="-v4.34.0">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+	<protocVersion implementation="java.lang.String" default-value="-v4.35.0">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>
@@ -185,7 +185,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${akka-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${akka-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v4.34.0">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v4.35.0">${akka-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/maven-plugin/src/main/scala/akka/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/AbstractGenerateMojo.scala
@@ -10,8 +10,11 @@ import akka.grpc.gen.javadsl.{ JavaClientCodeGenerator, JavaInterfaceCodeGenerat
 import akka.grpc.gen.scaladsl.{ ScalaClientCodeGenerator, ScalaServerCodeGenerator, ScalaTraitCodeGenerator }
 
 import javax.inject.Inject
+import org.apache.maven.artifact.repository.ArtifactRepository
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.project.MavenProject
+import org.apache.maven.repository.RepositorySystem
 import org.sonatype.plexus.build.incremental.BuildContext
 import protocbridge.{ JvmGenerator, ProtocRunner, Target }
 import scalapb.ScalaPbCodeGenerator
@@ -84,11 +87,16 @@ object AbstractGenerateMojo {
   }
 }
 
-abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) extends AbstractMojo {
+abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext, repositorySystem: RepositorySystem)
+    extends AbstractMojo {
   import AbstractGenerateMojo._
 
   @BeanProperty
   var project: MavenProject = _
+
+  @annotation.nowarn("cat=deprecation")
+  @BeanProperty
+  var localRepository: ArtifactRepository = _
 
   @BeanProperty
   var protoPaths: java.util.List[String] = _
@@ -206,9 +214,13 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
           glueGenerators.map(g => adaptAkkaGenerator(generatedSourcesDir, g, settings))
       }
 
-      val runProtoc: Seq[String] => Int = args =>
-        com.github.os72.protocjar.Protoc.runProtoc(protocVersion +: args.toArray)
-      val protocOptions = if (includeStdTypes) Seq("--include_std_types") else Seq.empty
+      val runProtoc: Seq[String] => Int = args => {
+        val protocFile = resolveProtocBinary(protocVersion.stripPrefix("-v"))
+        val proc = new ProcessBuilder((protocFile.getAbsolutePath +: args).asJava)
+        proc.inheritIO()
+        proc.start().waitFor()
+      }
+      val protocOptions = Seq.empty[String]
 
       compile(runProtoc, schemas, protoDir, protocOptions, targets)
     }
@@ -295,6 +307,35 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
     } else if (schemas.nonEmpty && generatedTargets.isEmpty) {
       getLog.info("Protobufs files found, but PB.targets is empty.")
     }
+  }
+
+  private def resolveProtocBinary(version: String): File = {
+    val classifier = protocClassifier()
+    val artifact =
+      repositorySystem.createArtifactWithClassifier("com.google.protobuf", "protoc", version, "exe", classifier)
+    val request = new ArtifactResolutionRequest()
+      .setArtifact(artifact)
+      .setLocalRepository(localRepository)
+      .setRemoteRepositories(project.getRemoteArtifactRepositories)
+    repositorySystem.resolve(request)
+    val file = artifact.getFile
+    file.setExecutable(true)
+    file
+  }
+
+  private def protocClassifier(): String = {
+    val os = System.getProperty("os.name").toLowerCase
+    val arch = System.getProperty("os.arch").toLowerCase
+    val osName =
+      if (os.contains("mac") || os.contains("darwin")) "osx"
+      else if (os.contains("linux")) "linux"
+      else if (os.contains("windows")) "windows"
+      else throw new RuntimeException(s"Unsupported OS for protoc: $os")
+    val archName =
+      if (arch == "aarch64" || arch == "arm64") "aarch_64"
+      else if (arch == "x86_64" || arch == "amd64") "x86_64"
+      else throw new RuntimeException(s"Unsupported architecture for protoc: $arch")
+    s"$osName-$archName"
   }
 
   def adaptAkkaGenerator(targetPath: File, generator: CodeGenerator, settings: Seq[String]): Target = {

--- a/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/GenerateMojo.scala
@@ -5,9 +5,11 @@
 package akka.grpc.maven
 
 import javax.inject.Inject
+import org.apache.maven.repository.RepositorySystem
 import org.sonatype.plexus.build.incremental.BuildContext
 
-class GenerateMojo @Inject() (buildContext: BuildContext) extends AbstractGenerateMojo(buildContext) {
+class GenerateMojo @Inject() (buildContext: BuildContext, repositorySystem: RepositorySystem)
+    extends AbstractGenerateMojo(buildContext, repositorySystem) {
   override def addGeneratedSourceRoot(generatedSourcesDir: String): Unit = {
     project.addCompileSourceRoot(generatedSourcesDir)
   }

--- a/maven-plugin/src/main/scala/akka/grpc/maven/TestGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/akka/grpc/maven/TestGenerateMojo.scala
@@ -5,9 +5,11 @@
 package akka.grpc.maven
 
 import javax.inject.Inject
+import org.apache.maven.repository.RepositorySystem
 import org.sonatype.plexus.build.incremental.BuildContext
 
-class TestGenerateMojo @Inject() (buildContext: BuildContext) extends AbstractGenerateMojo(buildContext) {
+class TestGenerateMojo @Inject() (buildContext: BuildContext, repositorySystem: RepositorySystem)
+    extends AbstractGenerateMojo(buildContext, repositorySystem) {
   override def addGeneratedSourceRoot(generatedSourcesDir: String): Unit = {
     project.addTestCompileSourceRoot(generatedSourcesDir)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and akka.grpc.sbt.AkkaGrpcPlugin
-    val googleProtobuf = "4.34.0" // checked synced by VersionSyncCheckPlugin
+    val googleProtobuf = "4.35.0" // checked synced by VersionSyncCheckPlugin
     val googleApi = "2.58.0"
 
     val scalaTest = "3.2.12"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,6 @@ object Dependencies {
     val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.17"
     val mavenPluginApi = "org.apache.maven" % "maven-plugin-api" % Versions.maven // Apache v2
     val mavenCore = "org.apache.maven" % "maven-core" % Versions.maven // Apache v2
-    val protocJar = "com.github.os72" % "protoc-jar" % "3.11.4"
 
     val plexusBuildApi = "org.sonatype.plexus" % "plexus-build-api" % "0.0.7" % "optional" // Apache v2
   }
@@ -128,7 +127,6 @@ object Dependencies {
     Compile.slf4jApi,
     Compile.mavenPluginApi,
     Compile.mavenCore,
-    Compile.protocJar,
     Compile.plexusBuildApi,
     Test.scalaTest)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -123,12 +123,8 @@ object Dependencies {
     Test.scalaTest,
     Test.scalaTestPlusJunit)
 
-  val mavenPlugin = l ++= Seq(
-    Compile.slf4jApi,
-    Compile.mavenPluginApi,
-    Compile.mavenCore,
-    Compile.plexusBuildApi,
-    Test.scalaTest)
+  val mavenPlugin =
+    l ++= Seq(Compile.slf4jApi, Compile.mavenPluginApi, Compile.mavenCore, Compile.plexusBuildApi, Test.scalaTest)
 
   val sbtPlugin = Seq(
     l ++= Seq(Compile.scalapbCompilerPlugin),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,4 +29,4 @@ libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.2024011
 // scripted testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.18"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.5"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
@@ -1,3 +1,6 @@
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % sys.props("project.version"))
 
 libraryDependencies ++= Seq("com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.0")
+
+// scalapb-validate-codegen 0.3.0 depends on compilerplugin 0.11.x; allow eviction to 1.0.x
+libraryDependencySchemes += "com.thesamet.scalapb" %% "compilerplugin" % "always"


### PR DESCRIPTION
Branched out of https://github.com/akka/akka-grpc/pull/2110 to test the scalaPB `1.0.0-alpha.5` release.

---

There was a bug was in protoc-jar (the library, version 3.11.4): when told to download and run protoc 4.35.0, its extractStdTypes method fails on macOS ARM because it was released before Apple Silicon support existed. It doesn't know about the osx-aarch_64 classifier.